### PR TITLE
Add subduction teeth

### DIFF
--- a/cmake/modules/Version.cmake
+++ b/cmake/modules/Version.cmake
@@ -111,7 +111,7 @@ set(GPLATES_VERSION ${GPLATES_VERSION_MAJOR}.${GPLATES_VERSION_MINOR}.${GPLATES_
 #
 # See note about pre-release version suffixes above.
 #
-set(GPLATES_VERSION_PRERELEASE_SUFFIX "1")
+set(GPLATES_VERSION_PRERELEASE_SUFFIX "2")
 # Ensure pre-release contains only dot-separated alphanumeric identifiers.
 check_prerelease_suffix("${GPLATES_VERSION_PRERELEASE_SUFFIX}")
 

--- a/src/app-logic/LayerProxyUtils.cc
+++ b/src/app-logic/LayerProxyUtils.cc
@@ -35,6 +35,7 @@
 #include "ResolvedTopologicalLine.h"
 #include "TopologyGeometryResolverLayerProxy.h"
 #include "TopologyNetworkResolverLayerProxy.h"
+#include "TopologyUtils.h"
 
 
 void
@@ -127,6 +128,48 @@ GPlatesAppLogic::LayerProxyUtils::find_dependent_topological_sections(
 		// Get the dependent topological sections from the current layer.
 		topology_network_resolver_layer_proxy->get_current_dependent_topological_sections(dependent_topological_sections);
 	}
+}
+
+
+void
+GPlatesAppLogic::LayerProxyUtils::find_resolved_topological_sections(
+		std::vector<ResolvedTopologicalSection::non_null_ptr_type> &resolved_topological_sections,
+		const Reconstruction &reconstruction)
+{
+	resolved_topological_sections.clear();
+
+	// Get the resolved geometry layer outputs.
+	std::vector<TopologyGeometryResolverLayerProxy::non_null_ptr_type> topology_geometry_resolver_layer_proxies;
+	reconstruction.get_active_layer_outputs<TopologyGeometryResolverLayerProxy>(topology_geometry_resolver_layer_proxies);
+
+	// Get the resolved topological boundaries.
+	std::vector<ResolvedTopologicalBoundary::non_null_ptr_type> resolved_topological_boundaries;
+	for (auto topology_geometry_resolver_layer_proxy : topology_geometry_resolver_layer_proxies)
+	{
+		topology_geometry_resolver_layer_proxy->get_resolved_topological_boundaries(
+				resolved_topological_boundaries,
+				reconstruction.get_reconstruction_time());
+	}
+
+
+	// Get the resolved network layer outputs.
+	std::vector<TopologyNetworkResolverLayerProxy::non_null_ptr_type> topology_network_resolver_layer_proxies;
+	reconstruction.get_active_layer_outputs<TopologyNetworkResolverLayerProxy>(topology_network_resolver_layer_proxies);
+
+	// Get the resolved topological networks.
+	std::vector<ResolvedTopologicalNetwork::non_null_ptr_type> resolved_topological_networks;
+	for (auto topology_network_resolver_layer_proxy : topology_network_resolver_layer_proxies)
+	{
+		topology_network_resolver_layer_proxy->get_resolved_topological_networks(
+				resolved_topological_networks,
+				reconstruction.get_reconstruction_time());
+	}
+
+	// Find the resolved topological sections from the resolved topological boundaries and networks.
+	TopologyUtils::find_resolved_topological_sections(
+			resolved_topological_sections,
+			std::vector<ResolvedTopologicalBoundary::non_null_ptr_to_const_type>(resolved_topological_boundaries.begin(), resolved_topological_boundaries.end()),
+			std::vector<ResolvedTopologicalNetwork::non_null_ptr_to_const_type>(resolved_topological_networks.begin(), resolved_topological_networks.end()));
 }
 
 

--- a/src/app-logic/LayerProxyUtils.h
+++ b/src/app-logic/LayerProxyUtils.h
@@ -41,6 +41,7 @@
 #include "ReconstructedFeatureGeometry.h"
 #include "ReconstructHandle.h"
 #include "ResolvedTopologicalLine.h"
+#include "ResolvedTopologicalSection.h"
 
 #include "global/GPlatesAssert.h"
 #include "global/PointerTraits.h"
@@ -170,6 +171,15 @@ namespace GPlatesAppLogic
 		void
 		find_dependent_topological_sections(
 				std::set<GPlatesModel::FeatureId> &dependent_topological_sections,
+				const Reconstruction &reconstruction);
+
+		/**
+		 * Finds all sub-segments shared by *all* resolved topology boundaries and network boundaries
+		 * in the specified reconstruction.
+		 */
+		void
+		find_resolved_topological_sections(
+				std::vector<ResolvedTopologicalSection::non_null_ptr_type> &resolved_topological_sections,
 				const Reconstruction &reconstruction);
 
 

--- a/src/app-logic/ReconstructGraph.cc
+++ b/src/app-logic/ReconstructGraph.cc
@@ -375,14 +375,12 @@ GPlatesAppLogic::ReconstructGraph::update_layer_tasks(
 	}
 
 	// Iterate over the layers again and update them.
-	// Note that the layers can be updated in any order - it is only when their layer proxy
-	// interfaces are queried that they will reference any dependency layers and that won't
-	// happen until after we're finished here and have returned.
 	//
-	// In any case the layers now operate in a pull model where a layer directly makes requests
-	// to its dependencies layers and so on, whereas previously layers operated in a push model
-	// that required dependency layers to produce output before the executing layers that
-	// depended on them thus requiring layers to be executed in dependency order.
+	// Note: The layers can be updated in any order.
+	//       This is because the layers now operate in a pull model where a layer directly makes requests
+	//       to its dependencies layers and so on. Whereas previously, layers operated in a push model
+	//       that required dependency layers to produce output before the executing layers that
+	//       depended on them thus requiring layers to be executed in dependency order.
 	BOOST_FOREACH(const layer_ptr_type &layer, d_layers)
 	{
 		// If this layer is not active then we don't add the layer proxy to the current reconstruction.

--- a/src/app-logic/Reconstruction.cc
+++ b/src/app-logic/Reconstruction.cc
@@ -27,6 +27,8 @@
 
 #include "Reconstruction.h"
 
+#include "LayerProxyUtils.h"
+
 #include "global/PreconditionViolationError.h"
 
 
@@ -49,4 +51,34 @@ GPlatesAppLogic::Reconstruction::Reconstruction(
 	// Create a reconstruction layer proxy that performs identity rotations...
 	d_default_reconstruction_layer_proxy(ReconstructionLayerProxy::create())
 {
+}
+
+
+const std::vector<GPlatesAppLogic::ResolvedTopologicalSection::non_null_ptr_type> &
+GPlatesAppLogic::Reconstruction::get_all_resolved_topological_sections() const
+{
+	// Cache all resolved topological sections in this reconstruction if we haven't already.
+	if (!d_all_resolved_topological_sections)
+	{
+		d_all_resolved_topological_sections = std::vector<ResolvedTopologicalSection::non_null_ptr_type>();
+		LayerProxyUtils::find_resolved_topological_sections(d_all_resolved_topological_sections.get(), *this);
+	}
+
+	return d_all_resolved_topological_sections.get();
+}
+
+
+const GPlatesAppLogic::TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &
+GPlatesAppLogic::Reconstruction::get_all_resolved_topological_shared_sub_segments() const
+{
+	// Cache all resolved topological shared sub-segments in this reconstruction if we haven't already.
+	if (!d_all_resolved_topological_shared_sub_segments)
+	{
+		d_all_resolved_topological_shared_sub_segments = TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type();
+		TopologyUtils::map_resolved_topological_boundaries_networks_to_shared_sub_segments(
+				d_all_resolved_topological_shared_sub_segments.get(),
+				get_all_resolved_topological_sections());
+	}
+
+	return d_all_resolved_topological_shared_sub_segments.get();
 }

--- a/src/app-logic/Reconstruction.h
+++ b/src/app-logic/Reconstruction.h
@@ -28,11 +28,14 @@
 #ifndef GPLATES_APP_LOGIC_RECONSTRUCTION_H
 #define GPLATES_APP_LOGIC_RECONSTRUCTION_H
 
+#include <vector>
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 
 #include "LayerProxyUtils.h"
 #include "ReconstructionLayerProxy.h"
+#include "ResolvedTopologicalSection.h"
+#include "TopologyUtils.h"
 
 #include "maths/Real.h"
 
@@ -104,6 +107,8 @@ namespace GPlatesAppLogic
 				const LayerProxy::non_null_ptr_type &layer_proxy)
 		{
 			d_active_layer_outputs.push_back(layer_proxy);
+			d_all_resolved_topological_sections = boost::none;  // flush cache
+			d_all_resolved_topological_shared_sub_segments = boost::none;  // flush cache
 		}
 
 
@@ -188,7 +193,29 @@ namespace GPlatesAppLogic
 				const ReconstructionLayerProxy::non_null_ptr_type &reconstruction_layer_proxy)
 		{
 			d_default_reconstruction_layer_proxy = reconstruction_layer_proxy;
+			d_all_resolved_topological_sections = boost::none;  // flush cache
+			d_all_resolved_topological_shared_sub_segments = boost::none;  // flush cache
 		}
+
+
+		/**
+		 * Finds all resolved topological sections (sub-segments shared by resolved topology boundaries and network boundaries)
+		 * from ALL layer outputs in this reconstruction.
+		 *
+		 * Note: Only finds resolved topological sections when first called, and is then cached.
+		 *       Subsequently calling @a add_active_layer_output will flush the cache however.
+		 */
+		const std::vector<ResolvedTopologicalSection::non_null_ptr_type> &
+		get_all_resolved_topological_sections() const;
+
+		/**
+		 * A different representation of @a find_resolved_topological_sections.
+		 *
+		 * Instead of shared sub-segments referencing resolved topological boundaries and networks,
+		 * it's the other way around.
+		 */
+		const TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &
+		get_all_resolved_topological_shared_sub_segments() const;
 
 	private:
 		/**
@@ -211,6 +238,17 @@ namespace GPlatesAppLogic
 		 * The sequence of active layer outputs.
 		 */
 		layer_output_seq_type d_active_layer_outputs;
+
+		/**
+		 * Resolved topological sections from ALL layer outputs in this reconstruction
+		 * (cached when calling @a get_all_resolved_topological_sections).
+		 */
+		mutable boost::optional<std::vector<ResolvedTopologicalSection::non_null_ptr_type>> d_all_resolved_topological_sections;
+		/**
+		 * Resolved topological shared sub-segments from ALL layer outputs in this reconstruction
+		 * (cached when calling @a get_all_resolved_topological_shared_sub_segments).
+		 */
+		mutable boost::optional<TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type> d_all_resolved_topological_shared_sub_segments;
 
 
 		/**

--- a/src/app-logic/TopologyUtils.cc
+++ b/src/app-logic/TopologyUtils.cc
@@ -1889,3 +1889,31 @@ GPlatesAppLogic::TopologyUtils::find_resolved_topological_sections(
 						section_feature_ref));
 	}
 }
+
+
+void
+GPlatesAppLogic::TopologyUtils::map_resolved_topological_boundaries_networks_to_shared_sub_segments(
+		resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &resolved_topological_shared_sub_segments_map,
+		const std::vector<ResolvedTopologicalSection::non_null_ptr_type> &resolved_topological_sections)
+{
+	resolved_topological_shared_sub_segments_map.clear();
+
+	for (auto resolved_topological_section : resolved_topological_sections)
+	{
+		for (auto shared_sub_segment : resolved_topological_section->get_shared_sub_segments())
+		{
+			// Add the current shared sub-segment to all the resolved topologies sharing it (and add their reversal flags).
+			for (const auto &sharing_resolved_topology : shared_sub_segment->get_sharing_resolved_topologies())
+			{
+				// Get the geometry property referenced by the resolved topology.
+				boost::optional<GPlatesModel::FeatureHandle::iterator> resolved_topology_geometry_property =
+						ReconstructionGeometryUtils::get_geometry_property_iterator(sharing_resolved_topology.resolved_topology);
+				if (resolved_topology_geometry_property)  // this should always succeed
+				{
+					resolved_topological_shared_sub_segments_map[resolved_topology_geometry_property.get()].push_back(
+						{ shared_sub_segment, sharing_resolved_topology.is_sub_segment_geometry_reversed });
+				}
+			}
+		}
+	}
+}

--- a/src/app-logic/TopologyUtils.h
+++ b/src/app-logic/TopologyUtils.h
@@ -29,6 +29,7 @@
 #define GPLATES_APP_LOGIC_TOPOLOGYUTILS_H
 
 #include <list>
+#include <map>
 #include <set>
 #include <utility>
 #include <vector>
@@ -52,6 +53,7 @@
 #include "maths/PolylineOnSphere.h"
 
 #include "model/FeatureCollectionHandle.h"
+#include "model/FeatureHandle.h"
 #include "model/FeatureId.h"
 
 #include "utils/ReferenceCount.h"
@@ -203,10 +205,6 @@ namespace GPlatesAppLogic
 				boost::optional<const std::vector<ReconstructHandle::type> &> topological_sections_reconstruct_handles = boost::none);
 
 
-		//! Typedef for a sequence of resolved topological boundaries.
-		typedef std::vector<const ResolvedTopologicalBoundary *> resolved_topological_boundary_seq_type;
-
-
 		/**
 		 * Returns true if @a feature is a topological network feature.
 		 */
@@ -278,6 +276,36 @@ namespace GPlatesAppLogic
 				std::vector<ResolvedTopologicalSection::non_null_ptr_type> &resolved_topological_sections,
 				const std::vector<ResolvedTopologicalBoundary::non_null_ptr_to_const_type> &resolved_topological_boundaries,
 				const std::vector<ResolvedTopologicalNetwork::non_null_ptr_to_const_type> &resolved_topological_networks);
