### PR TITLE
Support os.PathLike filenames in pyGPlates

### DIFF
--- a/cmake/modules/Version.cmake
+++ b/cmake/modules/Version.cmake
@@ -143,7 +143,7 @@ set_prerelease_version(
 # The pyGPlates version (MAJOR.MINOR.PATCH).
 #
 set(PYGPLATES_VERSION_MAJOR 0)
-set(PYGPLATES_VERSION_MINOR 43)
+set(PYGPLATES_VERSION_MINOR 44)
 set(PYGPLATES_VERSION_PATCH 0)
 
 # The pyGPlates version without the pre-release suffix

--- a/pygplates/test/test_app_logic/test.py
+++ b/pygplates/test/test_app_logic/test.py
@@ -4,6 +4,7 @@ Unit tests for the pygplates application logic API.
 
 import math
 import os
+import sys
 import pickle
 import shutil
 import unittest
@@ -45,6 +46,13 @@ class CrossoverTestCase(unittest.TestCase):
     def test_find_crossovers(self):
         crossovers = pygplates.find_crossovers(os.path.join(FIXTURES, 'rotations.rot'))
         self.assertTrue(len(crossovers) == 133)
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            crossovers = pygplates.find_crossovers(FIXTURES / Path('rotations.rot'))
+            self.assertTrue(len(crossovers) == 133)
         
         # TODO: Add more tests.
 
@@ -64,6 +72,26 @@ class CrossoverTestCase(unittest.TestCase):
                 crossover_results)
         # Due to filtering of crossover times less than 600Ma we have 123 instead of 134 crossovers.
         self.assertTrue(len(crossover_results) == 123)
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            import shutil
+            # Copy 'rotations.rot' to 'tmp.rot'.
+            tmp_rot_filename = FIXTURES / Path('tmp.rot')
+            shutil.copyfile(FIXTURES / Path('rotations.rot'), tmp_rot_filename)
+            # Modify 'tmp.rot' in place.
+            crossover_results = []
+            pygplates.synchronise_crossovers(
+                    tmp_rot_filename,
+                    lambda crossover: crossover.time < 600,
+                    0.01, # 2 decimal places
+                    pygplates.CrossoverType.synch_old_crossover_and_stages,
+                    crossover_results)
+            os.remove(tmp_rot_filename)  # remove 'tmp.rot'
+            # Due to filtering of crossover times less than 600Ma we have 123 instead of 134 crossovers.
+            self.assertTrue(len(crossover_results) == 123)
         
         # TODO: Add more tests.
 
@@ -139,6 +167,23 @@ class ReconstructTestCase(unittest.TestCase):
         
         self.assertTrue(os.path.isfile(os.path.join(FIXTURES, 'test.xy')))
         os.remove(os.path.join(FIXTURES, 'test.xy'))
+        self.assertFalse(os.path.isfile(os.path.join(FIXTURES, 'test.xy')))
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            output_path = FIXTURES / Path('test.xy')
+            pygplates.reconstruct(
+                FIXTURES / Path('volcanoes.gpml'),
+                FIXTURES / Path('rotations.rot'),
+                output_path,
+                pygplates.GeoTimeInstant(10))
+            
+            self.assertTrue(output_path.exists())
+            output_path.unlink()
+            self.assertFalse(output_path.exists())
         
         feature_collection = pygplates.FeatureCollectionFileFormatRegistry().read(
                 os.path.join(FIXTURES, 'volcanoes.gpml'))
@@ -1050,6 +1095,43 @@ class PlatePartitionerTestCase(unittest.TestCase):
         self.assertTrue(
                 plate_partitioner.partition_point(pygplates.PointOnSphere(0, -60)).get_feature().get_feature_id().get_string() ==
                 'GPlates-4fe56a89-d041-4494-ab07-3abead642b8e')
+    
+    def test_pathlike(self):
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+
+            # Test first PlatePartitioner.__init__ overload.
+            rotation_model = pygplates.RotationModel(self.rotation_features)
+            resolved_topologies = []
+            pygplates.resolve_topologies(self.topological_features, rotation_model, resolved_topologies, 0)
+            plate_partitioner = pygplates.PlatePartitioner(resolved_topologies, FIXTURES / Path('rotations.rot'))
+            self.assertTrue(plate_partitioner.partition_geometry(pygplates.PointOnSphere(0, -30)))
+
+            # Test second PlatePartitioner.__init__ overload.
+            plate_partitioner = pygplates.PlatePartitioner(FIXTURES / Path('topologies.gpml'), FIXTURES / Path('rotations.rot'))
+            self.assertTrue(plate_partitioner.partition_geometry(pygplates.PointOnSphere(0, -30)))
+
+            # Temporary file containing features to partition.
+            tmp_features_filename = FIXTURES / Path('tmp_features.gpml')
+            point_feature = pygplates.Feature()
+            point_feature.set_geometry(pygplates.PointOnSphere(0, -30))
+            pygplates.FeatureCollection(point_feature).write(tmp_features_filename)
+
+            # Test PlatePartitioner.partition_features().
+            partitioned_features = plate_partitioner.partition_features(tmp_features_filename)
+            self.assertTrue(len(partitioned_features) == 1)
+
+            # Test partition_into_plates().
+            partitioned_features = pygplates.partition_into_plates(
+                    FIXTURES / Path('topologies.gpml'),
+                    FIXTURES / Path('rotations.rot'),
+                    tmp_features_filename)
+            self.assertTrue(len(partitioned_features) == 1)
+
+            tmp_features_filename.unlink()
 
 
 class ResolvedTopologiesTestCase(unittest.TestCase):
@@ -1065,6 +1147,25 @@ class ResolvedTopologiesTestCase(unittest.TestCase):
         os.remove(os.path.join(FIXTURES, 'resolved_topologies.gmt'))
         self.assertTrue(os.path.isfile(os.path.join(FIXTURES, 'resolved_topological_sections.gmt')))
         os.remove(os.path.join(FIXTURES, 'resolved_topological_sections.gmt'))
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            resolved_topologies_output_path = FIXTURES / Path('resolved_topologies.gmt')
+            resolved_topological_sections_output_path = FIXTURES / Path('resolved_topological_sections.gmt')
+            pygplates.resolve_topologies(
+                FIXTURES / Path('topologies.gpml'),
+                FIXTURES / Path('rotations.rot'),
+                resolved_topologies_output_path,
+                pygplates.GeoTimeInstant(10),
+                resolved_topological_sections_output_path)
+            
+            self.assertTrue(resolved_topologies_output_path.exists())
+            resolved_topologies_output_path.unlink()
+            self.assertTrue(resolved_topological_sections_output_path.exists())
+            resolved_topological_sections_output_path.unlink()
         
         topological_features = pygplates.FeatureCollection(os.path.join(FIXTURES, 'topologies.gpml'))
         rotation_features = pygplates.FeatureCollection(os.path.join(FIXTURES, 'rotations.rot'))
@@ -1902,6 +2003,13 @@ class RotationModelCase(unittest.TestCase):
         # deprecated (not documented) overload accepting 'clone_rotation_features'.
         rotation_model_extended = pygplates.RotationModel(self.rotations, 100, True)
         self.assertTrue(rotation_model_extended.get_rotation(1000.0, 801, anchor_plate_id=802, use_identity_for_missing_plate_ids=False))
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            rotation_model_from_path = pygplates.RotationModel(FIXTURES / Path('rotations.rot'))
+            self.assertTrue(rotation_model_from_path.get_rotation(0.0, 801, use_identity_for_missing_plate_ids=False))
     
     def test_get_reconstruction_tree(self):
         to_reconstruction_tree = self.rotation_model.get_reconstruction_tree(self.to_time)