+
+		/**
+		 * Typedef for a mapping from resolved topological boundaries and networks to their shared boundary sub-segments.
+		 *
+		 * Note: The map key is a feature property iterator instead of a ReconstructionGeometry (resolved topology) because
+		 *       it's possible to have many reconstruction geometries referencing the same feature property since the
+		 *       topological features could have been resolved again (generating different reconstruction geometries) between
+		 *       when this map was created and when it is used to look up shared sub-segments.
+		 */
+		typedef std::map<
+				// The geometry property referenced by a ResolvedTopologicalBoundary or ResolvedTopologicalNetwork...
+				GPlatesModel::FeatureHandle::iterator,
+				// The shared sub-segment and whether the sub-segment geometry is reversed with respect to the section geometry
+				// (when it contributes to the ResolvedTopologicalBoundary or ResolvedTopologicalNetwork being mapped)...
+				std::vector<
+						std::pair<GPlatesAppLogic::ResolvedTopologicalSharedSubSegment::non_null_ptr_type, bool/*is_sub_segment_geometry_reversed*/>>>
+								resolved_topological_boundaries_networks_to_shared_sub_segments_map_type;
+		
+		/**
+		 * Takes a sequence of resolved topological sections and creates a mapping from
+		 * resolved topological boundaries and networks to their shared boundary sub-segments.
+		 *
+		 * This is just a different representation of @a find_resolved_topological_sections.
+		 * Instead of shared sub-segments referencing resolved topological boundaries and networks,
+		 * it's the other way around.
+		 */
+		void
+		map_resolved_topological_boundaries_networks_to_shared_sub_segments(
+				resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &resolved_topological_shared_sub_segments_map,
+				const std::vector<ResolvedTopologicalSection::non_null_ptr_type> &resolved_topological_sections);
 	}
 }
 

--- a/src/app-logic/TopologyUtils.h
+++ b/src/app-logic/TopologyUtils.h
@@ -277,10 +277,11 @@ namespace GPlatesAppLogic
 				const std::vector<ResolvedTopologicalBoundary::non_null_ptr_to_const_type> &resolved_topological_boundaries,
 				const std::vector<ResolvedTopologicalNetwork::non_null_ptr_to_const_type> &resolved_topological_networks);
 
+
 		/**
 		 * Typedef for a mapping from resolved topological boundaries and networks to their shared boundary sub-segments.
 		 *
-		 * Note: The map key is a feature property iterator instead of a ReconstructionGeometry (resolved topology) because
+		 * Note: The map key is a feature property iterator instead of a resolved topology (ReconstructionGeometry) because
 		 *       it's possible to have many reconstruction geometries referencing the same feature property since the
 		 *       topological features could have been resolved again (generating different reconstruction geometries) between
 		 *       when this map was created and when it is used to look up shared sub-segments.

--- a/src/gui/FeatureInspectionCanvasToolWorkflow.cc
+++ b/src/gui/FeatureInspectionCanvasToolWorkflow.cc
@@ -30,6 +30,7 @@
 #include "FeatureFocus.h"
 
 #include "app-logic/ApplicationState.h"
+#include "app-logic/Reconstruction.h"
 #include "app-logic/ReconstructionGeometryUtils.h"
 #include "app-logic/ScalarCoverageFeatureProperties.h"
 #include "app-logic/TopologyReconstructedFeatureGeometry.h"
@@ -431,6 +432,7 @@ GPlatesGui::FeatureInspectionCanvasToolWorkflow::draw_feature_focus()
 			d_rendered_geometry_parameters,
 			d_render_settings,
 			d_application_state.get_current_topological_sections(),
+			d_application_state.get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			d_symbol_map);
 }
 

--- a/src/gui/GeometryFocusHighlight.cc
+++ b/src/gui/GeometryFocusHighlight.cc
@@ -52,6 +52,7 @@ GPlatesGui::GeometryFocusHighlight::draw_focused_geometry(
 		const GPlatesViewOperations::RenderedGeometryParameters &rendered_geometry_parameters,
 		const GPlatesGui::RenderSettings &render_settings,
 		const std::set<GPlatesModel::FeatureId> &topological_sections,
+		const GPlatesAppLogic::TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &resolved_topological_shared_sub_segments_map,
 		const symbol_map_type &symbol_map)
 {
 	// Clear all geometries from layer before adding them.
@@ -127,6 +128,7 @@ GPlatesGui::GeometryFocusHighlight::draw_focused_geometry(
 				render_style_params,
 				render_settings,
 				topological_sections,
+				resolved_topological_shared_sub_segments_map,
 				highlight_colour, 
 				boost::none,
 				symbol_map);
@@ -157,6 +159,7 @@ GPlatesGui::GeometryFocusHighlight::draw_focused_geometry(
 				render_style_params,
 				render_settings,
 				topological_sections,
+				resolved_topological_shared_sub_segments_map,
 				highlight_colour, 
 				boost::none,
 				symbol_map);

--- a/src/gui/GeometryFocusHighlight.h
+++ b/src/gui/GeometryFocusHighlight.h
@@ -32,6 +32,7 @@
 #include <QObject>
 
 #include "app-logic/ReconstructedFeatureGeometry.h"
+#include "app-logic/TopologyUtils.h"
 
 #include "gui/Symbol.h"
 
@@ -71,6 +72,7 @@ namespace GPlatesGui
 				const GPlatesViewOperations::RenderedGeometryParameters &rendered_geometry_parameters,
 				const GPlatesGui::RenderSettings &render_settings,
 				const std::set<GPlatesModel::FeatureId> &topological_sections,
+				const GPlatesAppLogic::TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &resolved_topological_shared_sub_segments_map,
 				const symbol_map_type &symbol_map);
 	}
 }

--- a/src/gui/Globe.cc
+++ b/src/gui/Globe.cc
@@ -152,6 +152,7 @@ GPlatesGui::Globe::cache_handle_type
 GPlatesGui::Globe::paint(
 		GPlatesOpenGL::GLRenderer &renderer,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		float scale,
 		const GPlatesOpenGL::GLMatrix &projection_transform_include_front_half_globe,
 		const GPlatesOpenGL::GLMatrix &projection_transform_include_rear_half_globe,
@@ -218,6 +219,7 @@ GPlatesGui::Globe::paint(
 				renderer,
 				*cache_handle,
 				viewport_zoom_factor,
+				device_independent_pixel_to_world_space_ratio,
 				projection_transform_include_rear_half_globe,
 				false/*is_front_half_globe*/);
 	}
@@ -280,6 +282,7 @@ GPlatesGui::Globe::paint(
 					renderer,
 					*cache_handle,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					projection_transform_include_front_half_globe,
 					true/*is_front_half_globe*/);
 
@@ -296,6 +299,7 @@ GPlatesGui::Globe::paint(
 					renderer,
 					*cache_handle,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					projection_transform_include_full_globe,
 					front_globe_surface_texture);
 
@@ -312,6 +316,7 @@ GPlatesGui::Globe::paint(
 					renderer,
 					*cache_handle,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					projection_transform_include_full_globe);
 
 			// Render the front half of the globe surface next.
@@ -319,6 +324,7 @@ GPlatesGui::Globe::paint(
 					renderer,
 					*cache_handle,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					projection_transform_include_front_half_globe,
 					true/*is_front_half_globe*/);
 		}
@@ -330,6 +336,7 @@ GPlatesGui::Globe::paint(
 				renderer,
 				*cache_handle,
 				viewport_zoom_factor,
+				device_independent_pixel_to_world_space_ratio,
 				projection_transform_include_front_half_globe,
 				true/*is_front_half_globe*/);
 	}
@@ -437,6 +444,7 @@ GPlatesGui::Globe::render_globe_hemisphere_surface(
 		GPlatesOpenGL::GLRenderer &renderer,
 		std::vector<cache_handle_type> &cache_handle,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		const GPlatesOpenGL::GLMatrix &projection_transform,
 		bool is_front_half_globe)
 {
@@ -486,6 +494,7 @@ GPlatesGui::Globe::render_globe_hemisphere_surface(
 			d_rendered_geom_collection_painter.paint_surface(
 					renderer,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					vector_geometries_override_colour);
 	cache_handle.push_back(rendered_geoms_cache_half_globe);
 
@@ -546,6 +555,7 @@ GPlatesGui::Globe::render_globe_sub_surface(
 		GPlatesOpenGL::GLRenderer &renderer,
 		std::vector<cache_handle_type> &cache_handle,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		const GPlatesOpenGL::GLMatrix &projection_transform_include_full_globe,
 		boost::optional<GPlatesOpenGL::GLTexture::shared_ptr_to_const_type> surface_occlusion_texture)
 {
@@ -571,6 +581,7 @@ GPlatesGui::Globe::render_globe_sub_surface(
 			d_rendered_geom_collection_painter.paint_sub_surface(
 					renderer,
 					viewport_zoom_factor,
+					device_independent_pixel_to_world_space_ratio,
 					surface_occlusion_texture,
 					d_globe_orientation_changing_during_mouse_drag/*improve_performance_reduce_quality_hint*/);
 	cache_handle.push_back(rendered_geoms_cache_sub_surface_globe);

--- a/src/gui/Globe.h
+++ b/src/gui/Globe.h
@@ -155,6 +155,7 @@ namespace GPlatesGui
 		paint(
 				GPlatesOpenGL::GLRenderer &renderer,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				float scale,
 				const GPlatesOpenGL::GLMatrix &projection_transform_include_front_half_globe,
 				const GPlatesOpenGL::GLMatrix &projection_transform_include_rear_half_globe,
@@ -244,6 +245,7 @@ namespace GPlatesGui
 				GPlatesOpenGL::GLRenderer &renderer,
 				std::vector<cache_handle_type> &cache_handle,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				const GPlatesOpenGL::GLMatrix &projection_transform,
 				bool is_front_half_globe);
 
@@ -257,6 +259,7 @@ namespace GPlatesGui
 				GPlatesOpenGL::GLRenderer &renderer,
 				std::vector<cache_handle_type> &cache_handle,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				const GPlatesOpenGL::GLMatrix &projection_transform_include_full_globe,
 				boost::optional<GPlatesOpenGL::GLTexture::shared_ptr_to_const_type> surface_occlusion_texture = boost::none);
 	};

--- a/src/gui/GlobeRenderedGeometryCollectionPainter.cc
+++ b/src/gui/GlobeRenderedGeometryCollectionPainter.cc
@@ -138,6 +138,7 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::cache_handle_type
 GPlatesGui::GlobeRenderedGeometryCollectionPainter::paint_surface(
 		GPlatesOpenGL::GLRenderer &renderer,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		boost::optional<Colour> vector_geometries_override_colour)
 {
 	// Make sure we leave the OpenGL state the way it was.
@@ -147,6 +148,7 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::paint_surface(
 	d_paint_params = PaintParams(
 			renderer,
 			viewport_zoom_factor,
+			device_independent_pixel_to_world_space_ratio,
 			GlobeRenderedGeometryLayerPainter::PAINT_SURFACE,
 			vector_geometries_override_colour);
 
@@ -167,6 +169,7 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::cache_handle_type
 GPlatesGui::GlobeRenderedGeometryCollectionPainter::paint_sub_surface(
 		GPlatesOpenGL::GLRenderer &renderer,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		boost::optional<GPlatesOpenGL::GLTexture::shared_ptr_to_const_type> surface_occlusion_texture,
 		bool improve_performance_reduce_quality_hint)
 {
@@ -177,6 +180,7 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::paint_sub_surface(
 	d_paint_params = PaintParams(
 			renderer,
 			viewport_zoom_factor,
+			device_independent_pixel_to_world_space_ratio,
 			GlobeRenderedGeometryLayerPainter::PAINT_SUB_SURFACE,
 			boost::none/*vector_geometries_override_colour*/,
 			surface_occlusion_texture,
@@ -214,6 +218,7 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::visit_rendered_geometry_laye
 	GlobeRenderedGeometryLayerPainter rendered_geom_layer_painter(
 			rendered_geometry_layer,
 			d_paint_params->d_inverse_viewport_zoom_factor,
+			d_paint_params->d_device_independent_pixel_to_world_space_ratio,
 			d_visibility_tester,
 			d_colour_scheme,
 			d_paint_params->d_paint_region,
@@ -290,12 +295,14 @@ GPlatesGui::GlobeRenderedGeometryCollectionPainter::set_visual_layers_reversed(
 GPlatesGui::GlobeRenderedGeometryCollectionPainter::PaintParams::PaintParams(
 		GPlatesOpenGL::GLRenderer &renderer,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_world_space_ratio,
 		GlobeRenderedGeometryLayerPainter::PaintRegionType paint_region,
 		boost::optional<Colour> vector_geometries_override_colour,
 		boost::optional<GPlatesOpenGL::GLTexture::shared_ptr_to_const_type> surface_occlusion_texture,
 		bool improve_performance_reduce_quality_hint) :
 	d_renderer(&renderer),
 	d_inverse_viewport_zoom_factor(1.0 / viewport_zoom_factor),
+	d_device_independent_pixel_to_world_space_ratio(device_independent_pixel_to_world_space_ratio),
 	d_paint_region(paint_region),
 	d_vector_geometries_override_colour(vector_geometries_override_colour),
 	d_surface_occlusion_texture(surface_occlusion_texture),

--- a/src/gui/GlobeRenderedGeometryCollectionPainter.h
+++ b/src/gui/GlobeRenderedGeometryCollectionPainter.h
@@ -114,6 +114,7 @@ namespace GPlatesGui
 		paint_surface(
 				GPlatesOpenGL::GLRenderer &renderer,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				boost::optional<Colour> vector_geometries_override_colour = boost::none);
 
 		/**
@@ -131,6 +132,7 @@ namespace GPlatesGui
 		paint_sub_surface(
 				GPlatesOpenGL::GLRenderer &renderer,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				boost::optional<GPlatesOpenGL::GLTexture::shared_ptr_to_const_type> surface_occlusion_texture,
 				bool improve_performance_reduce_quality_hint = false);
 
@@ -174,6 +176,7 @@ namespace GPlatesGui
 			PaintParams(
 					GPlatesOpenGL::GLRenderer &renderer,
 					const double &viewport_zoom_factor,
+					const double &device_independent_pixel_to_world_space_ratio,
 					GlobeRenderedGeometryLayerPainter::PaintRegionType paint_region,
 					// Used for PAINT_SURFACE...
 					boost::optional<Colour> vector_geometries_override_colour = boost::none,
@@ -184,6 +187,7 @@ namespace GPlatesGui
 
 			GPlatesOpenGL::GLRenderer *d_renderer;
 			double d_inverse_viewport_zoom_factor;
+			double d_device_independent_pixel_to_world_space_ratio;
 			GlobeRenderedGeometryLayerPainter::PaintRegionType d_paint_region;
 
 			// Used for PAINT_SURFACE...

--- a/src/gui/GlobeRenderedGeometryLayerPainter.h
+++ b/src/gui/GlobeRenderedGeometryLayerPainter.h
@@ -180,6 +180,11 @@ namespace GPlatesGui
 
 		virtual
 		void
+		visit_rendered_subduction_teeth_polyline(
+				const GPlatesViewOperations::RenderedSubductionTeethPolyline &rendered_subduction_teeth_polyline);
+
+		virtual
+		void
 		visit_rendered_polygon_on_sphere(
 				const GPlatesViewOperations::RenderedPolygonOnSphere &rendered_polygon_on_sphere);
 

--- a/src/gui/GlobeRenderedGeometryLayerPainter.h
+++ b/src/gui/GlobeRenderedGeometryLayerPainter.h
@@ -106,6 +106,7 @@ namespace GPlatesGui
 		GlobeRenderedGeometryLayerPainter(
 				const GPlatesViewOperations::RenderedGeometryLayer &rendered_geometry_layer,
 				const double &inverse_viewport_zoom_factor,
+				const double &device_independent_pixel_to_world_space_ratio,
 				const GlobeVisibilityTester &visibility_tester,
 				ColourScheme::non_null_ptr_type colour_scheme,
 				PaintRegionType paint_region,
@@ -336,6 +337,9 @@ namespace GPlatesGui
 		const GPlatesViewOperations::RenderedGeometryLayer &d_rendered_geometry_layer;
 
 		const double d_inverse_zoom_factor;
+
+		//! The size of one device-independent pixel in world space units.
+		const double d_device_independent_pixel_to_world_space_ratio;
 
 		//! For determining whether a particular point on the globe is visible or not
 		GlobeVisibilityTester d_visibility_tester;

--- a/src/gui/Map.cc
+++ b/src/gui/Map.cc
@@ -137,6 +137,7 @@ GPlatesGui::Map::cache_handle_type
 GPlatesGui::Map::paint(
 		GPlatesOpenGL::GLRenderer &renderer,
 		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_map_space_ratio,
 		float scale)
 {
 	cache_handle_type cache_handle;
@@ -175,7 +176,10 @@ GPlatesGui::Map::paint(
 		d_background->paint(renderer);
 
 		// Render the rendered geometry layers onto the map.
-		cache_handle = d_rendered_geom_collection_painter.paint(renderer, viewport_zoom_factor);
+		cache_handle = d_rendered_geom_collection_painter.paint(
+				renderer,
+				viewport_zoom_factor,
+				device_independent_pixel_to_map_space_ratio);
 
 		// Render the grid lines on the map.
 		d_grid->paint(renderer);

--- a/src/gui/Map.h
+++ b/src/gui/Map.h
@@ -113,6 +113,7 @@ namespace GPlatesGui
 		paint(
 				GPlatesOpenGL::GLRenderer &renderer,
 				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_map_space_ratio,
 				float scale);
 
 	private:

--- a/src/gui/MapRenderedGeometryCollectionPainter.cc
+++ b/src/gui/MapRenderedGeometryCollectionPainter.cc
@@ -68,13 +68,14 @@ GPlatesGui::MapRenderedGeometryCollectionPainter::initialise(
 GPlatesGui::MapRenderedGeometryCollectionPainter::cache_handle_type
 GPlatesGui::MapRenderedGeometryCollectionPainter::paint(
 		GPlatesOpenGL::GLRenderer &renderer,
-		const double &viewport_zoom_factor)
+		const double &viewport_zoom_factor,
+		const double &device_independent_pixel_to_map_space_ratio)
 {
 	// Make sure we leave the OpenGL state the way it was.
 	GPlatesOpenGL::GLRenderer::StateBlockScope save_restore_globe_state_scope(renderer);
 
 	// Initialise our paint parameters so our visit methods can access them.
-	d_paint_params = PaintParams(renderer, viewport_zoom_factor);
+	d_paint_params = PaintParams(renderer, viewport_zoom_factor, device_independent_pixel_to_map_space_ratio);
 
 	// Draw the layers.
 	d_rendered_geometry_collection.accept_visitor(*this);
@@ -110,6 +111,7 @@ GPlatesGui::MapRenderedGeometryCollectionPainter::visit_rendered_geometry_layer(
 			rendered_geometry_layer,
 			d_gl_visual_layers,
 			d_paint_params->d_inverse_viewport_zoom_factor,
+			d_paint_params->d_device_independent_pixel_to_map_space_ratio,
 			d_colour_scheme);
 	rendered_geom_layer_painter.set_scale(d_scale);
 

--- a/src/gui/MapRenderedGeometryCollectionPainter.h
+++ b/src/gui/MapRenderedGeometryCollectionPainter.h
@@ -95,7 +95,8 @@ namespace GPlatesGui
 		cache_handle_type
 		paint(
 				GPlatesOpenGL::GLRenderer &renderer,
-				const double &viewport_zoom_factor);
+				const double &viewport_zoom_factor,
+				const double &device_independent_pixel_to_map_space_ratio);
 
 		void
 		set_scale(
@@ -132,9 +133,11 @@ namespace GPlatesGui
 		{
 			PaintParams(
 					GPlatesOpenGL::GLRenderer &renderer,
-					const double &viewport_zoom_factor) :
+					const double &viewport_zoom_factor,
+					const double &device_independent_pixel_to_map_space_ratio) :
 				d_renderer(&renderer),
 				d_inverse_viewport_zoom_factor(1.0 / viewport_zoom_factor),
+				d_device_independent_pixel_to_map_space_ratio(device_independent_pixel_to_map_space_ratio),
 				d_cache_handle(new std::vector<cache_handle_type>()),
 				// Default to RECONSTRUCTION_LAYER (we set it before visiting each layer anyway) ...
 				d_main_rendered_layer_type(GPlatesViewOperations::RenderedGeometryCollection::RECONSTRUCTION_LAYER)
@@ -142,6 +145,7 @@ namespace GPlatesGui
 
 			GPlatesOpenGL::GLRenderer *d_renderer;
 			double d_inverse_viewport_zoom_factor;
+			double d_device_independent_pixel_to_map_space_ratio;
 
 			// Cache of rendered geometry layers.
 			boost::shared_ptr<std::vector<cache_handle_type> > d_cache_handle;

--- a/src/gui/MapRenderedGeometryLayerPainter.cc
+++ b/src/gui/MapRenderedGeometryLayerPainter.cc
@@ -33,6 +33,8 @@
 #include <boost/foreach.hpp>
 
 #include <QDebug>
+#include <QLineF>
+#include <QPointF>
 #include <QTransform>
 
 #include "Colour.h"
@@ -77,6 +79,7 @@
 #include "view-operations/RenderedSmallCircleArc.h"
 #include "view-operations/RenderedSquareSymbol.h"
 #include "view-operations/RenderedString.h"
+#include "view-operations/RenderedSubductionTeethPolyline.h"
 #include "view-operations/RenderedTangentialArrow.h"
 #include "view-operations/RenderedTriangleSymbol.h"
 
@@ -672,6 +675,138 @@ GPlatesGui::MapRenderedGeometryLayerPainter::visit_rendered_coloured_polyline_on
 			d_layer_painter->translucent_drawables_on_the_sphere.get_lines_stream(line_width);
 
 	paint_vertex_coloured_polyline(polyline_on_sphere, vertex_colours, stream);
+}
+
+
+void
+GPlatesGui::MapRenderedGeometryLayerPainter::visit_rendered_subduction_teeth_polyline(
+		const GPlatesViewOperations::RenderedSubductionTeethPolyline &rendered_subduction_teeth_polyline)
+{
+	boost::optional<Colour> colour = get_vector_geometry_colour(rendered_subduction_teeth_polyline.get_colour());
+	if (!colour)
+	{
+		return;
+	}
+
+	GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type polyline_on_sphere =
+			rendered_subduction_teeth_polyline.get_polyline_on_sphere();
+
+	DatelineWrappedProjectedLineGeometry dateline_wrapped_projected_polyline;
+	dateline_wrap_and_project_line_geometry(dateline_wrapped_projected_polyline, polyline_on_sphere);
+
+	const std::vector<unsigned int> &geometries = dateline_wrapped_projected_polyline.get_geometries();
+	const unsigned int num_geometries = geometries.size();
+	if (num_geometries == 0)
+	{
+		// Return early if there's nothing to paint - shouldn't really be able to get here.
+		return;
+	}
+
+	// Convert colour from floats to bytes to use less vertex memory.
+	const rgba8_t rgba8_colour = Colour::to_rgba8(colour.get());
+
+	// Get the stream for lines of the current line width.
+	const float line_width = rendered_subduction_teeth_polyline.get_line_width_hint() * LINE_WIDTH_ADJUSTMENT * d_scale;
+	stream_primitives_type &lines_stream = d_layer_painter->translucent_drawables_on_the_sphere.get_lines_stream(line_width);
+
+	// Used to add line strips to the stream.
+	stream_primitives_type::LineStrips stream_line_strips(lines_stream);
+
+	const double spacing = GLOBE_TO_MAP_SCALE_FACTOR * d_inverse_zoom_factor * rendered_subduction_teeth_polyline.get_projected_teeth_spacing();
+	const double teeth_width = GLOBE_TO_MAP_SCALE_FACTOR * d_inverse_zoom_factor * rendered_subduction_teeth_polyline.get_projected_teeth_width();
+	const double teeth_height = rendered_subduction_teeth_polyline.get_teeth_height_to_width_ratio() * teeth_width;
+	// If overriding plate is on the left side then need to segment normal (which is on the right - see 'QLineF::normalVector()').
+	const double overriding_normal_factor =
+			(rendered_subduction_teeth_polyline.get_subduction_polarity() == GPlatesViewOperations::RenderedSubductionTeethPolyline::SubductionPolarity::RIGHT)
+			? 1.0
+			: -1.0;
+
+	// Get the stream for triangles (for the subduction teeth).
+	stream_primitives_type &teeth_stream = d_layer_painter->translucent_drawables_on_the_sphere.get_triangles_stream();
+	stream_primitives_type::Triangles stream_teeth(teeth_stream);
+	stream_teeth.begin_triangles();
+
+	unsigned int geometry_part_index = 0;
+	const std::vector<unsigned int> &geometry_parts = dateline_wrapped_projected_polyline.get_geometry_parts();
+
+	unsigned int vertex_index = 0;
+	const std::vector<QPointF> &vertices = dateline_wrapped_projected_polyline.get_vertices();
+
+	// Iterate over the dateline wrapped polylines.
+	for (unsigned int geometry_index = 0; geometry_index < num_geometries; ++geometry_index)
+	{
+		// Iterate over the parts of the current wrapped polyline (there's only one part per wrapped polyline).
+		const unsigned int end_geometry_part_index = geometries[geometry_index];
+		for ( ; geometry_part_index < end_geometry_part_index; ++geometry_part_index)
+		{
+			stream_line_strips.begin_line_strip();
+
+			// Start vertex.
+			const unsigned int start_vertex_index = vertex_index;
+			const QPointF &start_vertex = vertices[start_vertex_index];
+			const coloured_vertex_type coloured_start_vertex(start_vertex.x(), start_vertex.y(), 0/*z*/, rgba8_colour);
+			stream_line_strips.add_vertex(coloured_start_vertex);
+
+			const QPointF *prev_vertex = &start_vertex;
+			++vertex_index;
+			double length_since_last_tooth = 0;
+
+			// Iterate over the segment-end vertices of the current geometry part (current wrapped polyline).
+			const unsigned int end_vertex_index = geometry_parts[geometry_part_index];
+			for ( ; vertex_index < end_vertex_index; ++vertex_index)
+			{
+				// End vertex of current segment.
+				const QPointF &vertex = vertices[vertex_index];
+				const coloured_vertex_type coloured_vertex(vertex.x(), vertex.y(), 0/*z*/, rgba8_colour);
+				stream_line_strips.add_vertex(coloured_vertex);
+
+				// Current segment (from previous vertex to current vertex).
+				const QLineF segment(*prev_vertex, vertex);
+				const double segment_length = segment.length();
+				const double inv_segment_length = 1.0 / segment_length;
+
+				length_since_last_tooth += segment_length;
+				while (length_since_last_tooth > spacing)
+				{
+					if (GPlatesMaths::are_almost_exactly_equal(segment_length, 0))
+					{
+						continue;
+					}
+
+					const double interp = inv_segment_length * (segment_length - (length_since_last_tooth - spacing));
+					const QPointF tooth_base_midpoint = segment.pointAt(interp);
+
+					const QPointF tooth_base_direction(
+							inv_segment_length * segment.dx(),
+							inv_segment_length * segment.dy());
+
+					const QLineF segment_normal = segment.normalVector();  // same length as 'segment'
+					const QPointF tooth_normal_direction(
+							overriding_normal_factor * inv_segment_length * segment_normal.dx(),
+							overriding_normal_factor * inv_segment_length * segment_normal.dy());
+
+					const QPointF tooth_triangle_vertices[3] =
+					{
+						tooth_base_midpoint + teeth_height * tooth_normal_direction,
+						tooth_base_midpoint - 0.5 * teeth_width * tooth_base_direction,
+						tooth_base_midpoint + 0.5 * teeth_width * tooth_base_direction,
+					};
+
+					stream_teeth.add_vertex(coloured_vertex_type(tooth_triangle_vertices[0].x(), tooth_triangle_vertices[0].y(), 0/*z*/, rgba8_colour));
+					stream_teeth.add_vertex(coloured_vertex_type(tooth_triangle_vertices[1].x(), tooth_triangle_vertices[1].y(), 0/*z*/, rgba8_colour));
+					stream_teeth.add_vertex(coloured_vertex_type(tooth_triangle_vertices[2].x(), tooth_triangle_vertices[2].y(), 0/*z*/, rgba8_colour));
+
+					length_since_last_tooth -= spacing;
+				}
+
+				prev_vertex = &vertex;
+			}
+
+			stream_line_strips.end_line_strip();
+		}
+	}
+
+	stream_teeth.end_triangles();
 }
 
 

--- a/src/gui/MapRenderedGeometryLayerPainter.h
+++ b/src/gui/MapRenderedGeometryLayerPainter.h
@@ -86,6 +86,7 @@ namespace GPlatesGui
 				const GPlatesViewOperations::RenderedGeometryLayer &rendered_geometry_layer,
 				const GPlatesOpenGL::GLVisualLayers::non_null_ptr_type &gl_visual_layers,
 				const double &inverse_viewport_zoom_factor,
+				const double &device_independent_pixel_to_map_space_ratio,
 				ColourScheme::non_null_ptr_type colour_scheme);
 
 
@@ -417,6 +418,9 @@ namespace GPlatesGui
 		GPlatesOpenGL::GLVisualLayers::non_null_ptr_type d_gl_visual_layers;
 
 		const double d_inverse_zoom_factor;
+
+		//! The size of one device-independent pixel in (post projection) map space units.
+		const double d_device_independent_pixel_to_map_space_ratio;
 
 		//! For assigning colours to RenderedGeometry
 		ColourScheme::non_null_ptr_type d_colour_scheme;

--- a/src/gui/MapRenderedGeometryLayerPainter.h
+++ b/src/gui/MapRenderedGeometryLayerPainter.h
@@ -164,6 +164,11 @@ namespace GPlatesGui
 
 		virtual
 		void
+		visit_rendered_subduction_teeth_polyline(
+				const GPlatesViewOperations::RenderedSubductionTeethPolyline &rendered_subduction_teeth_polyline);
+
+		virtual
+		void
 		visit_rendered_polygon_on_sphere(
 				const GPlatesViewOperations::RenderedPolygonOnSphere &rendered_polygon_on_sphere);
 

--- a/src/gui/PoleManipulationCanvasToolWorkflow.cc
+++ b/src/gui/PoleManipulationCanvasToolWorkflow.cc
@@ -29,6 +29,7 @@
 #include "FeatureFocus.h"
 
 #include "app-logic/ApplicationState.h"
+#include "app-logic/Reconstruction.h"
 #include "app-logic/TopologyUtils.h"
 
 #include "canvas-tools/CanvasToolAdapterForGlobe.h"
@@ -293,6 +294,7 @@ GPlatesGui::PoleManipulationCanvasToolWorkflow::draw_feature_focus()
 			d_rendered_geometry_parameters,
 			d_render_settings,
 			d_application_state.get_current_topological_sections(),
+			d_application_state.get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			d_symbol_map);
 }
 

--- a/src/gui/RenderSettings.h
+++ b/src/gui/RenderSettings.h
@@ -113,6 +113,27 @@ namespace GPlatesGui
 		void set_show_3d_scalar_fields(bool b) { d_show_3d_scalar_fields = b; Q_EMIT settings_changed(); }
 		void set_show_scalar_coverages(bool b) { d_show_scalar_coverages = b; Q_EMIT settings_changed(); }
 		void set_show_strings(bool b) { d_show_strings = b; Q_EMIT settings_changed(); }
+
+		void
+		set_show_all(
+				bool b)
+		{
+			d_show_static_points = b;
+			d_show_static_multipoints = b;
+			d_show_static_lines = b;
+			d_show_static_polygons = b;
+			d_show_topological_sections = b;
+			d_show_topological_lines = b;
+			d_show_topological_polygons = b;
+			d_show_topological_networks = b;
+			d_show_velocity_arrows = b;
+			d_show_rasters = b;
+			d_show_3d_scalar_fields = b;
+			d_show_scalar_coverages = b;
+			d_show_strings = b;
+
+			Q_EMIT settings_changed();
+		}
 	
 	Q_SIGNALS:
 

--- a/src/gui/TopologyCanvasToolWorkflow.cc
+++ b/src/gui/TopologyCanvasToolWorkflow.cc
@@ -29,6 +29,7 @@
 #include "FeatureFocus.h"
 
 #include "app-logic/ApplicationState.h"
+#include "app-logic/Reconstruction.h"
 #include "app-logic/TopologyInternalUtils.h"
 #include "app-logic/TopologyUtils.h"
 
@@ -391,6 +392,7 @@ GPlatesGui::TopologyCanvasToolWorkflow::draw_feature_focus()
 			d_rendered_geometry_parameters,
 			d_render_settings,
 			d_application_state.get_current_topological_sections(),
+			d_application_state.get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			d_symbol_map);
 }
 