@@ -2044,6 +2152,15 @@ class TopologicalModelCase(unittest.TestCase):
                 self.rotation_model)
         # Make sure can specify a topological snapshot cache size.
         topological_model = pygplates.TopologicalModel(self.topologies, self.rotation_model, topological_snapshot_cache_size=2)
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            topological_model = pygplates.TopologicalModel(
+                FIXTURES / Path('topologies.gpml'),
+                FIXTURES / Path('rotations.rot'))
 
     def test_get_topological_snapshot(self):
         topological_snapshot = self.topological_model.topological_snapshot(10.5)  # note: it should allow a non-integral time
@@ -2358,6 +2475,19 @@ class TopologicalSnapshotCase(unittest.TestCase):
             rotations,
             pygplates.GeoTimeInstant(10))
 
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            snapshot = pygplates.TopologicalSnapshot(
+                FIXTURES / Path('topologies.gpml'),
+                FIXTURES / Path('rotations.rot'),
+                pygplates.GeoTimeInstant(10))
+            
+            self.assertTrue(snapshot.get_anchor_plate_id() == 0)
+            self.assertTrue(snapshot.get_rotation_model())
+
     def test_resolved_export_files(self):
         resolve_features = pygplates.FeatureCollection(os.path.join(FIXTURES, 'topologies.gpml')) 
         rotation_model = pygplates.RotationModel(os.path.join(FIXTURES, 'rotations.rot'))