--- a/src/gui/TopologyTools.cc
+++ b/src/gui/TopologyTools.cc
@@ -1898,6 +1898,7 @@ GPlatesGui::TopologyTools::draw_focused_geometry(
 			render_style_params,
 			d_viewport_window_ptr->get_view_state().get_render_settings(),
 			d_application_state_ptr->get_current_topological_sections(),
+			d_application_state_ptr->get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			d_rendered_geometry_parameters.get_topology_tool_focused_geometry_colour(),
 			boost::none,
 			boost::none);

--- a/src/presentation/ReconstructionGeometryRenderer.cc
+++ b/src/presentation/ReconstructionGeometryRenderer.cc
@@ -907,6 +907,7 @@ GPlatesPresentation::ReconstructionGeometryRenderer::visit(
 				get_colour(rtg, d_colour, d_style_adapter),
 				d_reconstruction_adjustment,
 				d_feature_type_symbol_map,
+				// Topological boundary outlines and topological lines get rendered with a different thickness...
 				d_render_params.reconstruction_topology_size_multiplier/*line_width_and_point_size_multiplier*/);
 
 	// The rendered geometry represents a geometry-on-sphere so render to the spatial partition.
@@ -2166,6 +2167,7 @@ GPlatesPresentation::ReconstructionGeometryRenderer::render_topological_network_
 					get_colour(rigid_block_rfg, d_colour, d_style_adapter),
 					d_reconstruction_adjustment,
 					d_feature_type_symbol_map,
+					// Topological network boundaries get rendered with a different thickness...
 					d_render_params.reconstruction_topology_size_multiplier/*line_width_and_point_size_multiplier*/);
 
 		// The rendered geometry is a rigid interior block, which is on the sphere and within the bounds of the
@@ -2294,6 +2296,7 @@ GPlatesPresentation::ReconstructionGeometryRenderer::render_topological_shared_s
 					shared_sub_segment_polyline,
 					subduction_polarity.get() == SubductionPolarity::LEFT,  // subduction_polarity_is_left
 					shared_sub_segment_colour,
+					// Topological plate/network boundaries get rendered with a different thickness...
 					d_render_params.reconstruction_line_width_hint * d_render_params.reconstruction_topology_size_multiplier);
 		}
 		else
@@ -2302,6 +2305,7 @@ GPlatesPresentation::ReconstructionGeometryRenderer::render_topological_shared_s
 			shared_sub_segment_rendered_geom = GPlatesViewOperations::RenderedGeometryFactory::create_rendered_polyline_on_sphere(
 					shared_sub_segment_polyline,
 					shared_sub_segment_colour,
+					// Topological plate/network boundaries get rendered with a different thickness...
 					d_render_params.reconstruction_line_width_hint * d_render_params.reconstruction_topology_size_multiplier,
 					d_render_params.fill_polylines,
 					d_render_params.fill_modulate_colour);

--- a/src/presentation/ReconstructionGeometryRenderer.h
+++ b/src/presentation/ReconstructionGeometryRenderer.h
@@ -44,6 +44,7 @@
 #include "app-logic/ResolvedTriangulationDelaunay2.h"
 #include "app-logic/ResolvedTriangulationNetwork.h"
 #include "app-logic/ResolvedTriangulationUtils.h"
+#include "app-logic/TopologyUtils.h"
 
 #include "global/AssertionFailureException.h"
 #include "global/GPlatesAssert.h"
@@ -62,6 +63,7 @@
 #include "maths/Real.h"
 #include "maths/Rotation.h"
 
+#include "model/FeatureHandle.h"
 #include "model/FeatureId.h"
 
 #include "view-operations/RenderedColouredTriangleSurfaceMesh.h"
@@ -257,6 +259,9 @@ namespace GPlatesPresentation
 		 * @a topological_sections are all topological sections referenced by loaded topologies.
 		 * Together with @a render_settings this determines whether to show/hide topological sections.
 		 *
+		 * @a all_resolved_topological_shared_sub_segments are resolved topological shared sub-segments
+		 * between ALL resolved topological boundaries and networks for the current reconstruction being rendered.
+		 *
 		 * @a reconstruction_adjustment is only used to rotate derived @a ReconstructionGeometry
 		 * objects that are reconstructed. Ignored by types not explicitly reconstructed.
 		 *
@@ -267,6 +272,7 @@ namespace GPlatesPresentation
 				const RenderParams &render_params,
 				const GPlatesGui::RenderSettings &render_settings,
 				const std::set<GPlatesModel::FeatureId> &topological_sections,
+				const GPlatesAppLogic::TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &all_resolved_topological_shared_sub_segments,
 				const boost::optional<GPlatesGui::Colour> &colour = boost::none,
 				const boost::optional<GPlatesMaths::Rotation> &reconstruction_adjustment = boost::none,
 				boost::optional<const GPlatesGui::symbol_map_type &> feature_type_symbol_map = boost::none,
@@ -414,6 +420,7 @@ namespace GPlatesPresentation
 		RenderParams d_render_params;
 		const GPlatesGui::RenderSettings &d_render_settings;
 		const std::set<GPlatesModel::FeatureId> &d_topological_sections;
+		const GPlatesAppLogic::TopologyUtils::resolved_topological_boundaries_networks_to_shared_sub_segments_map_type &d_all_resolved_topological_shared_sub_segments;
 		boost::optional<GPlatesGui::Colour> d_colour;
 		boost::optional<GPlatesMaths::Rotation> d_reconstruction_adjustment;
 		boost::optional<const GPlatesGui::symbol_map_type &> d_feature_type_symbol_map;
@@ -429,8 +436,12 @@ namespace GPlatesPresentation
 		 *
 		 * It is only valid during @a render.
 		 */
-		boost::optional<const rendered_geometries_spatial_partition_type::location_type &>
-				d_rendered_geometries_spatial_partition_location;
+		boost::optional<const rendered_geometries_spatial_partition_type::location_type &> d_rendered_geometries_spatial_partition_location;
+
+		/**
+		 * Shared boundary sub-segments of resolved topological boundaries and networks rendered in the current rendered geometry layer.
+		 */
+		std::set<GPlatesAppLogic::ResolvedTopologicalSharedSubSegment::non_null_ptr_type> d_resolved_topological_shared_sub_segments;
 
 
 		/**
@@ -558,6 +569,22 @@ namespace GPlatesPresentation
 		void
 		render_topological_network_velocities(
 				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &topological_network);
+
+
+		/**
+		 * Add the shared sub-segments of a resolved topological boundary or network to be rendered later
+		 * (at the end of the current rendered geometry layer).
+		 */
+		void
+		add_topological_shared_sub_segments(
+				const GPlatesModel::FeatureHandle::iterator &resolved_topology_feature_property);
+
+		/**
+		 * Render shared sub-segments of resolved topological boundaries and networks
+		 * (rendered in the current rendered geometry layer).
+		 */
+		void
+		render_topological_shared_sub_segments();
 	};
 
 

--- a/src/presentation/ReconstructionGeometryRenderer.h
+++ b/src/presentation/ReconstructionGeometryRenderer.h
@@ -592,6 +592,15 @@ namespace GPlatesPresentation
 		 */
 		void
 		render_topological_shared_sub_segments();
+
+		enum class SubductionPolarity { LEFT, RIGHT };
+
+		/**
+		 * Returns the subduction polarity if the specified reconstruction geometry represents a subduction zone.
+		 */
+		boost::optional<SubductionPolarity>
+		get_subduction_polarity(
+				const GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type &resolved_topological_section) const;
 	};
 
 

--- a/src/presentation/ReconstructionGeometryRenderer.h
+++ b/src/presentation/ReconstructionGeometryRenderer.h
@@ -28,6 +28,7 @@
 #define GPLATES_PRESENTATION_RECONSTRUCTION_GEOMETRY_RENDERER_H
 
 #include <functional>
+#include <map>
 #include <set>
 #include <utility>
 #include <vector>
@@ -439,9 +440,14 @@ namespace GPlatesPresentation
 		boost::optional<const rendered_geometries_spatial_partition_type::location_type &> d_rendered_geometries_spatial_partition_location;
 
 		/**
-		 * Shared boundary sub-segments of resolved topological boundaries and networks rendered in the current rendered geometry layer.
+		 * Mapping from shared boundary sub-segments to their sharing resolved topological boundaries and networks
+		 * (rendered in the current rendered geometry layer).
+		 *
+		 * This is used to render all shared sub-segments at the end of a rendered geometry layer.
 		 */
-		std::set<GPlatesAppLogic::ResolvedTopologicalSharedSubSegment::non_null_ptr_type> d_resolved_topological_shared_sub_segments;
+		std::map<
+				GPlatesAppLogic::ResolvedTopologicalSharedSubSegment::non_null_ptr_type,
+				std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type>> d_resolved_topological_shared_sub_segments_map;
 
 
 		/**
@@ -577,6 +583,7 @@ namespace GPlatesPresentation
 		 */
 		void
 		add_topological_shared_sub_segments(
+				const GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type &resolved_topology,
 				const GPlatesModel::FeatureHandle::iterator &resolved_topology_feature_property);
 
 		/**

--- a/src/presentation/ReconstructionGeometryRenderer.h
+++ b/src/presentation/ReconstructionGeometryRenderer.h
@@ -106,6 +106,7 @@ namespace GPlatesPresentation
 
 			float reconstruction_line_width_hint;
 			float reconstruction_point_size_hint;
+			float reconstruction_topology_size_multiplier;
 			bool fill_polygons;
 			bool fill_polylines;
 

--- a/src/presentation/ReconstructionGeometryRenderer.h
+++ b/src/presentation/ReconstructionGeometryRenderer.h
@@ -533,20 +533,18 @@ namespace GPlatesPresentation
 		void
 		render_topological_network_delaunay_edges_smoothed_strain_rates(
 				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &rtn,
-				const double &subdivide_edge_threshold_angle,
-				bool only_boundary_edges = false);
+				const double &subdivide_edge_threshold_angle);
 
 		void
 		render_topological_network_delaunay_edges_unsmoothed_strain_rates(
-				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &rtn,
-				bool only_boundary_edges = false);
+				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &rtn);
 
 		void
 		render_topological_network_delaunay_edges_using_draw_style(
 				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &rtn);
 
 		void
-		render_topological_network_boundary_using_draw_style(
+		render_topological_network_fill_using_draw_style(
 				const GPlatesAppLogic::ResolvedTopologicalNetwork::non_null_ptr_to_const_type &rtn);
 
 		void

--- a/src/presentation/TopologyNetworkVisualLayerParams.cc
+++ b/src/presentation/TopologyNetworkVisualLayerParams.cc
@@ -305,7 +305,9 @@ GPlatesPresentation::transcribe(
 	//          So don't change the string ids even if the enum name changes.
 	static const GPlatesScribe::EnumValue enum_values[] =
 	{
-		GPlatesScribe::EnumValue("DRAW_BOUNDARY", TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_BOUNDARY),
+		// Note: Changed enum from TRIANGULATION_DRAW_BOUNDARY to TRIANGULATION_DRAW_NONE,
+		//       but we keep the string id "DRAW_BOUNDARY" for compatibility...
+		GPlatesScribe::EnumValue("DRAW_BOUNDARY", TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_NONE),
 		GPlatesScribe::EnumValue("DRAW_MESH", TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_MESH),
 		GPlatesScribe::EnumValue("DRAW_FILL", TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_FILL)
 	};

--- a/src/presentation/TopologyNetworkVisualLayerParams.h
+++ b/src/presentation/TopologyNetworkVisualLayerParams.h
@@ -60,7 +60,7 @@ namespace GPlatesPresentation
 
 		enum TriangulationDrawMode
 		{
-			TRIANGULATION_DRAW_BOUNDARY,
+			TRIANGULATION_DRAW_NONE,
 			TRIANGULATION_DRAW_MESH,
 			TRIANGULATION_DRAW_FILL
 		};
@@ -301,7 +301,7 @@ namespace GPlatesPresentation
 		set_fill_triangulation(
 				bool b)
 		{
-			d_triangulation_draw_mode = b ? TRIANGULATION_DRAW_FILL : TRIANGULATION_DRAW_BOUNDARY;
+			d_triangulation_draw_mode = b ? TRIANGULATION_DRAW_FILL : TRIANGULATION_DRAW_NONE;
 			emit_modified();
 		}
 

--- a/src/presentation/TranscribeSession.cc
+++ b/src/presentation/TranscribeSession.cc
@@ -2227,11 +2227,12 @@ namespace GPlatesPresentation
 						}
 						else
 						{
-							// Unfilled triangulations were previously drawn as a boundary (when colouring by draw style) and
-							// as a mesh (when colouring by strain rate).
+							// Unfilled triangulations were previously:
+							// - drawn as a boundary when colouring by draw style (ie, only boundary was drawn, not triangulation),
+							// - drawn as a mesh when colouring by strain rate.
 							params.set_triangulation_draw_mode(
 									colour_mode == TopologyNetworkVisualLayerParams::TRIANGULATION_COLOUR_DRAW_STYLE
-									? TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_BOUNDARY
+									? TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_NONE
 									: TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_MESH);
 						}
 					}

--- a/src/presentation/TranscribeSession.cc
+++ b/src/presentation/TranscribeSession.cc
@@ -3062,6 +3062,10 @@ namespace GPlatesPresentation
 					reconstruction_layer_geometry_parameters_tag("line_width_hint"));
 			scribe.save(
 					TRANSCRIBE_SOURCE,
+					rendered_geometry_parameters.get_reconstruction_layer_topology_size_multiplier(),
+					reconstruction_layer_geometry_parameters_tag("topology_size_multiplier"));
+			scribe.save(
+					TRANSCRIBE_SOURCE,
 					rendered_geometry_parameters.get_reconstruction_layer_ratio_arrow_unit_vector_direction_to_globe_radius(),
 					reconstruction_layer_geometry_parameters_tag("ratio_arrow_unit_vector_direction_to_globe_radius"));
 			scribe.save(
@@ -3096,6 +3100,15 @@ namespace GPlatesPresentation
 					reconstruction_layer_geometry_parameters_tag("line_width_hint")))
 			{
 				rendered_geometry_parameters.set_reconstruction_layer_line_width_hint(reconstruction_layer_line_width_hint);
+			}
+
+			float reconstruction_layer_topology_size_multiplier;
+			if (scribe.transcribe(
+					TRANSCRIBE_SOURCE,
+					reconstruction_layer_topology_size_multiplier,
+					reconstruction_layer_geometry_parameters_tag("topology_size_multiplier")))
+			{
+				rendered_geometry_parameters.set_reconstruction_layer_topology_size_multiplier(reconstruction_layer_topology_size_multiplier);
 			}
 
 			float reconstruction_layer_ratio_arrow_unit_vector_direction_to_globe_radius;

--- a/src/presentation/VisualLayer.cc
+++ b/src/presentation/VisualLayer.cc
@@ -35,6 +35,7 @@
 
 #include "app-logic/ApplicationState.h"
 #include "app-logic/Layer.h"
+#include "app-logic/Reconstruction.h"
 
 #include "gui/Symbol.h"
 
@@ -151,8 +152,9 @@ GPlatesPresentation::VisualLayer::create_rendered_geometries()
 			render_params_populator.get_render_params(),
 			d_render_settings,
 			d_application_state.get_current_topological_sections(),
+			d_application_state.get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			boost::none, // colour 
-            boost::none, // rotation adjustment
+			boost::none, // rotation adjustment
 			d_symbol_map,
 			draw_style_adapter);
 

--- a/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialog.cc
+++ b/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialog.cc
@@ -82,6 +82,8 @@ GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::ConfigureCa
 			d_rendered_geometry_parameters.get_reconstruction_layer_point_size_hint());
 	reconstruction_layer_line_width_hint_spinbox->setValue(
 			d_rendered_geometry_parameters.get_reconstruction_layer_line_width_hint());
+	reconstruction_layer_topology_size_multiplier_spinbox->setValue(
+			d_rendered_geometry_parameters.get_reconstruction_layer_topology_size_multiplier());
 
 	QObject::connect(
 			d_focused_feature_clicked_geometry_colour_button,
@@ -140,6 +142,11 @@ GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::ConfigureCa
 			SIGNAL(valueChanged(double)),
 			this,
 			SLOT(react_reconstruction_layer_line_width_hint_spinbox_value_changed(double)));
+	QObject::connect(
+			reconstruction_layer_topology_size_multiplier_spinbox,
+			SIGNAL(valueChanged(double)),
+			this,
+			SLOT(react_reconstruction_layer_topology_size_multiplier_spinbox_value_changed(double)));
 
 	// Also update our GUI when the render geometry parameters change.
 	QObject::connect(
@@ -241,6 +248,14 @@ GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::react_recon
 
 
 void
+GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::react_reconstruction_layer_topology_size_multiplier_spinbox_value_changed(
+		double value)
+{
+	d_rendered_geometry_parameters.set_reconstruction_layer_topology_size_multiplier(value);
+}
+
+
+void
 GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::handle_rendered_geometry_parameters_changed()
 {
 	// Note: Calling 'ChooseColourButton::set_colour()' will only emit a signal if the colour changes and
@@ -279,4 +294,7 @@ GPlatesQtWidgets::ConfigureCanvasToolGeometryRenderParametersDialog::handle_rend
 
 	reconstruction_layer_line_width_hint_spinbox->setValue(
 			d_rendered_geometry_parameters.get_reconstruction_layer_line_width_hint());
+
+	reconstruction_layer_topology_size_multiplier_spinbox->setValue(
+			d_rendered_geometry_parameters.get_reconstruction_layer_topology_size_multiplier());
 }

--- a/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialog.h
+++ b/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialog.h
@@ -99,6 +99,10 @@ namespace GPlatesQtWidgets
 				double value);
 
 		void
+		react_reconstruction_layer_topology_size_multiplier_spinbox_value_changed(
+				double value);
+
+		void
 		handle_rendered_geometry_parameters_changed();
 
 	private:

--- a/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialogUi.ui
+++ b/src/qt-widgets/ConfigureCanvasToolGeometryRenderParametersDialogUi.ui
@@ -43,7 +43,16 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -145,7 +154,16 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -238,7 +256,16 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -329,7 +356,16 @@
      <layout class="QFormLayout" name="formLayout_3">
       <item row="0" column="0" colspan="2">
        <layout class="QHBoxLayout" name="reconstruction_layer_warning_layout">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -412,6 +448,29 @@
         </property>
         <property name="singleStep">
          <double>0.200000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="reconstruction_layer_topology_size_multiplier_label">
+        <property name="text">
+         <string>Topology size multiplier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QDoubleSpinBox" name="reconstruction_layer_topology_size_multiplier_spinbox">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="minimum">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
         </property>
        </widget>
       </item>

--- a/src/qt-widgets/GlobeCanvas.cc
+++ b/src/qt-widgets/GlobeCanvas.cc
@@ -194,6 +194,33 @@ namespace
 
 
 	/**
+	 * Calculate the size of one device-independent pixel in world space coordinates.
+	 */
+	double
+	calc_device_independent_pixel_to_world_space_ratio(
+			int scene_view_width_in_device_independent_pixels,
+			int scene_view_height_in_device_independent_pixels,
+			const double &zoom_factor)
+	{
+		// Smallest dimension (view width or height) in device-independent pixels.
+		double smaller_dim_in_device_independent_pixels;
+		if (scene_view_width_in_device_independent_pixels <= scene_view_height_in_device_independent_pixels)
+		{
+			smaller_dim_in_device_independent_pixels = static_cast<GLdouble>(scene_view_width_in_device_independent_pixels);
+		}
+		else
+		{
+			smaller_dim_in_device_independent_pixels = static_cast<GLdouble>(scene_view_height_in_device_independent_pixels);
+		}
+
+		// The smallest dimension (view width or height) is bounded by this size in world space.
+		const GLdouble smaller_dim_world_space = 2 * GPlatesQtWidgets::GlobeCanvas::FRAMING_RATIO / zoom_factor;
+
+		return smaller_dim_world_space / smaller_dim_in_device_independent_pixels;
+	}
+
+
+	/**
 	 * Given the scene view's dimensions (eg, canvas dimensions) generate projection transforms
 	 * needed to display the scene.
 	 *
@@ -1100,6 +1127,12 @@ GPlatesQtWidgets::GlobeCanvas::render_scene(
 	const float scale = calculate_scale(
 			paint_device_width_in_device_independent_pixels,
 			paint_device_height_in_device_independent_pixels);
+	const double device_independent_pixel_to_world_space_ratio =
+			calc_device_independent_pixel_to_world_space_ratio(
+					paint_device_width_in_device_independent_pixels,
+					paint_device_height_in_device_independent_pixels,
+					viewport_zoom_factor);
+
 
 	//
 	// Paint the globe and its contents.
@@ -1114,6 +1147,7 @@ GPlatesQtWidgets::GlobeCanvas::render_scene(
 	const cache_handle_type frame_cache_handle = d_globe.paint(
 			renderer,
 			viewport_zoom_factor,
+			device_independent_pixel_to_world_space_ratio,
 			scale,
 			projection_transform_include_front_half_globe,
 			projection_transform_include_rear_half_globe,

--- a/src/qt-widgets/MapCanvas.cc
+++ b/src/qt-widgets/MapCanvas.cc
@@ -224,6 +224,11 @@ GPlatesQtWidgets::MapCanvas::render_scene(
 			paint_device_height_in_device_independent_pixels,
 			map_canvas_paint_device_width_in_device_independent_pixels,
 			map_canvas_paint_device_height_in_device_independent_pixels);
+	const double device_independent_pixel_to_map_space_ratio =
+			d_map_view_ptr->get_device_independent_pixel_to_map_space_ratio(
+					paint_device_width_in_device_independent_pixels,
+					paint_device_height_in_device_independent_pixels,
+					viewport_zoom_factor);
 
 	//
 	// Paint the map and its contents.
@@ -235,7 +240,11 @@ GPlatesQtWidgets::MapCanvas::render_scene(
 	// Since the view direction usually differs little from one frame to the next there is a lot
 	// of overlap that we want to reuse (and not recalculate).
 	//
-	const cache_handle_type frame_cache_handle = d_map.paint(renderer, viewport_zoom_factor, scale);
+	const cache_handle_type frame_cache_handle = d_map.paint(
+			renderer,
+			viewport_zoom_factor,
+			device_independent_pixel_to_map_space_ratio,
+			scale);
 
 	// The text overlay is rendered in screen window coordinates (ie, no model-view transform needed).
 	renderer.gl_load_matrix(GL_MODELVIEW, GPlatesOpenGL::GLMatrix::IDENTITY);

--- a/src/qt-widgets/MapView.h
+++ b/src/qt-widgets/MapView.h
@@ -198,6 +198,15 @@ namespace GPlatesQtWidgets
 		get_viewport_size() const;
 
 		/**
+		 * Calculate the size of one device-independent pixel in (post projection) map space coordinates.
+		 */
+		double
+		get_device_independent_pixel_to_map_space_ratio(
+				int paint_device_width_in_device_independent_pixels,
+				int paint_device_height_in_device_independent_pixels,
+				const double &zoom_factor);
+
+		/**
 		 * Renders the scene to a QImage of the dimensions specified by @a image_size.
 		 *
 		 * The specified image size should be in device *independent* pixels (eg, widget dimensions).

--- a/src/qt-widgets/ModifyReconstructionPoleWidget.cc
+++ b/src/qt-widgets/ModifyReconstructionPoleWidget.cc
@@ -920,6 +920,7 @@ GPlatesQtWidgets::ModifyReconstructionPoleWidget::draw_initial_geometries()
 			render_style_params,
 			d_view_state_ptr->get_render_settings(),
 			d_application_state_ptr->get_current_topological_sections(),
+			d_application_state_ptr->get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			white_colour,
 			boost::none,
 			boost::none);
@@ -977,6 +978,7 @@ GPlatesQtWidgets::ModifyReconstructionPoleWidget::draw_dragged_geometries()
 			render_style_params,
 			d_view_state_ptr->get_render_settings(),
 			d_application_state_ptr->get_current_topological_sections(),
+			d_application_state_ptr->get_current_reconstruction().get_all_resolved_topological_shared_sub_segments(),
 			silver_colour,
 			d_accum_orientation->rotation(),
 			boost::none);

--- a/src/qt-widgets/TopologyNetworkResolverLayerOptionsWidget.cc
+++ b/src/qt-widgets/TopologyNetworkResolverLayerOptionsWidget.cc
@@ -125,23 +125,27 @@ namespace
 			QObject::tr("Network triangulation colour mode");
 	const QString HELP_TRIANGULATION_COLOUR_MODE_DIALOG_TEXT = QObject::tr(
 			"<html><body>\n"
-			"<p>The network triangulation is coloured with <i>use draw style</i> by default. "
-			"This colours the network triangulation and any interior rigid blocks using the colour scheme selected for the layer.</p>"
-			"<p>Alternatively the network triangulation can be coloured using <i>dilatation strain rate</i>, "
+			"<p>This selects the colour mode for the <i>triangulation</i> of the network.</p>"
+			"<p>By default, the triangulation is coloured with the <i>draw style</i> (this uses the colour scheme selected for the layer).</p>"
+			"<p>Alternatively the triangulation can be coloured using <i>dilatation strain rate</i>, "
 			"<i>total strain rate</i> or <i>strain rate style</i> and a colour palette.</p>"
 			"<p><i>Strain rate style</i> is typically in the range [-1.0, 1.0] where -1.0 implies contraction, "
 			"1.0 implies extension and 0.0 implies strike-slip.</p>"
+			"<p>Note that the <i>boundary</i> of the network (including any interior rigid blocks) is always coloured with the <i>draw style</i> "
+			"regardless of the <i>triangulation colour mode</i>.</p>"
 			"</body></html>\n");
 
 	const QString HELP_TRIANGULATION_DRAW_MODE_DIALOG_TITLE =
 			QObject::tr("Network triangulation draw mode");
 	const QString HELP_TRIANGULATION_DRAW_MODE_DIALOG_TEXT = QObject::tr(
 			"<html><body>\n"
-			"<p>To display only the boundary of the network triangulation select <i>Boundary</i>. "
-			"<p>Alternatively the triangulation wireframe mesh can be displayed with <i>Mesh</i> or "
-			"the triangulation can be filled with <i>Fill</i>.</p>"
-			"<p>Note that the rigid interior blocks (if any) can be filled by selecting <i>fill rigid interior blocks</i> "
-			"and are always displayed using the <i>draw style</i>.</p>"
+			"<p>The wireframe mesh of the triangulation can be displayed with <i>Mesh</i>, or "
+			"the triangulation can be filled with <i>Fill</i>, or not displayed with <i>None</i>.</p>"
+			"<p>The triangulation is coloured using the <i>triangulation colour mode</i> (when <i>Mesh</i> or <i>Fill</i> is selected).</p>"
+			"<p>Note that the <i>boundary</i> of the network (including any interior rigid blocks) is always displayed "
+			"regardless of the <i>triangulation draw mode</i>, and is always coloured with the <i>draw style</i>.</p>"
+			"<p>Also note that the rigid interior blocks (if any) can be independently filled by selecting <i>fill rigid interior blocks</i> "
+			"(and are always coloured with the <i>draw style</i>).</p>"
 			"</body></html>\n");
 }
 
@@ -353,9 +357,9 @@ GPlatesQtWidgets::TopologyNetworkResolverLayerOptionsWidget::TopologyNetworkReso
 			d_help_triangulation_colour_mode_dialog, SLOT(show()));
 
 	// Draw mode.
-	boundary_draw_mode_radio_button->setCursor(QCursor(Qt::ArrowCursor));
+	none_draw_mode_radio_button->setCursor(QCursor(Qt::ArrowCursor));
 	QObject::connect(
-			boundary_draw_mode_radio_button, SIGNAL(toggled(bool)),
+			none_draw_mode_radio_button, SIGNAL(toggled(bool)),
 			this, SLOT(handle_draw_mode_button(bool)));
 	mesh_draw_mode_radio_button->setCursor(QCursor(Qt::ArrowCursor));
 	QObject::connect(
@@ -768,7 +772,7 @@ GPlatesQtWidgets::TopologyNetworkResolverLayerOptionsWidget::set_data(
 			// Changing the current mode will emit signals which can lead to an infinitely recursive decent.
 			// To avoid this we temporarily disconnect their signals.
 			QObject::disconnect(
-					boundary_draw_mode_radio_button, SIGNAL(toggled(bool)),
+					none_draw_mode_radio_button, SIGNAL(toggled(bool)),
 					this, SLOT(handle_draw_mode_button(bool)));
 			QObject::disconnect(
 					mesh_draw_mode_radio_button, SIGNAL(toggled(bool)),
@@ -778,8 +782,8 @@ GPlatesQtWidgets::TopologyNetworkResolverLayerOptionsWidget::set_data(
 					this, SLOT(handle_draw_mode_button(bool)));
 			switch (params->get_triangulation_draw_mode())
 			{
-			case GPlatesPresentation::TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_BOUNDARY:
-				boundary_draw_mode_radio_button->setChecked(true);
+			case GPlatesPresentation::TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_NONE:
+				none_draw_mode_radio_button->setChecked(true);
 				break;
 			case GPlatesPresentation::TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_MESH:
 				mesh_draw_mode_radio_button->setChecked(true);
@@ -792,7 +796,7 @@ GPlatesQtWidgets::TopologyNetworkResolverLayerOptionsWidget::set_data(
 				break;
 			}
 			QObject::connect(
-					boundary_draw_mode_radio_button, SIGNAL(toggled(bool)),
+					none_draw_mode_radio_button, SIGNAL(toggled(bool)),
 					this, SLOT(handle_draw_mode_button(bool)));
 			QObject::connect(
 					mesh_draw_mode_radio_button, SIGNAL(toggled(bool)),
@@ -1343,10 +1347,10 @@ GPlatesQtWidgets::TopologyNetworkResolverLayerOptionsWidget::handle_draw_mode_bu
 					locked_visual_layer->get_visual_layer_params().get());
 		if (params)
 		{
-			if (boundary_draw_mode_radio_button->isChecked())
+			if (none_draw_mode_radio_button->isChecked())
 			{
 				params->set_triangulation_draw_mode(
-						GPlatesPresentation::TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_BOUNDARY);
+						GPlatesPresentation::TopologyNetworkVisualLayerParams::TRIANGULATION_DRAW_NONE);
 			}
 			if (mesh_draw_mode_radio_button->isChecked())
 			{

--- a/src/qt-widgets/TopologyNetworkResolverLayerOptionsWidgetUi.ui
+++ b/src/qt-widgets/TopologyNetworkResolverLayerOptionsWidgetUi.ui
@@ -1097,7 +1097,7 @@
     <widget class="QWidget" name="draw_style_placeholder_widget" native="true"/>
    </item>
    <item>
-    <widget class="QGroupBox" name="draw_mode_group_box">
+    <widget class="QGroupBox" name="triangulation_draw_mode_group_box">
      <property name="title">
       <string>Triangulation Draw Mode</string>
      </property>
@@ -1115,9 +1115,9 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QRadioButton" name="boundary_draw_mode_radio_button">
+       <widget class="QRadioButton" name="none_draw_mode_radio_button">
         <property name="text">
-         <string>Boundary</string>
+         <string>None</string>
         </property>
        </widget>
       </item>

--- a/src/qt-widgets/ViewportWindow.cc
+++ b/src/qt-widgets/ViewportWindow.cc
@@ -755,6 +755,8 @@ GPlatesQtWidgets::ViewportWindow::connect_view_menu_actions()
 			this, SLOT(enable_3d_scalar_field_display()));
 	QObject::connect(action_Show_Scalar_Coverages, SIGNAL(triggered()),
 			this, SLOT(enable_scalar_coverage_display()));
+	QObject::connect(action_Show_All_Geometries, SIGNAL(triggered()),
+			this, SLOT(enable_all_geometries_display()));
 	// Also update the GUI when the RenderSettings change.
 	QObject::connect(&get_view_state().get_render_settings(), SIGNAL(settings_changed()),
 			this, SLOT(handle_render_settings_changed()));
@@ -1409,6 +1411,16 @@ GPlatesQtWidgets::ViewportWindow::enable_scalar_coverage_display()
 {
 	get_view_state().get_render_settings().set_show_scalar_coverages(
 			action_Show_Scalar_Coverages->isChecked());
+}
+
+void
+GPlatesQtWidgets::ViewportWindow::enable_all_geometries_display()
+{
+	const bool show_all = action_Show_All_Geometries->isChecked();
+
+	// This will show/hide all geometries in the render settings which will also
+	// signal 'handle_render_settings_changed()' to change the individual checkboxes.
+	get_view_state().get_render_settings().set_show_all(show_all);
 }
 
 void

--- a/src/qt-widgets/ViewportWindow.h
+++ b/src/qt-widgets/ViewportWindow.h
@@ -391,6 +391,9 @@ namespace GPlatesQtWidgets
 		enable_scalar_coverage_display();
 
 		void
+		enable_all_geometries_display();
+
+		void
 		handle_render_settings_changed();
 
 		void

--- a/src/qt-widgets/ViewportWindowUi.ui
+++ b/src/qt-widgets/ViewportWindowUi.ui
@@ -33,7 +33,7 @@
      <x>0</x>
      <y>0</y>
      <width>780</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_Help">
@@ -163,6 +163,8 @@
      <addaction name="action_Show_Rasters"/>
      <addaction name="action_Show_3D_Scalar_Fields"/>
      <addaction name="action_Show_Scalar_Coverages"/>
+     <addaction name="separator"/>
+     <addaction name="action_Show_All_Geometries"/>
     </widget>
     <addaction name="action_Set_Projection"/>
     <addaction name="menu_Move_Camera"/>
@@ -625,6 +627,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether non-topological points are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, P</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_Static_Lines">
    <property name="checkable">
@@ -638,6 +646,12 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether non-topological lines are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, L</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_Show_Static_Polygons">
@@ -653,6 +667,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether non-topological polygons are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, G</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_Static_Multipoints">
    <property name="checkable">
@@ -666,6 +686,12 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether non-topological multipoints are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, M</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_Show_Velocity_Arrows">
@@ -683,6 +709,12 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether velocity arrows are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, V, A</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_Delete_Feature">
@@ -1249,6 +1281,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether features used as topological sections are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, T, S</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_Topological_Lines">
    <property name="checkable">
@@ -1262,6 +1300,12 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether topological lines are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, T, L</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_Show_Topological_Polygons">
@@ -1277,6 +1321,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether topological polygons are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, T, P</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_Topological_Networks">
    <property name="checkable">
@@ -1290,6 +1340,12 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether topological networks are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, T, N</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_Show_Rasters">
@@ -1305,6 +1361,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether rasters are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, R</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_3D_Scalar_Fields">
    <property name="checkable">
@@ -1319,6 +1381,12 @@
    <property name="toolTip">
     <string>A toggle operation which controls whether 3D scalar fields are shown.</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, F</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_Show_Scalar_Coverages">
    <property name="checkable">
@@ -1332,6 +1400,32 @@
    </property>
    <property name="toolTip">
     <string>A toggle operation which controls whether scalar coverages are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, S, C</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
+  </action>
+  <action name="action_Show_All_Geometries">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show All</string>
+   </property>
+   <property name="toolTip">
+    <string>A toggle operation which controls whether all geometries are shown.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V, A</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
  </widget>

--- a/src/view-operations/CMakeLists.txt
+++ b/src/view-operations/CMakeLists.txt
@@ -65,6 +65,7 @@ set(srcs
     RenderedGeometryUtils.h
     RenderedGeometryVisitor.h
     RenderedMultiPointOnSphere.h
+    RenderedMultiReconstructionGeometry.h
     RenderedPointOnSphere.h
     RenderedPolygonOnSphere.h
     RenderedPolylineOnSphere.h

--- a/src/view-operations/CMakeLists.txt
+++ b/src/view-operations/CMakeLists.txt
@@ -78,6 +78,7 @@ set(srcs
     RenderedSquareSymbol.h
     RenderedStrainMarkerSymbol.h
     RenderedString.h
+    RenderedSubductionTeethPolyline.h
     RenderedTangentialArrow.h
     RenderedTriangleSymbol.h
     ScalarField3DRenderParameters.cc

--- a/src/view-operations/MoveVertexGeometryOperation.h
+++ b/src/view-operations/MoveVertexGeometryOperation.h
@@ -41,6 +41,7 @@
 #include "RenderedGeometryFactory.h"
 #include "RenderedGeometryParameters.h"
 #include "RenderedGeometryVisitor.h"
+#include "RenderedMultiReconstructionGeometry.h"
 #include "RenderedReconstructionGeometry.h"
 #include "UndoRedo.h"
 
@@ -100,6 +101,15 @@ namespace GPlatesViewOperations
 			{
 				d_rendered_reconstruction_geometry.reset(
 					rendered_reconstruction_geometry.get_reconstruction_geometry());
+			}
+
+			virtual
+			void
+			visit_rendered_multi_reconstruction_geometry(
+				const RenderedMultiReconstructionGeometry &rendered_multi_reconstruction_geometry)
+			{
+				d_rendered_reconstruction_geometry.reset(
+					rendered_multi_reconstruction_geometry.get_reconstruction_geometries().front());
 			}
 
 			boost::optional<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type>

--- a/src/view-operations/RenderedArrowedPolyline.h
+++ b/src/view-operations/RenderedArrowedPolyline.h
@@ -41,14 +41,11 @@ namespace GPlatesViewOperations
 		RenderedArrowedPolyline(
 				GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type points,
 				const GPlatesGui::ColourProxy &colour,
-				float arrowhead_projected_size,
-				float max_arrowhead_size,
-				float arrowline_width_hint
-				) :
+				float arrowhead_size_in_pixels,
+				float arrowline_width_hint) :
 		d_points(points),
 		d_colour(colour),
-		d_arrowhead_projected_size(arrowhead_projected_size),
-		d_max_arrowhead_size(max_arrowhead_size),
+		d_arrowhead_size_in_pixels(arrowhead_size_in_pixels),
 		d_arrowline_width_hint(arrowline_width_hint)
 		{  }
 
@@ -89,18 +86,14 @@ namespace GPlatesViewOperations
 			return d_colour;
 		}
 		
+		//! The size of the arrowhead (in device-independent pixels).
 		float
-		get_arrowhead_projected_size() const
+		get_arrowhead_size_in_pixels() const
 		{
-			return d_arrowhead_projected_size;
+			return d_arrowhead_size_in_pixels;
 		}
 		
-		float
-		get_max_arrowhead_size() const
-		{
-			return d_max_arrowhead_size;
-		}
-		
+		//! The arrow line width (in device-independent pixels).
 		float
 		get_arrowline_width_hint() const
 		{
@@ -110,8 +103,7 @@ namespace GPlatesViewOperations
 	private:
 		GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type d_points;
 		const GPlatesGui::ColourProxy d_colour;
-		const float d_arrowhead_projected_size;
-		const float d_max_arrowhead_size;
+		const float d_arrowhead_size_in_pixels;
 		const float d_arrowline_width_hint;		
 	};
 }

--- a/src/view-operations/RenderedGeometryFactory.cc
+++ b/src/view-operations/RenderedGeometryFactory.cc
@@ -37,6 +37,7 @@
 #include "RenderedCrossSymbol.h"
 #include "RenderedEllipse.h"
 #include "RenderedMultiPointOnSphere.h"
+#include "RenderedMultiReconstructionGeometry.h"
 #include "RenderedPointOnSphere.h"
 #include "RenderedPolygonOnSphere.h"
 #include "RenderedPolylineOnSphere.h"
@@ -561,6 +562,17 @@ GPlatesViewOperations::RenderedGeometryFactory::create_rendered_reconstruction_g
 {
 	RenderedGeometry::impl_ptr_type rendered_geom_impl(new RenderedReconstructionGeometry(
 			reconstruction_geom, rendered_geom));
+
+	return RenderedGeometry(rendered_geom_impl);
+}
+
+GPlatesViewOperations::RenderedGeometry
+GPlatesViewOperations::RenderedGeometryFactory::create_rendered_multi_reconstruction_geometry(
+		const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type> &reconstruction_geoms,
+		RenderedGeometry rendered_geom)
+{
+	RenderedGeometry::impl_ptr_type rendered_geom_impl(new RenderedMultiReconstructionGeometry(
+			reconstruction_geoms, rendered_geom));
 
 	return RenderedGeometry(rendered_geom_impl);
 }

--- a/src/view-operations/RenderedGeometryFactory.cc
+++ b/src/view-operations/RenderedGeometryFactory.cc
@@ -664,8 +664,8 @@ GPlatesViewOperations::RenderedGeometryFactory::create_rendered_subduction_teeth
 		bool subduction_polarity_is_left,
 		const GPlatesGui::ColourProxy &colour,
 		float line_width_hint,
-		float teeth_spacing_to_globe_radius,
-		float teeth_width_to_globe_radius,
+		float teeth_width_in_pixels,
+		float teeth_spacing_to_width_ratio,
 		float teeth_height_to_width_ratio)
 {
 	RenderedGeometry::impl_ptr_type rendered_geom_impl(new RenderedSubductionTeethPolyline(
@@ -675,8 +675,8 @@ GPlatesViewOperations::RenderedGeometryFactory::create_rendered_subduction_teeth
 				: RenderedSubductionTeethPolyline::SubductionPolarity::RIGHT,
 		colour,
 		line_width_hint,
-		teeth_spacing_to_globe_radius,
-		teeth_width_to_globe_radius,
+		teeth_width_in_pixels,
+		teeth_spacing_to_width_ratio,
 		teeth_height_to_width_ratio));
 
 	return RenderedGeometry(rendered_geom_impl);

--- a/src/view-operations/RenderedGeometryFactory.cc
+++ b/src/view-operations/RenderedGeometryFactory.cc
@@ -641,18 +641,13 @@ GPlatesViewOperations::RenderedGeometryFactory::create_rendered_string(
 
 GPlatesViewOperations::RenderedGeometry
 GPlatesViewOperations::RenderedGeometryFactory::create_rendered_arrowed_polyline(
-	GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type points,
-	const GPlatesGui::ColourProxy &colour,
-	const float ratio_arrowhead_size_to_globe_radius,
-	const float arrowline_width_hint)
+		GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type points,
+		const GPlatesGui::ColourProxy &colour,
+		const float arrowhead_size_in_pixels,
+		const float arrowline_width_hint)
 {
-
-	// This could also be passed in the arguments to this "create..." function...
-	const float MAX_ARROWHEAD_SIZE = 0.005f;
-
 	RenderedGeometry::impl_ptr_type rendered_geom_impl(new RenderedArrowedPolyline(
-		points, colour,ratio_arrowhead_size_to_globe_radius,
-		MAX_ARROWHEAD_SIZE,arrowline_width_hint));
+		points, colour, arrowhead_size_in_pixels, arrowline_width_hint));
 
 	return RenderedGeometry(rendered_geom_impl);		
 

--- a/src/view-operations/RenderedGeometryFactory.cc
+++ b/src/view-operations/RenderedGeometryFactory.cc
@@ -50,6 +50,7 @@
 #include "RenderedSquareSymbol.h"
 #include "RenderedStrainMarkerSymbol.h"
 #include "RenderedString.h"
+#include "RenderedSubductionTeethPolyline.h"
 #include "RenderedTangentialArrow.h"
 #include "RenderedTriangleSymbol.h"
 
@@ -655,6 +656,30 @@ GPlatesViewOperations::RenderedGeometryFactory::create_rendered_arrowed_polyline
 
 	return RenderedGeometry(rendered_geom_impl);		
 
+}
+
+GPlatesViewOperations::RenderedGeometry
+GPlatesViewOperations::RenderedGeometryFactory::create_rendered_subduction_teeth_polyline(
+		GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type polyline,
+		bool subduction_polarity_is_left,
+		const GPlatesGui::ColourProxy &colour,
+		float line_width_hint,
+		float teeth_spacing_to_globe_radius,
+		float teeth_width_to_globe_radius,
+		float teeth_height_to_width_ratio)
+{
+	RenderedGeometry::impl_ptr_type rendered_geom_impl(new RenderedSubductionTeethPolyline(
+		polyline,
+		subduction_polarity_is_left
+				? RenderedSubductionTeethPolyline::SubductionPolarity::LEFT
+				: RenderedSubductionTeethPolyline::SubductionPolarity::RIGHT,
+		colour,
+		line_width_hint,
+		teeth_spacing_to_globe_radius,
+		teeth_width_to_globe_radius,
+		teeth_height_to_width_ratio));
+
+	return RenderedGeometry(rendered_geom_impl);
 }
 
 GPlatesViewOperations::RenderedGeometry

--- a/src/view-operations/RenderedGeometryFactory.h
+++ b/src/view-operations/RenderedGeometryFactory.h
@@ -116,9 +116,15 @@ namespace GPlatesViewOperations
 		const float DEFAULT_RATIO_ARROWHEAD_SIZE_TO_GLOBE_RADIUS = 0.03f;
 
 		/**
+		 * Determines the default size of an arrowhead (in device-independent pixels).
+		 * This is a view-dependent scalar.
+		 */
+		const float DEFAULT_ARROWHEAD_SIZE_IN_PIXELS = 8.0f;
+
+		/**
 		 * Determines the default ratio of the width of an arrowline relative to the size of its arrowhead.
 		 *
-		 * The size of an arrowhead is actually is length (along the arrowline), not its width -
+		 * The size of an arrowhead is actually its length (along the arrowline), not its width -
 		 * the arrowhead width to arrowhead length ratio is fixed in the rendering engine in order
 		 * to give the arrowhead a nice shape.
 		 */