@@ -2438,6 +2568,21 @@ class TopologicalSnapshotCase(unittest.TestCase):
         _internal_test_export_files(self, snapshot, 'tmp.gmt', 'tmp_sections.gmt')  # OGRGMT
         _internal_test_export_files(self, snapshot, 'tmp.geojson', 'tmp_sections.geojson')  # GeoJSON
         _internal_test_export_files(self, snapshot, 'tmp.json', 'tmp_sections.json')  # GeoJSON
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            tmp_export_resolved_topologies_filename = FIXTURES / Path('tmp_export_resolved_topologies.gmt')
+            snapshot.export_resolved_topologies(tmp_export_resolved_topologies_filename)
+            self.assertTrue(tmp_export_resolved_topologies_filename.exists())
+            tmp_export_resolved_topologies_filename.unlink()
+            
+            tmp_export_resolved_topological_sections_filename = FIXTURES / Path('tmp_export_resolved_topological_sections.gmt')
+            snapshot.export_resolved_topological_sections(tmp_export_resolved_topological_sections_filename)
+            self.assertTrue(tmp_export_resolved_topological_sections_filename.exists())
+            tmp_export_resolved_topological_sections_filename.unlink()
     
     def test_pickle(self):
         snapshot = pygplates.TopologicalSnapshot(

--- a/pygplates/test/test_model/test.py
+++ b/pygplates/test/test_model/test.py
@@ -3,6 +3,7 @@ Unit tests for the pygplates model API.
 """
 
 import os
+import sys
 import pickle
 import unittest
 import pygplates
@@ -606,6 +607,33 @@ class FeatureCollectionCase(unittest.TestCase):
         _internal_test_read_write(self, feature_collection, 'tmp.json')  # GeoJSON
         _internal_test_read_write(self, feature_collection, 'tmp.gpkg')  # GeoPackage
 
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            # Test anything that is PathLike.
+            class PathLike(object):
+                def __init__(self, path):
+                    self.path = path
+                def __fspath__(self):
+                    return str(self.path)
+            
+            feature_collection = pygplates.FeatureCollection(self.volcanoes_filename)
+            tmp_filename = 'tmp.gpml'
+
+            # Test write and then read of PathLike.
+            feature_collection.write(PathLike(tmp_filename))
+            self.assertTrue(os.path.isfile(tmp_filename))
+            feature_collection_from_pathlike = pygplates.FeatureCollection.read(PathLike(tmp_filename))
+            self.assertTrue(len(feature_collection_from_pathlike) == self.feature_count)
+            os.remove(tmp_filename)
+            # Test write and then read of pathlib.Path.
+            from pathlib import Path  # pathlib new in Python 3.4
+            feature_collection.write(Path(tmp_filename))
+            self.assertTrue(os.path.isfile(tmp_filename))
+            feature_collection_from_path = pygplates.FeatureCollection.read(Path(tmp_filename))
+            self.assertTrue(len(feature_collection_from_path) == self.feature_count)
+            os.remove(tmp_filename)
+
     def test_construct(self):
         # Create new empty feature collection.
         new_feature_collection = pygplates.FeatureCollection()
@@ -623,6 +651,23 @@ class FeatureCollectionCase(unittest.TestCase):
 
         feature_collection_from_file = pygplates.FeatureCollection(self.volcanoes_filename)
         self.assertTrue(len(feature_collection_from_file) == self.feature_count)
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            # Test anything that is PathLike.
+            class PathLike(object):
+                def __init__(self, path):
+                    self.path = path
+                def __fspath__(self):
+                    return str(self.path)
+            
+            feature_collection_from_pathlike = pygplates.FeatureCollection(PathLike(self.volcanoes_filename))
+            self.assertTrue(len(feature_collection_from_pathlike) == self.feature_count)
+            # Test pathlib.Path.
+            from pathlib import Path  # pathlib new in Python 3.4
+            feature_collection_from_path = pygplates.FeatureCollection(Path(self.volcanoes_filename))
+            self.assertTrue(len(feature_collection_from_path) == self.feature_count)
 
     def test_clone(self):
         # Modify original and make sure clone is not affected.

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -36,6 +36,8 @@ set(srcs
     PyFeatureCollectionFileFormatRegistry.h
     PyFeatureCollectionFunctionArgument.cc
     PyFeatureCollectionFunctionArgument.h
+    PyFilePathFunctionArgument.cc
+    PyFilePathFunctionArgument.h
     PyFiniteRotation.cc
     PyGeometriesOnSphere.cc
     PyGeometriesOnSphere.h

--- a/src/api/PyFeatureCollection.cc
+++ b/src/api/PyFeatureCollection.cc
@@ -28,10 +28,10 @@
 #include <vector>
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include <QString>
 
 #include "PyFeatureCollectionFileFormatRegistry.h"
 #include "PyFeatureCollectionFunctionArgument.h"
+#include "PyFilePathFunctionArgument.h"
 #include "PythonConverterUtils.h"
 #include "PythonExtractUtils.h"
 #include "PythonHashDefVisitor.h"
@@ -80,7 +80,7 @@ namespace GPlatesApi
 	void
 	feature_collection_handle_write(
 			GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection,
-			const QString &filename)
+			const FilePathFunctionArgument &filename)
 	{
 		GPlatesFileIO::FeatureCollectionFileFormat::Registry registry;
 
@@ -818,7 +818,11 @@ export_feature_collection()
 					"   Can index a feature in feature collection *fc* with ``fc[i]``.\n"
 					"\n"
 					".. versionchanged:: 0.42\n"
-					"   Added pickle support.\n",
+					"   Added pickle support.\n"
+					"\n"
+					".. versionchanged:: 0.44\n"
+					"   Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+					"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n",
 					// We need this (even though "__init__" is defined) since
 					// there is no publicly-accessible default constructor...
 					bp::no_init)
@@ -831,7 +835,7 @@ export_feature_collection()
 				"  Create a new feature collection instance.\n"
 				"\n"
 				"  :param features: an optional filename, or sequence of features, or a single feature\n"
-				"  :type features: string, or a sequence (eg, ``list`` or ``tuple``) of :class:`Feature`, "
+				"  :type features: string/``os.PathLike``, or a sequence (eg, ``list`` or ``tuple``) of :class:`Feature`, "
 				"or a single :class:`Feature`\n"
 				"  :raises: OpenFileForReadingError if file is not readable (if filename specified)\n"
 				"  :raises: FileFormatNotSupportedError if file format (identified by the filename "
@@ -870,7 +874,11 @@ export_feature_collection()
 				"       # since the feature data is shared by both collections...\n"
 				"       for feature in original_feature_collection:\n"
 				"           # Changing the reconstruction plate ID affects both original and shallow copy collections.\n"
-				"           feature.set_reconstruction_plate_id(...)\n")
+				"           feature.set_reconstruction_plate_id(...)\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		// Pickle support...
 		//
 		// Note: This adds an __init__ method accepting a single argument (of type 'bytes') that supports pickling.
@@ -887,7 +895,7 @@ export_feature_collection()
 				"  [*staticmethod*] Reads one or more feature collections (from one or more files).\n"
 				"\n"
 				"  :param filename: the name of the file (or files) to read\n"
-				"  :type filename: string, or sequence of strings\n"
+				"  :type filename: string/``os.PathLike``, or sequence of string/``os.PathLike``\n"
 				"  :rtype: :class:`FeatureCollection`, list of :class:`FeatureCollection`\n"
 				"  :raises: OpenFileForReadingError if any file is not readable\n"
 				"  :raises: FileFormatNotSupportedError if any file format (identified by a filename "
@@ -906,7 +914,11 @@ export_feature_collection()
 				"  ::\n"
 				"\n"
 				"    for feature_collection in pygplates.FeatureCollection.read([filename1, filename2]):\n"
-				"        ...\n")
+				"        ...\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.staticmethod("read")
 		.def("write",
 				&GPlatesApi::feature_collection_handle_write,
@@ -915,14 +927,18 @@ export_feature_collection()
 				"  Writes this feature collection to the file with name *filename*.\n"
 				"\n"
 				"  :param filename: the name of the file to write\n"
-				"  :type filename: string\n"
+				"  :type filename: string/``os.PathLike``\n"
 				"  :raises: OpenFileForWritingError if the file is not writable\n"
 				"  :raises: FileFormatNotSupportedError if the file format (identified by the filename "
 				"extension) does not support writing\n"
 				"\n"
 				"  ::\n"
 				"\n"
-				"    feature_collection.write(filename)\n")
+				"    feature_collection.write(filename)\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.def("clone",
 				&GPlatesApi::feature_collection_handle_clone,
 				"clone()\n"

--- a/src/api/PyFeatureCollectionFileFormatRegistry.cc
+++ b/src/api/PyFeatureCollectionFileFormatRegistry.cc
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <iterator>
 #include <vector>
-#include <boost/foreach.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <QString>
@@ -52,9 +51,9 @@ namespace GPlatesApi
 	GPlatesModel::FeatureCollectionHandle::non_null_ptr_type
 	read_feature_collection(
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
-			const QString &filename)
+			const FilePathFunctionArgument &filename)
 	{
-		const GPlatesFileIO::FileInfo file_info(filename);
+		const GPlatesFileIO::FileInfo file_info(filename.get_file_path());
 
 		// Create a file with an empty feature collection.
 		GPlatesFileIO::File::non_null_ptr_type file = GPlatesFileIO::File::create_file(file_info);
@@ -72,9 +71,9 @@ namespace GPlatesApi
 	read_feature_collections(
 			std::vector<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> &feature_collections,
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
-			const std::vector<QString> &filenames)
+			const std::vector<FilePathFunctionArgument> &filenames)
 	{
-		BOOST_FOREACH(const QString &filename, filenames)
+		for (const auto &filename : filenames)
 		{
 			feature_collections.push_back(
 					read_feature_collection(registry, filename));
@@ -87,16 +86,16 @@ namespace GPlatesApi
 			bp::object filename_object)
 	{
 		// See if a single filename.
-		bp::extract<QString> extract_filename(filename_object);
+		bp::extract<FilePathFunctionArgument> extract_filename(filename_object);
 		if (extract_filename.check())
 		{
-			const QString filename = extract_filename();
+			const FilePathFunctionArgument filename = extract_filename();
 
 			return bp::object(read_feature_collection(registry, filename));
 		}
 
 		// Try a sequence of filenames next.
-		std::vector<QString> filenames;
+		std::vector<FilePathFunctionArgument> filenames;
 		PythonExtractUtils::extract_iterable(
 				filenames,
 				filename_object,
@@ -107,9 +106,7 @@ namespace GPlatesApi
 
 		bp::list feature_collections_list;
 
-		BOOST_FOREACH(
-				GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection,
-				feature_collections)
+		for (auto feature_collection : feature_collections)
 		{
 			feature_collections_list.append(feature_collection);
 		}
@@ -121,9 +118,9 @@ namespace GPlatesApi
 	write_feature_collection(
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
 			GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection,
-			const QString &filename)
+			const FilePathFunctionArgument &filename)
 	{
-		const GPlatesFileIO::FileInfo file_info(filename);
+		const GPlatesFileIO::FileInfo file_info(filename.get_file_path());
 
 		// Create an output file to write out the feature collection.
 		GPlatesFileIO::File::non_null_ptr_type file =

--- a/src/api/PyFeatureCollectionFileFormatRegistry.h
+++ b/src/api/PyFeatureCollectionFileFormatRegistry.h
@@ -27,7 +27,8 @@
 #define GPLATES_API_PYFEATURECOLLECTIONFILEFORMATREGISTRY_H
 
 #include <vector>
-#include <QString>
+
+#include "PyFilePathFunctionArgument.h"
 
 #include "file-io/FeatureCollectionFileFormatRegistry.h"
 
@@ -46,7 +47,7 @@ namespace GPlatesApi
 	GPlatesModel::FeatureCollectionHandle::non_null_ptr_type
 	read_feature_collection(
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
-			const QString &filename);
+			const FilePathFunctionArgument &filename);
 
 	/**
 	 * Read a sequence of feature collections from the specified files.
@@ -57,7 +58,7 @@ namespace GPlatesApi
 	read_feature_collections(
 			std::vector<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> &feature_collections,
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
-			const std::vector<QString> &filenames);
+			const std::vector<FilePathFunctionArgument> &filenames);
 
 	/**
 	 * Read a single filename (or a sequence of filenames) from @a filename_object and return a
@@ -77,7 +78,7 @@ namespace GPlatesApi
 	write_feature_collection(
 			const GPlatesFileIO::FeatureCollectionFileFormat::Registry &registry,
 			GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection,
-			const QString &filename);
+			const FilePathFunctionArgument &filename);
 }
 
 #endif // GPLATES_API_PYFEATURECOLLECTIONFILEFORMATREGISTRY_H

--- a/src/api/PyFeatureCollectionFunctionArgument.cc
+++ b/src/api/PyFeatureCollectionFunctionArgument.cc
@@ -53,8 +53,7 @@ namespace bp = boost::python;
 namespace GPlatesApi
 {
 	/**
-	 * A from-python converter from a feature collection or a string filename to a
-	 * @a FeatureCollectionFunctionArgument.
+	 * A from-python converter from a feature collection or a filename to a @a FeatureCollectionFunctionArgument.
 	 */
 	struct ConversionFeatureCollectionFunctionArgument :
 			private boost::noncopyable
@@ -97,7 +96,7 @@ namespace GPlatesApi
 
 
 	/**
-	 * Registers converter from a feature collection or a string filename to a @a FeatureCollectionFunctionArgument.
+	 * Registers converter from a feature collection or a filename to a @a FeatureCollectionFunctionArgument.
 	 */
 	void
 	register_conversion_feature_collection_function_argument()
@@ -117,8 +116,8 @@ namespace GPlatesApi
 
 
 	/**
-	 * A from-python converter from a feature collection or a string filename or a sequence of feature
-	 * collections and/or string filenames to a @a FeatureCollectionSequenceFunctionArgument.
+	 * A from-python converter from a feature collection or a filename or a sequence of feature
+	 * collections and/or filenames to a @a FeatureCollectionSequenceFunctionArgument.
 	 */
 	struct ConversionFeatureCollectionSequenceFunctionArgument :
 			private boost::noncopyable
@@ -161,7 +160,7 @@ namespace GPlatesApi
 
 
 	/**
-	 * Registers converter from a feature collection or a string filename to a @a FeatureCollectionSequenceFunctionArgument.
+	 * Registers converter from a feature collection or a filename to a @a FeatureCollectionSequenceFunctionArgument.
 	 */
 	void
 	register_conversion_feature_collection_sequence_function_argument()
@@ -187,7 +186,7 @@ GPlatesApi::FeatureCollectionFunctionArgument::is_convertible(
 {
 	// Test all supported types (in function_argument_type) except the bp::object (since that's a sequence).
 	if (bp::extract<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type>(python_function_argument).check() ||
-		bp::extract<QString>(python_function_argument).check() ||
+		bp::extract<FilePathFunctionArgument>(python_function_argument).check() ||
 		bp::extract<GPlatesModel::FeatureHandle::non_null_ptr_type>(python_function_argument).check())
 	{
 		return true;
@@ -227,12 +226,12 @@ GPlatesApi::FeatureCollectionFunctionArgument::initialise_feature_collection(
 		// came from a file or not.
 		return GPlatesFileIO::File::create_file(GPlatesFileIO::FileInfo(), *feature_collection_function_argument);
 	}
-	else if (const QString *filename_function_argument =
-		boost::get<QString>(&function_argument))
+	else if (const FilePathFunctionArgument *filename_function_argument =
+		boost::get<FilePathFunctionArgument>(&function_argument))
 	{
 		// Create a file with an empty feature collection.
 		GPlatesFileIO::File::non_null_ptr_type file =
-				GPlatesFileIO::File::create_file(GPlatesFileIO::FileInfo(*filename_function_argument));
+				GPlatesFileIO::File::create_file(GPlatesFileIO::FileInfo(filename_function_argument->get_file_path()));
 
 		// Read new features from the file into the feature collection.
 		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_registry;
@@ -518,7 +517,7 @@ export_feature_collection_function_argument()
 					"The currently supported source types are:\n"
 					"\n"
 					"* :class:`FeatureCollection`\n"
-					"* filename (string)\n"
+					"* filename (string/``os.PathLike``)\n"
 					"* :class:`Feature`\n"
 					"* sequence of :class:`Feature`\n"
 					"* sequence of any combination of the above four types\n"
@@ -542,7 +541,13 @@ export_feature_collection_function_argument()
 					"  my_function([feature1, feature2])\n"
 					"  my_function([feature_collection,  feature1, feature2 ])\n"
 					"  my_function([feature_collection, [feature1, feature2]])\n"
-					"  my_function(feature)\n",
+					"  my_function(feature)\n"
+					"  from pathlib import Path\n"
+					"  my_function(Path('file.gpml')\n"
+					"\n"
+					".. versionchanged:: 0.44\n"
+					"   Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+					"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n",
 					// We need this (even though "__init__" is defined) since
 					// there is no publicly-accessible default constructor...
 					bp::no_init)
@@ -557,7 +562,7 @@ export_feature_collection_function_argument()
 				"  :param function_argument: A feature collection, or filename, or feature, or "
 				"sequence of features, or a sequence (eg, ``list`` or ``tuple``) of any combination "
 				"of those four types\n"
-				"  :type function_argument: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+				"  :type function_argument: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 				"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 				"  :raises: OpenFileForReadingError if any file is not readable (when filenames specified)\n"
 				"  :raises: FileFormatNotSupportedError if any file format (identified by the filename "
@@ -580,7 +585,11 @@ export_feature_collection_function_argument()
 				"        for feature in features.get_features()\n"
 				"            ...\n"
 				"    \n"
-				"    my_function(['file1.gpml', 'file2.gpml'])\n")
+				"    my_function(['file1.gpml', 'file2.gpml'])\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.def("contains_features",
 				&GPlatesApi::FeaturesFunctionArgument::contains_features,
 				(bp::arg("function_argument")),

--- a/src/api/PyFeatureCollectionFunctionArgument.h
+++ b/src/api/PyFeatureCollectionFunctionArgument.h
@@ -31,6 +31,8 @@
 #include <boost/variant.hpp>
 #include <QString>
 
+#include "PyFilePathFunctionArgument.h"
+
 #include "file-io/File.h"
 
 #include "global/python.h"
@@ -61,7 +63,7 @@ namespace GPlatesApi
 		 */
 		typedef boost::variant<
 				GPlatesModel::FeatureCollectionHandle::non_null_ptr_type,
-				QString,
+				FilePathFunctionArgument,
 				GPlatesModel::FeatureHandle::non_null_ptr_type,
 				boost::python::object/*sequence of features*/> function_argument_type;
 

--- a/src/api/PyFilePathFunctionArgument.cc
+++ b/src/api/PyFilePathFunctionArgument.cc
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <boost/noncopyable.hpp>
+#include <QString>
+
+#include "PyFilePathFunctionArgument.h"
+
+#include "PythonConverterUtils.h"
+#include "PythonExtractUtils.h"
+
+#include "global/python.h"
+
+#include "utils/ReferenceCount.h"
+
+
+namespace bp = boost::python;
+
+
+namespace GPlatesApi
+{
+	/**
+	 * A from-python converter from a string filename or a 'os.PathLike' object to a @a FilePathFunctionArgument.
+	 */
+	struct ConversionFilePathFunctionArgument :
+			private boost::noncopyable
+	{
+		static
+		void *
+		convertible(
+				PyObject *obj)
+		{
+			namespace bp = boost::python;
+
+			if (FilePathFunctionArgument::is_convertible(
+				bp::object(bp::handle<>(bp::borrowed(obj)))))
+			{
+				return obj;
+			}
+
+			return NULL;
+		}
+
+		static
+		void
+		construct(
+				PyObject *obj,
+				boost::python::converter::rvalue_from_python_stage1_data *data)
+		{
+			namespace bp = boost::python;
+
+			void *const storage = reinterpret_cast<
+					bp::converter::rvalue_from_python_storage<
+							FilePathFunctionArgument> *>(
+									data)->storage.bytes;
+
+			new (storage) FilePathFunctionArgument(
+					bp::object(bp::handle<>(bp::borrowed(obj))));
+
+			data->convertible = storage;
+		}
+	};
+
+
+	/**
+	 * Registers converter from a string filename or a 'os.PathLike' object to a @a FilePathFunctionArgument.
+	 */
+	void
+	register_conversion_file_path_function_argument()
+	{
+		// Register function argument types variant.
+		PythonConverterUtils::register_variant_conversion<
+				FilePathFunctionArgument::function_argument_type>();
+
+		// NOTE: We don't define a to-python conversion.
+
+		// From python conversion.
+		bp::converter::registry::push_back(
+				&ConversionFilePathFunctionArgument::convertible,
+				&ConversionFilePathFunctionArgument::construct,
+				bp::type_id<FilePathFunctionArgument>());
+	}
+}
+
+
+bool
+GPlatesApi::FilePathFunctionArgument::is_convertible(
+		bp::object python_function_argument)
+{
+	// Test all supported types (in function_argument_type).
+	return bp::extract<QString>(python_function_argument).check() ||
+			// See if the argument is an 'os.PathLike' object with a '__fspath__()' method to get the path as a string
+			// (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike)...
+			PyObject_HasAttrString(python_function_argument.ptr(), "__fspath__");
+}
+
+
+GPlatesApi::FilePathFunctionArgument::FilePathFunctionArgument(
+		bp::object python_function_argument) :
+	d_file_path(
+			initialise_file_path(
+					bp::extract<function_argument_type>(python_function_argument)))
+{
+}
+
+
+GPlatesApi::FilePathFunctionArgument::FilePathFunctionArgument(
+		const function_argument_type &function_argument) :
+	d_file_path(initialise_file_path(function_argument))
+{
+}
+
+
+QString
+GPlatesApi::FilePathFunctionArgument::initialise_file_path(
+		const function_argument_type &function_argument)
+{
+	if (const QString *string_function_argument =
+		boost::get<QString>(&function_argument))
+	{
+		return *string_function_argument;
+	}
+	else
+	{
+		const bp::object function_argument_object = boost::get<bp::object>(function_argument);
+
+		// The argument is an 'os.PathLike' object, so call its '__fspath__()' method to get the path as a string
+		// (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+		bp::object fspath_object = function_argument_object.attr("__fspath__")();
+		bp::extract<QString> extract_fspath(fspath_object);
+		if (!extract_fspath.check())
+		{
+			PyErr_SetString(PyExc_TypeError, "expected __fspath__() to return str or bytes");
+			bp::throw_error_already_set();
+		}
+
+		return extract_fspath();
+	}
+}
+
+
+void
+export_file_path_function_argument()
+{
+	// Register converter from a feature collection or a string filename to a @a FilePathFunctionArgument.
+	GPlatesApi::register_conversion_file_path_function_argument();
+}

--- a/src/api/PyFilePathFunctionArgument.h
+++ b/src/api/PyFilePathFunctionArgument.h
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef GPLATES_API_PYFILEPATHARGUMENT_H
+#define GPLATES_API_PYFILEPATHARGUMENT_H
+
+#include <boost/variant.hpp>
+#include <QString>
+
+#include "global/python.h"
+
+
+namespace GPlatesApi
+{
+	/**
+	 * A convenience class for receiving a file path function argument as either:
+	 *  (1) a string, or
+	 *  (2) an os.PathLike object with a '__fspath__()' method to get the path as a string
+	 *      (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+	 *
+	 * To get an instance of @a FilePathFunctionArgument you can either:
+	 *  (1) specify FilePathFunctionArgument directly as a function argument type
+	 *      (in the C++ function being wrapped), or
+	 *  (2) use boost::python::extract<FilePathFunctionArgument>().
+	 */
+	class FilePathFunctionArgument
+	{
+	public:
+
+		/**
+		 * Types of function argument.
+		 */
+		typedef boost::variant<
+				QString,
+				boost::python::object/*os.PathLike object*/> function_argument_type;
+
+
+		/**
+		 * Returns true if @a python_function_argument is convertible to an instance of this class.
+		 */
+		static
+		bool
+		is_convertible(
+				boost::python::object python_function_argument);
+
+
+		//! Default constructor with empty file path.
+		FilePathFunctionArgument()
+		{  }
+
+		explicit
+		FilePathFunctionArgument(
+				boost::python::object python_function_argument);
+
+
+		explicit
+		FilePathFunctionArgument(
+				const function_argument_type &function_argument);
+
+		/**
+		 * Return the file path.
+		 */
+		QString
+		get_file_path() const
+		{
+			return d_file_path;
+		}
+
+	private:
+
+		static
+		QString
+		initialise_file_path(
+				const function_argument_type &function_argument);
+
+
+		QString d_file_path;
+	};
+}
+
+#endif // GPLATES_API_PYFILEPATHARGUMENT_H

--- a/src/api/PyGPlatesModule.cc
+++ b/src/api/PyGPlatesModule.cc
@@ -69,6 +69,7 @@ void export_feature_collection_file_format_registry();
 void export_feature();
 void export_feature_collection();
 void export_feature_collection_function_argument();
+void export_file_path_function_argument();
 void export_topological_feature_collection_function_argument();
 void export_geo_time_instant();
 void export_ids();
@@ -188,6 +189,7 @@ export_cpp_python_api()
 	export_feature();
 	export_feature_collection();
 	export_feature_collection_function_argument();
+	export_file_path_function_argument();
 	export_topological_feature_collection_function_argument();
 	export_old_feature(); // TODO: Remove this once transitioned to 'export_feature()'.
 	export_old_feature_collection();

--- a/src/api/PyPlatePartitioner.cc
+++ b/src/api/PyPlatePartitioner.cc
@@ -522,8 +522,8 @@ export_plate_partitioner()
 				"  :type partitioning_plates: Any sequence of :class:`ReconstructionGeometry`\n"
 				"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 				"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-				"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-				"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+				"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+				"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 				"  :param sort_partitioning_plates: optional sort order of partitioning plates "
 				"(defaults to *SortPartitioningPlates.by_partition_type_then_plate_id*)\n"
 				"  :type sort_partitioning_plates: One of the values in the *SortPartitioningPlates* table above, or None\n"
@@ -547,7 +547,11 @@ export_plate_partitioner()
 				"\n"
 				"  .. note:: *rotation_model* should be the same rotation model used to reconstruct/resolve "
 				"the partitioning plates. This enables partitioned feature geometries to be reverse-reconstructed "
-				"correctly in :meth:`partition_features` for non-zero reconstruction times.\n")
+				"correctly in :meth:`partition_features` for non-zero reconstruction times.\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		//
 		// NOTE: We define this *after* the '__init__' associated with 'plate_partitioner_create_from_reconstruction_geometries()'
 		// because boost-python matches most recently defined functions first and this function has a tighter
@@ -568,12 +572,12 @@ export_plate_partitioner()
 				"  Create a partitioner by reconstructing/resolving plates from a sequence of plate features.\n"
 				"\n"
 				"  :param partitioning_features: A sequence of plate features to partition with.\n"
-				"  :type partitioning_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+				"  :type partitioning_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 				"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 				"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 				"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-				"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-				"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+				"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+				"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 				"  :param reconstruction_time: the specific geological time to reconstruct/resolve the "
 				"*partitioning_features* to (defaults to zero)\n"
 				"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
@@ -591,7 +595,11 @@ export_plate_partitioner()
 				"  To create a plate partitioner suitable for partitioning present day geometries/features (ie, *reconstruction_time* is zero):.\n"
 				"  ::\n"
 				"    \n"
-				"    plate_partitioner = pygplates.PlatePartitioner('static_polygons.gpml', 'rotations.rot')\n")
+				"    plate_partitioner = pygplates.PlatePartitioner('static_polygons.gpml', 'rotations.rot')\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.def("partition_geometry",
 				&GPlatesApi::plate_partitioner_partition_geometry,
 				(bp::arg("geometry"),

--- a/src/api/PyReconstruct.cc
+++ b/src/api/PyReconstruct.cc
@@ -37,6 +37,7 @@
 #include <QString>
 
 #include "PyFeatureCollectionFunctionArgument.h"
+#include "PyFilePathFunctionArgument.h"
 #include "PyRotationModel.h"
 #include "PythonConverterUtils.h"
 #include "PythonUtils.h"
@@ -96,7 +97,7 @@ namespace GPlatesApi
 		 * The argument types for 'reconstructed feature geometries'.
 		 */
 		typedef boost::variant<
-				QString,  // export filename
+				FilePathFunctionArgument,  // export filename
 				bp::list> // list of ReconstructedFeatureGeometry's
 						reconstructed_feature_geometries_argument_type;
 
@@ -130,7 +131,7 @@ namespace GPlatesApi
 					RotationModelFunctionArgument,
 					double, // Note: This is not GPlatesPropertyValues::GeoTimeInstant.
 					boost::optional<GPlatesModel::integer_plate_id_type>,
-					QString> // Only export filename supported (not a python list of RFG's).
+					FilePathFunctionArgument> // Only export filename supported (not a python list of RFG's).
 							reconstruct_args_type;
 
 			// Define the explicit function argument names...
@@ -694,8 +695,10 @@ namespace GPlatesApi
 		// respective features with each feature collection (and the order across feature collections).
 		//
 
-		if (const QString *export_file_name = boost::get<QString>(&reconstructed_feature_geometries_argument))
+		if (const FilePathFunctionArgument *export_file_path = boost::get<FilePathFunctionArgument>(&reconstructed_feature_geometries_argument))
 		{
+			const QString export_file_name = export_file_path->get_file_path();
+
 			// Get the sequence of reconstructable files as File pointers.
 			std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
 			BOOST_FOREACH(GPlatesFileIO::File::non_null_ptr_type reconstructable_file, reconstructable_files)
@@ -718,7 +721,7 @@ namespace GPlatesApi
 			case ReconstructType::FEATURE_GEOMETRY:
 				export_reconstructed_feature_geometries(
 						rfgs,
-						*export_file_name,
+						export_file_name,
 						reconstructable_file_ptrs,
 						reconstruction_file_ptrs,
 						reconstruction_tree_creator.get_default_anchor_plate_id(),
@@ -729,7 +732,7 @@ namespace GPlatesApi
 			case ReconstructType::MOTION_PATH:
 				export_reconstructed_motion_paths(
 						rfgs,
-						*export_file_name,
+						export_file_name,
 						reconstructable_file_ptrs,
 						reconstruction_file_ptrs,
 						reconstruction_tree_creator.get_default_anchor_plate_id(),
@@ -740,7 +743,7 @@ namespace GPlatesApi
 			case ReconstructType::FLOWLINE:
 				export_reconstructed_flowlines(
 						rfgs,
-						*export_file_name,
+						export_file_name,
 						reconstructable_file_ptrs,
 						reconstruction_file_ptrs,
 						reconstruction_tree_creator.get_default_anchor_plate_id(),
@@ -959,12 +962,12 @@ export_reconstruct()
 			"  :param reconstructable_features: the features to reconstruct as a feature collection, or filename, or "
 			"feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) of any "
 			"combination of those four types\n"
-			"  :type reconstructable_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type reconstructable_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-			"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+			"  :type rotation_model: :class:`RotationModel`, or :class:`FeatureCollection`, or string/``os.PathLike``, "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 			"  :param reconstructed_geometries: the "
 			":class:`reconstructed feature geometries<ReconstructedFeatureGeometry>` (default) or "
 			":class:`reconstructed motion paths<ReconstructedMotionPath>` or "
@@ -973,7 +976,7 @@ export_reconstruct()
 			"file (with specified filename) or *appended* to a Python ``list`` (note that the list is *not* "
 			"cleared first and note that the list contents are affected by *group_with_feature* - see "
 			"*output_parameters* table)\n"
-			"  :type reconstructed_geometries: string or ``list``\n"
+			"  :type reconstructed_geometries: string/``os.PathLike`` or ``list``\n"
 			"  :param reconstruction_time: the specific geological time to reconstruct to\n"
 			"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
 			"  :param anchor_plate_id: The anchored plate id used during reconstruction. "
@@ -1129,7 +1132,11 @@ export_reconstruct()
 			"\n"
 			"    reconstructed_feature_geometries = []\n"
             "    pygplates.reconstruct(feature, rotation_model, reconstructed_feature_geometries, 10)\n"
-			"    # assert(reconstructed_feature_geometries[0].get_feature().get_feature_id() == feature.get_feature_id())\n";
+			"    # assert(reconstructed_feature_geometries[0].get_feature().get_feature_id() == feature.get_feature_id())\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n";
 
 	// Register 'reconstructed feature geometries' variant.
 	GPlatesApi::PythonConverterUtils::register_variant_conversion<
@@ -1148,12 +1155,12 @@ export_reconstruct()
 			"  :param reconstructable_features: A reconstructable feature collection, or filename, or "
 			"feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) of any "
 			"combination of those four types - all features used as input and output\n"
-			"  :type reconstructable_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type reconstructable_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-			"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 			"  :param reconstruction_time: the specific geological time to reverse reconstruct from "
 			"(note that this also :meth:`sets the geometry import time<Feature.set_geometry_import_time>`).\n"
 			"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
@@ -1214,5 +1221,9 @@ export_reconstruct()
             "    pygplates.reconstruct(feature, rotation_model, 10)\n"
 			"\n"
 			"  .. versionchanged:: 0.29\n"
-			"     The :meth:`geometry import time<Feature.set_geometry_import_time>` is set to *reconstruction_time*.\n");
+			"     The :meth:`geometry import time<Feature.set_geometry_import_time>` is set to *reconstruction_time*.\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n");
 }

--- a/src/api/PyResolveTopologies.cc
+++ b/src/api/PyResolveTopologies.cc
@@ -33,9 +33,9 @@
 #include <vector>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
-#include <QString>
 
 #include "PyFeatureCollectionFunctionArgument.h"
+#include "PyFilePathFunctionArgument.h"
 #include "PyRotationModel.h"
 #include "PyTopologicalSnapshot.h"
 #include "PythonConverterUtils.h"
@@ -70,7 +70,7 @@ namespace GPlatesApi
 		 */
 		typedef boost::variant<
 				// Export filename...
-				QString,
+				FilePathFunctionArgument,
 				// List of 'ResolvedTopologicalLine's, 'ResolvedTopologicalBoundary's and 'ResolvedTopologicalNetwork's...
 				bp::list>
 						resolved_topologies_argument_type;
@@ -80,7 +80,7 @@ namespace GPlatesApi
 		 */
 		typedef boost::variant<
 				// Export filename...
-				QString,
+				FilePathFunctionArgument,
 				// List of 'ResolvedTopologicalSection's...
 				bp::list>
 						resolved_topological_sections_argument_type;
@@ -282,8 +282,8 @@ namespace GPlatesApi
 		// Either export the resolved topologies to a file or append them to a python list.
 		//
 
-		if (const QString *resolved_topologies_export_file_name =
-			boost::get<QString>(&resolved_topologies_argument))
+		if (const FilePathFunctionArgument *resolved_topologies_export_file_name =
+			boost::get<FilePathFunctionArgument>(&resolved_topologies_argument))
 		{
 			// Export resolved topologies.
 			topological_snapshot->export_resolved_topologies(
@@ -318,8 +318,8 @@ namespace GPlatesApi
 			// Either export the resolved topological sections to a file or append them to a python list.
 			//
 
-			if (const QString *resolved_topological_sections_export_file_name =
-				boost::get<QString>(&resolved_topological_sections_argument.get()))
+			if (const FilePathFunctionArgument *resolved_topological_sections_export_file_name =
+				boost::get<FilePathFunctionArgument>(&resolved_topological_sections_argument.get()))
 			{
 				// Export resolved topological sections.
 				topological_snapshot->export_resolved_topological_sections(
@@ -374,12 +374,12 @@ export_resolve_topologies()
 			"or filename, or feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) "
 			"of any combination of those four types. Note: Each sequence entry can optionally be a 2-tuple "
 			"(entry, :class:`ResolveTopologyParameters`) to override *default_resolve_topology_parameters* for that entry.\n"
-			"  :type topological_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type topological_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-			"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 			"  :param resolved_topologies: the "
 			":class:`resolved topological lines<ResolvedTopologicalLine>`, "
 			":class:`resolved topological boundaries<ResolvedTopologicalBoundary>` and "
@@ -387,13 +387,13 @@ export_resolve_topologies()
 			"keyword argument *resolve_topology_types* - see *output_parameters* table) are either exported "
 			"to a file (with specified filename) or *appended* to a python ``list`` (note that the list is "
 			"*not* cleared first)\n"
-			"  :type resolved_topologies: string or ``list``\n"
+			"  :type resolved_topologies: string/``os.PathLike`` or ``list``\n"
 			"  :param reconstruction_time: the specific geological time to resolve to\n"
 			"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
 			"  :param resolved_topological_sections: The :class:`resolved topological sections<ResolvedTopologicalSection>` "
 			" are either exported to a file (with specified filename) or *appended* to a python ``list`` "
 			"(note that the list is *not* cleared first). Default is to do neither.\n"
-			"  :type resolved_topological_sections: string or ``list``\n"
+			"  :type resolved_topological_sections: string/``os.PathLike`` or ``list``\n"
 			"  :param anchor_plate_id: The anchored plate id used during reconstruction. "
 			"Defaults to the default anchor plate of *rotation_model*.\n"
 			"  :type anchor_plate_id: int\n"
@@ -598,7 +598,11 @@ export_resolve_topologies()
 			"     Added *default_resolve_topology_parameters* argument.\n"
 			"\n"
 			"  .. versionchanged:: 0.33\n"
-			"     Added *export_topological_line_sub_segments* argument.\n";
+			"     Added *export_topological_line_sub_segments* argument.\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n";
 
 	// Register 'resolved topologies' variant.
 	GPlatesApi::PythonConverterUtils::register_variant_conversion<GPlatesApi::resolved_topologies_argument_type>();

--- a/src/api/PyRotationModel.cc
+++ b/src/api/PyRotationModel.cc
@@ -678,7 +678,7 @@ export_rotation_model()
 			"  :param rotation_features: A rotation feature collection, or rotation filename, or "
 			"rotation feature, or sequence of rotation features, or a sequence (eg, ``list`` or ``tuple``) "
 			"of any combination of those four types\n"
-			"  :type rotation_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type rotation_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param reconstruction_tree_cache_size: Number of reconstruction trees to cache internally. "
 			"Defaults to " << GPlatesApi::RotationModel::DEFAULT_RECONSTRUCTION_TREE_CACHE_SIZE << ".\n"
@@ -711,12 +711,16 @@ export_rotation_model()
 			"    ...\n"
 			"    rotation_model = pygplates.RotationModel(['rotations.rot', rotation_adjustments])\n"
 			"\n"
-			".. versionchanged:: 0.25\n"
+			"  .. versionchanged:: 0.25\n"
 			"     Added *extend_total_reconstruction_poles_to_distant_past* argument and "
 			"removed *clone_rotation_features* argument.\n"
 			"\n"
-			".. versionchanged:: 0.26\n"
+			"  .. versionchanged:: 0.26\n"
 			"     Added *default_anchor_plate_id* argument.\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n"
 			;
 
 	//

--- a/src/api/PyTopologicalModel.cc
+++ b/src/api/PyTopologicalModel.cc
@@ -1521,12 +1521,12 @@ export_topological_model()
 			"or filename, or feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) "
 			"of any combination of those four types. Note: Each sequence entry can optionally be a 2-tuple "
 			"(entry, :class:`ResolveTopologyParameters`) to override *default_resolve_topology_parameters* for that entry.\n"
-			"  :type topological_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type topological_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-			"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 			"  :param anchor_plate_id: The anchored plate id used for all reconstructions "
 			"(resolving topologies, and reconstructing regular features and :meth:`geometries<reconstruct_geometry>`). "
 			"Defaults to the default anchor plate of *rotation_model* (or zero if *rotation_model* is not a :class:`RotationModel`).\n"
@@ -1568,7 +1568,11 @@ export_topological_model()
 			"     Added *default_resolve_topology_parameters* argument.\n"
 			"\n"
 			"  .. versionchanged:: 0.43\n"
-			"     Added *topological_snapshot_cache_size* argument.\n")
+			"     Added *topological_snapshot_cache_size* argument.\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		// Pickle support...
 		//
 		// Note: This adds an __init__ method accepting a single argument (of type 'bytes') that supports pickling.

--- a/src/api/PyTopologicalSnapshot.cc
+++ b/src/api/PyTopologicalSnapshot.cc
@@ -140,7 +140,7 @@ namespace GPlatesApi
 	void
 	topological_snapshot_export_resolved_topologies(
 			TopologicalSnapshot::non_null_ptr_type topological_snapshot,
-			const QString &export_file_name,
+			const FilePathFunctionArgument &export_file_name,
 			ResolveTopologyType::flags_type resolve_topology_types,
 			bool wrap_to_dateline,
 			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation)
@@ -196,7 +196,7 @@ namespace GPlatesApi
 	void
 	topological_snapshot_export_resolved_topological_sections(
 			TopologicalSnapshot::non_null_ptr_type topological_snapshot,
-			const QString &export_file_name,
+			const FilePathFunctionArgument &export_file_name,
 			ResolveTopologyType::flags_type resolve_topological_section_types,
 			bool export_topological_line_sub_segments,
 			bool wrap_to_dateline)
@@ -455,11 +455,13 @@ namespace GPlatesApi
 
 	void
 	TopologicalSnapshot::export_resolved_topologies(
-			const QString &export_file_name,
+			const FilePathFunctionArgument &export_file_path,
 			ResolveTopologyType::flags_type resolve_topology_types,
 			bool wrap_to_dateline,
 			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
 	{
+		const QString export_file_name = export_file_path.get_file_path();
+
 		// Get the resolved topologies.
 		const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_type> resolved_topologies =
 				get_resolved_topologies(
@@ -576,11 +578,13 @@ namespace GPlatesApi
 
 	void
 	TopologicalSnapshot::export_resolved_topological_sections(
-			const QString &export_file_name,
+			const FilePathFunctionArgument &export_file_path,
 			ResolveTopologyType::flags_type resolve_topological_section_types,
 			bool export_topological_line_sub_segments,
 			bool wrap_to_dateline) const
 	{
+		const QString export_file_name = export_file_path.get_file_path();
+
 		// Get the resolved topological sections.
 		const std::vector<GPlatesAppLogic::ResolvedTopologicalSection::non_null_ptr_type> resolved_topological_sections =
 				get_resolved_topological_sections(
@@ -1082,12 +1086,12 @@ export_topological_snapshot()
 			"or filename, or feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) "
 			"of any combination of those four types. Note: Each sequence entry can optionally be a 2-tuple "
 			"(entry, :class:`ResolveTopologyParameters`) to override *default_resolve_topology_parameters* for that entry.\n"
-			"  :type topological_features: :class:`FeatureCollection`, or string, or :class:`Feature`, "
+			"  :type topological_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
 			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
 			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
 			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
-			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string "
-			"or sequence of :class:`FeatureCollection` instances and/or strings\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
 			"  :param reconstruction_time: the specific geological time to resolve to\n"
 			"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
 			"  :param anchor_plate_id: The anchored plate id used for all reconstructions "
@@ -1108,7 +1112,11 @@ export_topological_snapshot()
 			"    topological_snapshot = pygplates.TopologicalSnapshot(topology_features, rotation_model, reconstruction_time)\n"
 			"\n"
 			"  .. versionchanged:: 0.31\n"
-			"     Added *default_resolve_topology_parameters* argument.\n")
+			"     Added *default_resolve_topology_parameters* argument.\n"
+			"\n"
+			"  .. versionchanged:: 0.44\n"
+			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		// Pickle support...
 		//
 		// Note: This adds an __init__ method accepting a single argument (of type 'bytes') that supports pickling.
@@ -1150,7 +1158,7 @@ export_topological_snapshot()
 				"  Exports the resolved topologies to a file.\n"
 				"\n"
 				"  :param export_filename: the name of the export file\n"
-				"  :type export_filename: string\n"
+				"  :type export_filename: string/``os.PathLike``\n"
 				"  :param resolve_topology_types: specifies the resolved topology types to export - defaults "
 				"to :class:`resolved topological boundaries<ResolvedTopologicalBoundary>` and "
 				":class:`resolved topological networks<ResolvedTopologicalNetwork>` "
@@ -1183,7 +1191,11 @@ export_topological_snapshot()
 				"\n"
 				"  .. note:: Resolved topologies are exported in the same order as that of their "
 				"respective topological features (see :meth:`constructor<__init__>`) and the order across "
-				"topological feature collections (if any) is also retained.\n")
+				"topological feature collections (if any) is also retained.\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.def("get_resolved_topological_sections",
 				&GPlatesApi::topological_snapshot_get_resolved_topological_sections,
 				(bp::arg("resolve_topological_section_types") = GPlatesApi::ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGICAL_SECTION_TYPES,
@@ -1216,7 +1228,7 @@ export_topological_snapshot()
 				"  Exports the resolved topological sections to a file.\n"
 				"\n"
 				"  :param export_filename: the name of the export file\n"
-				"  :type export_filename: string\n"
+				"  :type export_filename: string/``os.PathLike``\n"
 				"  :param resolve_topological_section_types: Determines whether :class:`ResolvedTopologicalBoundary` or "
 				":class:`ResolvedTopologicalNetwork` (or both types) are listed in the exported resolved topological sections. "
 				"Note that ``ResolveTopologyType.line`` cannot be specified since only topologies with boundaries are considered. "
@@ -1256,7 +1268,11 @@ export_topological_snapshot()
 				"topological feature collections (if any) is also retained.\n"
 				"\n"
 				"  .. versionchanged:: 0.33\n"
-				"     Added *export_topological_line_sub_segments* argument.\n")
+				"     Added *export_topological_line_sub_segments* argument.\n"
+				"\n"
+				"  .. versionchanged:: 0.44\n"
+				"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
+				"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n")
 		.def("get_rotation_model",
 				&GPlatesApi::TopologicalSnapshot::get_rotation_model,
 				"get_rotation_model()\n"

--- a/src/api/PyTopologicalSnapshot.h
+++ b/src/api/PyTopologicalSnapshot.h
@@ -30,8 +30,8 @@
 #include <vector>
 #include <map>
 #include <boost/optional.hpp>
-#include <QString>
 
+#include "PyFilePathFunctionArgument.h"
 #include "PyResolveTopologyParameters.h"
 #include "PyRotationModel.h"
 #include "PyTopologicalFeatureCollectionFunctionArgument.h"
@@ -196,7 +196,7 @@ namespace GPlatesApi
 		 */
 		void
 		export_resolved_topologies(
-				const QString &export_file_name,
+				const FilePathFunctionArgument &export_file_name,
 				ResolveTopologyType::flags_type resolve_topology_types = ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGY_TYPES,
 				bool wrap_to_dateline = true,
 				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation = boost::none) const;
@@ -233,7 +233,7 @@ namespace GPlatesApi
 		 */
 		void
 		export_resolved_topological_sections(
-				const QString &export_file_name,
+				const FilePathFunctionArgument &export_file_name,
 				ResolveTopologyType::flags_type resolve_topological_section_types = ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGICAL_SECTION_TYPES,
 				bool export_topological_line_sub_segments = true,
 				bool wrap_to_dateline = true) const;

--- a/src/qt-resources/python/api/Crossovers.py
+++ b/src/qt-resources/python/api/Crossovers.py
@@ -203,7 +203,7 @@ def find_crossovers(
     :param rotation_features: A rotation feature collection, or rotation filename, or \
         rotation feature, or sequence of rotation features, or a sequence (eg, ``list`` or ``tuple``) \
         of any combination of those four types
-    :type rotation_features: :class:`FeatureCollection`, or string, or :class:`Feature`, \
+    :type rotation_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, \
         or sequence of :class:`Feature`, or sequence of any combination of those four types
     
     :param crossover_filter: A predicate function to determine which crossovers to return
@@ -375,6 +375,10 @@ def find_crossovers(
           rotation_feature_collection,
           lambda crossover: crossover.moving_plate_id==801,
           pygplates.CrossoverType.synch_old_crossover_and_stages)
+
+    .. versionchanged:: 0.44
+       Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_
+       (such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.
     """
     
     # Use helper class to convert 'rotation_features' argument to a list of features.
@@ -517,7 +521,7 @@ def synchronise_crossovers(
     :param rotation_features: A rotation feature collection, or rotation filename, or \
         rotation feature, or sequence of rotation features, or a sequence (eg, ``list`` or ``tuple``) \
         of any combination of those four types - all features are used as input and output
-    :type rotation_features: :class:`FeatureCollection`, or string, or :class:`Feature`, \
+    :type rotation_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, \
         or sequence of :class:`Feature`, or sequence of any combination of those four types
     
     :param crossover_filter: Optional predicate function (accepting a single crossover argument) that determines \
@@ -720,6 +724,10 @@ def synchronise_crossovers(
           crossover_results)
       print 'Fixed %d crossovers' % sum(
           1 for result in crossover_results if result[1]==pygplates.CrossoverResult.synchronised)
+
+    .. versionchanged:: 0.44
+       Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_
+       (such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.
     """
     
     # Use helper class to convert 'rotation_features' argument to a list of features.

--- a/src/qt-resources/python/api/PlatePartitioning.py
+++ b/src/qt-resources/python/api/PlatePartitioning.py
@@ -123,7 +123,7 @@ def plate_partitioner_partition_features(
     Partitions features into partitioning plates.
     
     :param features: the features to partition
-    :type features: :class:`FeatureCollection`, or string, or :class:`Feature`, \
+    :type features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, \
         or sequence of :class:`Feature`, or sequence of any combination of those four types
     
     :param properties_to_copy: the properties to copy from partitioning plate features to the partitioned features \
@@ -333,6 +333,10 @@ def plate_partitioner_partition_features(
     ...this is useful when the features to be partitioned already have reconstruction plate IDs but
     they are deemed to be incorrect. By resetting them to zero we ensure the unpartitioned features remain stationary
     and do not reconstruct incorrectly over geological time. Any partitioned features will get a new plate ID.
+
+    .. versionchanged:: 0.44
+       Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ \
+    (such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.
     """
     
     # Turn function argument into something more convenient for extracting features.
@@ -526,16 +530,16 @@ def partition_into_plates(
     Partition features into plates.
     
     :param partitioning_features: the partitioning features
-    :type partitioning_features: :class:`FeatureCollection`, or string, or :class:`Feature`, \
+    :type partitioning_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, \
         or sequence of :class:`Feature`, or sequence of any combination of those four types
     
     :param rotation_model: A rotation model or a rotation feature collection or a rotation \
         filename or a sequence of rotation feature collections and/or rotation filenames
-    :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string \
-        or sequence of :class:`FeatureCollection` instances and/or strings
+    :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` \
+        or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances
     
     :param features_to_partition: the features to be partitioned
-    :type features_to_partition: :class:`FeatureCollection`, or string, or :class:`Feature`, \
+    :type features_to_partition: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, \
         or sequence of :class:`Feature`, or sequence of any combination of those four types
     
     :param properties_to_copy: the properties to copy from partitioning plate features to the partitioned features \
@@ -833,6 +837,10 @@ def partition_into_plates(
             plate_partitioner = pygplates.PlatePartitioner(partitioning_features, rotation_model, reconstruction_time, sort_partitioning_plates)
             
             return plate_partitioner.partition_features(features_to_partition, properties_to_copy, partition_method, partition_return)
+
+    .. versionchanged:: 0.44
+       Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ \
+    (such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.
     """
     
     plate_partitioner = PlatePartitioner(partitioning_features, rotation_model, reconstruction_time, sort_partitioning_plates)


### PR DESCRIPTION
Filenames in pyGPlates can be [os.PathLike](https://docs.python.org/3/library/os.html#os.PathLike) (such as [pathlib.Path](https://docs.python.org/3/library/pathlib.html)) in addition to strings.