@@ -459,7 +465,7 @@ namespace GPlatesViewOperations
 		create_rendered_arrowed_polyline(
 				GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type,
 				const GPlatesGui::ColourProxy &colour = DEFAULT_COLOUR,
-				const float ratio_arrowhead_size_to_globe_radius = DEFAULT_RATIO_ARROWHEAD_SIZE_TO_GLOBE_RADIUS,
+				const float arrowhead_size_in_pixels = DEFAULT_ARROWHEAD_SIZE_IN_PIXELS,
 				const float arrowline_width_hint = DEFAULT_LINE_WIDTH_HINT);
 
 		/**

--- a/src/view-operations/RenderedGeometryFactory.h
+++ b/src/view-operations/RenderedGeometryFactory.h
@@ -385,6 +385,15 @@ namespace GPlatesViewOperations
 				RenderedGeometry rendered_geom);
 
 		/**
+		 * Creates a composite @a RenderedGeometry containing another @a RenderedGeometry
+		 * and multiple @a ReconstructionGeometry objects associated with it.
+		 */
+		RenderedGeometry
+		create_rendered_multi_reconstruction_geometry(
+				const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type> &reconstruction_geoms,
+				RenderedGeometry rendered_geom);
+
+		/**
 		 * Creates a @a RenderedGeometry for text.
 		 */
 		RenderedGeometry

--- a/src/view-operations/RenderedGeometryFactory.h
+++ b/src/view-operations/RenderedGeometryFactory.h
@@ -125,6 +125,23 @@ namespace GPlatesViewOperations
 		const float DEFAULT_RATIO_ARROWLINE_WIDTH_TO_ARROWHEAD_SIZE = 0.2f;
 
 		/**
+		 * Determines the default width of a subduction tooth relative to the globe radius when the globe fills the viewport window.
+		 * This is a view-dependent scalar.
+		 */
+		const float DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS = 0.04f;
+
+		/**
+		 * Determines the default spacing between subduction teeth relative to the globe radius when the globe fills the viewport window.
+		 * This is a view-dependent scalar.
+		 */
+		const float DEFAULT_SUBDUCTION_TEETH_SPACING_TO_GLOBE_RADIUS = 2 * DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS;
+
+		/**
+		 * Determines the default height-to-width radio of a subduction tooth .
+		 */
+		const float DEFAULT_SUBDUCTION_TEETH_HEIGHT_TO_WIDTH_RATIO = 2.0f / 3.0f;
+
+		/**
 		 * Determines the size of symbol rendered geometries.
 		 */
 		const unsigned int DEFAULT_SYMBOL_SIZE = 1;
@@ -445,6 +462,21 @@ namespace GPlatesViewOperations
 				const GPlatesGui::ColourProxy &colour = DEFAULT_COLOUR,
 				const float ratio_arrowhead_size_to_globe_radius = DEFAULT_RATIO_ARROWHEAD_SIZE_TO_GLOBE_RADIUS,
 				const float arrowline_width_hint = DEFAULT_LINE_WIDTH_HINT);
+
+		/**
+		 * Creates a @a RenderedGeometry for a @a PolylineOnSphere that has subduction teeth.
+		 *
+		 * If @a subduction_polarity_is_left is true then the overriding plate is on the left (otherwise on the right).
+		 */
+		RenderedGeometry
+		create_rendered_subduction_teeth_polyline(
+				GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type polyline,
+				bool subduction_polarity_is_left,
+				const GPlatesGui::ColourProxy &colour = DEFAULT_COLOUR,
+				float line_width_hint = DEFAULT_LINE_WIDTH_HINT,
+				float teeth_spacing_to_globe_radius = DEFAULT_SUBDUCTION_TEETH_SPACING_TO_GLOBE_RADIUS,
+				float teeth_width_to_globe_radius = DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS,
+				float teeth_height_to_width_ratio = DEFAULT_SUBDUCTION_TEETH_HEIGHT_TO_WIDTH_RATIO);
 
 
 		/**

--- a/src/view-operations/RenderedGeometryFactory.h
+++ b/src/view-operations/RenderedGeometryFactory.h
@@ -125,19 +125,18 @@ namespace GPlatesViewOperations
 		const float DEFAULT_RATIO_ARROWLINE_WIDTH_TO_ARROWHEAD_SIZE = 0.2f;
 
 		/**
-		 * Determines the default width of a subduction tooth relative to the globe radius when the globe fills the viewport window.
+		 * Determines the default width of a subduction tooth (in device-independent pixels).
 		 * This is a view-dependent scalar.
 		 */
-		const float DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS = 0.04f;
+		const float DEFAULT_SUBDUCTION_TEETH_WIDTH_IN_PIXELS = 8.0f;
 
 		/**
-		 * Determines the default spacing between subduction teeth relative to the globe radius when the globe fills the viewport window.
-		 * This is a view-dependent scalar.
+		 * Determines the default spacing-to-width ratio of subduction teeth.
 		 */
-		const float DEFAULT_SUBDUCTION_TEETH_SPACING_TO_GLOBE_RADIUS = 2 * DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS;
+		const float DEFAULT_SUBDUCTION_TEETH_SPACING_TO_WIDTH_RATIO = 2.0;
 
 		/**
-		 * Determines the default height-to-width radio of a subduction tooth .
+		 * Determines the default height-to-width ratio of a subduction tooth .
 		 */
 		const float DEFAULT_SUBDUCTION_TEETH_HEIGHT_TO_WIDTH_RATIO = 2.0f / 3.0f;
 
@@ -474,8 +473,8 @@ namespace GPlatesViewOperations
 				bool subduction_polarity_is_left,
 				const GPlatesGui::ColourProxy &colour = DEFAULT_COLOUR,
 				float line_width_hint = DEFAULT_LINE_WIDTH_HINT,
-				float teeth_spacing_to_globe_radius = DEFAULT_SUBDUCTION_TEETH_SPACING_TO_GLOBE_RADIUS,
-				float teeth_width_to_globe_radius = DEFAULT_SUBDUCTION_TEETH_WIDTH_TO_GLOBE_RADIUS,
+				float teeth_width_in_pixels = DEFAULT_SUBDUCTION_TEETH_WIDTH_IN_PIXELS,
+				float teeth_spacing_to_width_ratio = DEFAULT_SUBDUCTION_TEETH_SPACING_TO_WIDTH_RATIO,
 				float teeth_height_to_width_ratio = DEFAULT_SUBDUCTION_TEETH_HEIGHT_TO_WIDTH_RATIO);
 
 

--- a/src/view-operations/RenderedGeometryParameters.h
+++ b/src/view-operations/RenderedGeometryParameters.h
@@ -53,6 +53,7 @@ namespace GPlatesViewOperations
 		RenderedGeometryParameters() :
 			d_reconstruction_layer_point_size_hint(4.0f),
 			d_reconstruction_layer_line_width_hint(1.5f),
+			d_reconstruction_layer_topology_size_multiplier(1.0f),
 			d_reconstruction_layer_ratio_arrow_unit_vector_direction_to_globe_radius(0.05f),
 			d_reconstruction_layer_ratio_arrowhead_size_to_globe_radius(
 					RenderedGeometryFactory::DEFAULT_RATIO_ARROWHEAD_SIZE_TO_GLOBE_RADIUS),
@@ -67,7 +68,6 @@ namespace GPlatesViewOperations
 			d_topology_tool_topological_sections_colour(GPlatesGui::Colour(0.05f, 0.05f, 0.05f, 1.0f)), // dark grey
 			d_topology_tool_topological_sections_point_size_hint(4.0f),
 			d_topology_tool_topological_sections_line_width_hint(2.5f)
-
 		{  }
 
 
@@ -99,6 +99,21 @@ namespace GPlatesViewOperations
 				float reconstruction_layer_line_width_hint)
 		{
 			d_reconstruction_layer_line_width_hint = reconstruction_layer_line_width_hint;
+			Q_EMIT parameters_changed(*this);
+		}
+
+		//! Line width for topologies in reconstruction layer.
+		float
+		get_reconstruction_layer_topology_size_multiplier() const
+		{
+			return d_reconstruction_layer_topology_size_multiplier;
+		}
+
+		void
+		set_reconstruction_layer_topology_size_multiplier(
+				float reconstruction_layer_topology_size_multiplier)
+		{
+			d_reconstruction_layer_topology_size_multiplier = reconstruction_layer_topology_size_multiplier;
 			Q_EMIT parameters_changed(*this);
 		}
 
@@ -333,6 +348,7 @@ namespace GPlatesViewOperations
 
 		float d_reconstruction_layer_point_size_hint;
 		float d_reconstruction_layer_line_width_hint;
+		float d_reconstruction_layer_topology_size_multiplier;
 		float d_reconstruction_layer_ratio_arrow_unit_vector_direction_to_globe_radius;
 		float d_reconstruction_layer_ratio_arrowhead_size_to_globe_radius;
 		float d_reconstruction_layer_arrow_spacing;

--- a/src/view-operations/RenderedGeometryUtils.cc
+++ b/src/view-operations/RenderedGeometryUtils.cc
@@ -35,6 +35,7 @@
 
 #include "RenderedGeometryUtils.h"
 
+#include "RenderedMultiReconstructionGeometry.h"
 #include "RenderedReconstructionGeometry.h"
 #include "RenderedGeometryVisitor.h"
 
@@ -107,7 +108,6 @@ namespace GPlatesViewOperations
 									boost::ref(*this)));
 				}
 
-
 				virtual
 				void
 				visit_rendered_reconstruction_geometry(
@@ -117,6 +117,16 @@ namespace GPlatesViewOperations
 							rendered_recon_geom.get_reconstruction_geometry());
 				}
 
+				virtual
+				void
+				visit_rendered_multi_reconstruction_geometry(
+						const RenderedMultiReconstructionGeometry &rendered_multi_recon_geom)
+				{
+					d_reconstruction_geom_seq.insert(
+							d_reconstruction_geom_seq.end(),
+							rendered_multi_recon_geom.get_reconstruction_geometries().begin(),
+							rendered_multi_recon_geom.get_reconstruction_geometries().end());
+				}
 
 			private:
 				reconstruction_geom_seq_type &d_reconstruction_geom_seq;

--- a/src/view-operations/RenderedGeometryUtils.h
+++ b/src/view-operations/RenderedGeometryUtils.h
@@ -114,8 +114,8 @@ namespace GPlatesViewOperations
 				reconstruction_geom_seq_type;
 
 		/**
-		 * Collects any @a ReconstructionGeometry objects contained in
-		 * @a RenderedReconstructionGeometry objects in the specified main layer.
+		 * Collects any @a ReconstructionGeometry objects contained in @a RenderedReconstructionGeometry
+		 * and @a RenderedMultiReconstructionGeometry objects in the specified main layer.
 		 * Returns true if any found.
 		 *
 		 * NOTE: Before returning, any duplicate @a ReconstructionGeometry objects are removed
@@ -133,8 +133,8 @@ namespace GPlatesViewOperations
 				bool only_if_main_layer_active = true);
 
 		/**
-		 * Collects any @a ReconstructionGeometry objects contained in
-		 * @a RenderedReconstructionGeometry objects in the specified main layers.
+		 * Collects any @a ReconstructionGeometry objects contained in @a RenderedReconstructionGeometry
+		 * and @a RenderedMultiReconstructionGeometry objects in the specified main layers.
 		 * Returns true if any found.
 		 *
 		 * NOTE: Before returning, any duplicate @a ReconstructionGeometry objects are removed
@@ -155,8 +155,7 @@ namespace GPlatesViewOperations
 
 
 		/**
-		 * Collects any @a ReconstructionGeometry objects contained in
-		 * the results of a proximity test.
+		 * Collects any @a ReconstructionGeometry objects contained in the results of a proximity test.
 		 * Returns true if any found.
 		 *
 		 * NOTE: Before returning, any duplicate @a ReconstructionGeometry objects are removed

--- a/src/view-operations/RenderedGeometryVisitor.h
+++ b/src/view-operations/RenderedGeometryVisitor.h
@@ -40,6 +40,7 @@ namespace GPlatesViewOperations
 	class RenderedCrossSymbol;
 	class RenderedEllipse;
 	class RenderedMultiPointOnSphere;
+	class RenderedMultiReconstructionGeometry;
 	class RenderedPointOnSphere;
 	class RenderedPolygonOnSphere;
 	class RenderedPolylineOnSphere;
@@ -162,6 +163,17 @@ namespace GPlatesViewOperations
 		void
 		visit_rendered_reconstruction_geometry(
 				const RenderedReconstructionGeometry &)
+		{  }
+
+		/**
+		 * This rendered geometry is a composite object as opposed to the others.
+		 *
+		 * It wraps/associates multiple @a GPlatesAppLogic::ReconstructionGeometry objects with a single rendered geometry.
+		 */
+		virtual
+		void
+		visit_rendered_multi_reconstruction_geometry(
+				const RenderedMultiReconstructionGeometry &)
 		{  }
 
 		virtual

--- a/src/view-operations/RenderedGeometryVisitor.h
+++ b/src/view-operations/RenderedGeometryVisitor.h
@@ -49,10 +49,11 @@ namespace GPlatesViewOperations
 	class RenderedResolvedRaster;
 	class RenderedResolvedScalarField3D;
 	class RenderedSmallCircle;
-	class RenderedSmallCircleArc;	
+	class RenderedSmallCircleArc;
 	class RenderedSquareSymbol;
 	class RenderedStrainMarkerSymbol;
 	class RenderedString;
+	class RenderedSubductionTeethPolyline;
 	class RenderedTangentialArrow;
 	class RenderedTriangleSymbol;
 
@@ -216,6 +217,12 @@ namespace GPlatesViewOperations
 		void
 		visit_rendered_string(
 				const RenderedString &)
+		{  }
+
+		virtual
+		void
+		visit_rendered_subduction_teeth_polyline(
+				const RenderedSubductionTeethPolyline &)
 		{  }
 
 		/**

--- a/src/view-operations/RenderedMultiReconstructionGeometry.h
+++ b/src/view-operations/RenderedMultiReconstructionGeometry.h
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef GPLATES_VIEWOPERATIONS_RENDEREDMULTIRECONSTRUCTIONGEOMETRY_H
+#define GPLATES_VIEWOPERATIONS_RENDEREDMULTIRECONSTRUCTIONGEOMETRY_H
+
+#include <vector>
+
+#include "RenderedGeometry.h"
+#include "RenderedGeometryImpl.h"
+#include "RenderedGeometryVisitor.h"
+
+#include "app-logic/ReconstructionGeometry.h"
+
+
+namespace GPlatesViewOperations
+{
+	class RenderedMultiReconstructionGeometry :
+		public RenderedGeometryImpl
+	{
+	public:
+		RenderedMultiReconstructionGeometry(
+				const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type> &reconstruction_geoms,
+				RenderedGeometry rendered_geom) :
+		d_reconstruction_geoms(reconstruction_geoms),
+		d_rendered_geom(rendered_geom)
+		{  }
+
+		virtual
+		void
+		accept_visitor(
+				ConstRenderedGeometryVisitor& visitor)
+		{
+			visitor.visit_rendered_multi_reconstruction_geometry(*this);
+
+			// Also visit our internal rendered geometry.
+			d_rendered_geom.accept_visitor(visitor);
+		}
+
+		virtual
+		GPlatesMaths::ProximityHitDetail::maybe_null_ptr_type
+		test_proximity(
+				const GPlatesMaths::ProximityCriteria &criteria) const
+		{
+			return d_rendered_geom.test_proximity(criteria);
+		}
+
+		virtual
+		GPlatesMaths::ProximityHitDetail::maybe_null_ptr_type
+		test_vertex_proximity(
+			const GPlatesMaths::ProximityCriteria &criteria) const
+		{
+			return d_rendered_geom.test_vertex_proximity(criteria);
+		}
+
+		const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type> &
+		get_reconstruction_geometries() const
+		{
+			return d_reconstruction_geoms;
+		}
+
+	private:
+		std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_to_const_type> d_reconstruction_geoms;
+		RenderedGeometry d_rendered_geom;
+	};
+}
+
+#endif // GPLATES_VIEWOPERATIONS_RENDEREDMULTIRECONSTRUCTIONGEOMETRY_H

--- a/src/view-operations/RenderedSubductionTeethPolyline.h
+++ b/src/view-operations/RenderedSubductionTeethPolyline.h
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef GPLATES_VIEWOPERATIONS_RENDERED_SUBDUCTION_TEETH_POLYLINE_H
+#define GPLATES_VIEWOPERATIONS_RENDERED_SUBDUCTION_TEETH_POLYLINE_H
+
+#include "RenderedGeometryImpl.h"
+#include "RenderedGeometryVisitor.h"
+
+#include "maths/PolylineOnSphere.h"
+
+#include "gui/ColourProxy.h"
+
+
+namespace GPlatesViewOperations
+{
+	/**
+	 * A polyline with subduction teeth.
+	 */
+	class RenderedSubductionTeethPolyline :
+		public RenderedGeometryImpl
+	{
+	public:
+
+		enum class SubductionPolarity { LEFT, RIGHT };
+
+		RenderedSubductionTeethPolyline(
+				GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type polyline_on_sphere,
+				SubductionPolarity subduction_polarity,
+				const GPlatesGui::ColourProxy &colour,
+				float line_width_hint,
+				float projected_teeth_spacing,
+				float projected_teeth_width,
+				float teeth_height_to_width_ratio) :
+		d_polyline_on_sphere(polyline_on_sphere),
+		d_subduction_polarity(subduction_polarity),
+		d_colour(colour),
+		d_line_width_hint(line_width_hint),
+		d_projected_teeth_spacing(projected_teeth_spacing),
+		d_projected_teeth_width(projected_teeth_width),
+		d_teeth_height_to_width_ratio(teeth_height_to_width_ratio)
+		{  }
+
+		virtual
+		void
+		accept_visitor(
+				ConstRenderedGeometryVisitor &visitor)
+		{
+			visitor.visit_rendered_subduction_teeth_polyline(*this);
+		}
+
+		virtual
+		GPlatesMaths::ProximityHitDetail::maybe_null_ptr_type
+		test_proximity(
+				const GPlatesMaths::ProximityCriteria &criteria) const
+		{
+			return d_polyline_on_sphere->test_proximity(criteria);
+		}
+
+		virtual
+		GPlatesMaths::ProximityHitDetail::maybe_null_ptr_type
+		test_vertex_proximity(
+			const GPlatesMaths::ProximityCriteria &criteria) const
+		{
+			return d_polyline_on_sphere->test_vertex_proximity(criteria);
+		}
+
+		GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type
+		get_polyline_on_sphere() const
+		{
+			return d_polyline_on_sphere;
+		}
+
+		SubductionPolarity
+		get_subduction_polarity() const
+		{
+			return d_subduction_polarity;
+		}
+
+		const GPlatesGui::ColourProxy &
+		get_colour() const
+		{
+			return d_colour;
+		}
+
+		float
+		get_line_width_hint() const
+		{
+			return d_line_width_hint;
+		}
+
+		float
+		get_projected_teeth_spacing() const
+		{
+			return d_projected_teeth_spacing;
+		}
+
+		float
+		get_projected_teeth_width() const
+		{
+			return d_projected_teeth_width;
+		}
+
+		float
+		get_teeth_height_to_width_ratio() const
+		{
+			return d_teeth_height_to_width_ratio;
+		}
+
+	private:
+		GPlatesMaths::PolylineOnSphere::non_null_ptr_to_const_type d_polyline_on_sphere;
+		SubductionPolarity d_subduction_polarity;
+		GPlatesGui::ColourProxy d_colour;
+		float d_line_width_hint;
+		float d_projected_teeth_spacing;
+		float d_projected_teeth_width;
+		float d_teeth_height_to_width_ratio;
+	};
+}
+
+#endif // GPLATES_VIEWOPERATIONS_RENDERED_SUBDUCTION_TEETH_POLYLINE_H

--- a/src/view-operations/RenderedSubductionTeethPolyline.h
+++ b/src/view-operations/RenderedSubductionTeethPolyline.h
@@ -45,15 +45,15 @@ namespace GPlatesViewOperations
 				SubductionPolarity subduction_polarity,
 				const GPlatesGui::ColourProxy &colour,
 				float line_width_hint,
-				float projected_teeth_spacing,
-				float projected_teeth_width,
+				float teeth_width_in_pixels,
+				float teeth_spacing_to_width_ratio,
 				float teeth_height_to_width_ratio) :
 		d_polyline_on_sphere(polyline_on_sphere),
 		d_subduction_polarity(subduction_polarity),
 		d_colour(colour),
 		d_line_width_hint(line_width_hint),
-		d_projected_teeth_spacing(projected_teeth_spacing),
-		d_projected_teeth_width(projected_teeth_width),
+		d_teeth_spacing_to_width_ratio(teeth_spacing_to_width_ratio),
+		d_teeth_width_in_pixels(teeth_width_in_pixels),
 		d_teeth_height_to_width_ratio(teeth_height_to_width_ratio)
 		{  }
 
@@ -99,22 +99,24 @@ namespace GPlatesViewOperations
 			return d_colour;
 		}
 
+		//! The line width (in device-independent pixels).
 		float
 		get_line_width_hint() const
 		{
 			return d_line_width_hint;
 		}
 
+		//! The width of a tooth (in device-independent pixels).
 		float
-		get_projected_teeth_spacing() const
+		get_teeth_width_in_pixels() const
 		{
-			return d_projected_teeth_spacing;
+			return d_teeth_width_in_pixels;
 		}
 
 		float
-		get_projected_teeth_width() const
+		get_teeth_spacing_to_width_ratio() const
 		{
-			return d_projected_teeth_width;
+			return d_teeth_spacing_to_width_ratio;
 		}
 
 		float
@@ -128,8 +130,8 @@ namespace GPlatesViewOperations
 		SubductionPolarity d_subduction_polarity;
 		GPlatesGui::ColourProxy d_colour;
 		float d_line_width_hint;
-		float d_projected_teeth_spacing;
-		float d_projected_teeth_width;
+		float d_teeth_width_in_pixels;
+		float d_teeth_spacing_to_width_ratio;
 		float d_teeth_height_to_width_ratio;
 	};
 }

--- a/src/view-operations/RenderedSubductionTeethPolyline.h
+++ b/src/view-operations/RenderedSubductionTeethPolyline.h
@@ -52,8 +52,8 @@ namespace GPlatesViewOperations
 		d_subduction_polarity(subduction_polarity),
 		d_colour(colour),
 		d_line_width_hint(line_width_hint),
-		d_teeth_spacing_to_width_ratio(teeth_spacing_to_width_ratio),
 		d_teeth_width_in_pixels(teeth_width_in_pixels),
+		d_teeth_spacing_to_width_ratio(teeth_spacing_to_width_ratio),
 		d_teeth_height_to_width_ratio(teeth_height_to_width_ratio)
 		{  }
 


### PR DESCRIPTION
- Subduction zones have teeth in 3D globe and 2D map views.
- Topological boundaries coloured by individual boundary *line segments*.
  - Instead of each boundary *polygon* having its own colour.
  - Eg,  subduction zones coloured differently than mid-ocean ridges.
- Topology line width multiplier (under “Tools > Configure Geometry Rendering”).
  - So topologies can be thicker than non-topologies.
- Keyboard shortcuts for show/hide geometry types (see “View > Geometry Visibility”).