### PR TITLE
Add reconstruct model/snapshot to pyGPlates

### DIFF
--- a/cmake/modules/Version.cmake
+++ b/cmake/modules/Version.cmake
@@ -75,7 +75,7 @@ set(GPLATES_SEMANTIC_VERSION 2.5.0)
 #   1.0.0
 #   1.0.1
 #
-set(PYGPLATES_PEP440_VERSION 0.47.0)
+set(PYGPLATES_PEP440_VERSION 0.48.0)
 
 
 ##################

--- a/doc-python-api/pygplates_getting_started.rst
+++ b/doc-python-api/pygplates_getting_started.rst
@@ -310,7 +310,7 @@ input and output if the function first reads from it (input) and then writes to 
 An example pyGPlates function call is reconstructing coastlines to 10Ma:
 ::
 
-  pygplates.reconstruct('coastlines.gpml', 'rotations.rot', 'reconstructed_coastlines_10Ma.shp', 10)
+  pygplates.reconstruct('coastlines.gpmlz', 'rotations.rot', 'reconstructed_coastlines_10Ma.shp', 10)
 
 .. note:: The ``pygplates.`` in front of ``reconstruct()`` means the ``reconstruct()`` function belongs to the ``pygplates`` module.
           Also this particular function doesn't need to a return value.
@@ -318,18 +318,18 @@ An example pyGPlates function call is reconstructing coastlines to 10Ma:
 All four parameters are input parameters since they only pass data *to* the function
 (even though ``'reconstructed_coastlines_10Ma.shp'`` specifies the filename to *write* the output to).
 
-A similar use of the ``pygplates.reconstruct()`` function appends the reconstructed output to a
+A similar use of the ``pygplates.reconstruct()`` function appends the reconstructed coastlines to a
 Python list (instead of writing to a file):
 ::
 
-  reconstructed_feature_geometries = []
-  pygplates.reconstruct('coastlines.gpml', 'rotations.rot', reconstructed_feature_geometries, 10)
+  reconstructed_coastline_geometries = []
+  pygplates.reconstruct('coastlines.gpmlz', 'rotations.rot', reconstructed_coastline_geometries, 10)
   
   # Do something with the reconstructed output.
-  for reconstructed_feature_geometry in reconstructed_feature_geometries:
+  for reconstructed_geometry in reconstructed_coastline_geometries:
     ...
 
-The parameter ``reconstructed_feature_geometries`` is now an *output* parameter because it is used
+The parameter ``reconstructed_coastline_geometries`` is now an *output* parameter because it is used
 to pass data from the function back to the caller so that the caller can do something with it.
 
 Classes
@@ -338,30 +338,50 @@ Classes
 Primarily a class is a way to group some data together as a single entity.
 
 An object can be created (instantiated) from a class by providing a specific initial state.
-For example, a point object can be created (instantiated) from the :class:`pygplates.PointOnSphere` class
-by giving it a specific latitude and longitude:
+For example, a *reconstruct model* object can be created (instantiated) from the :class:`pygplates.ReconstructModel` class
+by giving it the features to reconstruct and the rotations used to reconstruct them:
 ::
 
-  point = pygplates.PointOnSphere(latitude, longitude)
+  reconstruct_coastlines_model = pyglates.ReconstructModel('coastlines.gpmlz', 'rotations.rot')
 
 .. note:: This looks like a regular ``pygplates`` function call (such as ``pygplates.reconstruct()``)
    but this is just how you create (instantiate) an object from a class with a specific initial state.
    Python uses the special method name ``__init__()`` for this and you will see these special methods
    documented in the classes listed in the :ref:`reference section<pygplates_reference>`.
 
-You can then call functions (methods) on the *point* object such as querying its latitude and longitude
-(this particular method returns a Python tuple):
+You can then call functions (methods) on the *reconstruct model* object such as reconstructing to a specific reconstruction time
+(this particular method returns a :class:`reconstruct snapshot <pygplates.ReconstructSnapshot>` object):
 ::
 
-  latitude, longitude = point.to_lat_lon()
+  reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(10)
 
-The ``point.`` before the ``to_lat_lon()`` means the ``to_lat_lon()`` function (method) applies to the ``point`` object.
-And :meth:`to_lat_lon()<pygplates.PointOnSphere.to_lat_lon>` will be one of several functions (methods)
-documented in the :class:`pygplates.PointOnSphere` class.
+The ``reconstruct_coastlines_model.`` before the ``reconstruct_snapshot(10)`` means the ``reconstruct_snapshot()`` function (method)
+applies to the ``reconstruct_coastlines_model`` object.
+And :meth:`reconstruct_snapshot()<pygplates.ReconstructModel.reconstruct_snapshot>` will be one of several functions (methods)
+documented in the :class:`pygplates.ReconstructModel` class.
 
 These class *methods* behave similarly to top-level functions (such as ``pygplates.reconstruct()``) except
 they operate on an instance of class. Hence a class *method* has an implicit first function
-argument that is the object itself (for example, ``point`` is the implicit argument in ``point.to_lat_lon()``).
+argument that is the object itself (for example, ``reconstruct_coastlines_model`` is the implicit argument in
+``reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(10)``).
+
+Since the returned :class:`reconstruct snapshot <pygplates.ReconstructSnapshot>` is another object, you can in turn
+call one of its *methods*. For example:
+::
+
+  reconstruct_coastlines_snapshot.export_reconstructed_geometries('reconstructed_coastlines_10Ma.shp')
+
+...to save the reconstructed snapshot (at 10 Ma) to the Shapefile ``reconstructed_coastlines_10Ma.shp``.
+
+A similar use of the :class:`reconstruct snapshot <pygplates.ReconstructSnapshot>` class returns the
+reconstructed coastlines as a Python list (instead of writing to a file):
+::
+
+  reconstructed_coastline_geometries = reconstruct_coastlines_snapshot.get_reconstructed_geometries()
+  
+  # Do something with the reconstructed output.
+  for reconstructed_geometry in reconstructed_coastline_geometries:
+    ...
 
 .. note:: A complete list of pyGPlates functions and classes can be found in the :ref:`reference section<pygplates_reference>`.
 
@@ -381,7 +401,10 @@ Our introductory pyGPlates Python script will contain the following lines of sou
 
   import pygplates
   
-  pygplates.reconstruct('coastlines.gpmlz', 'rotations.rot', 'reconstructed_coastlines_10Ma.shp', 10)
+  reconstruct_coastlines_model = pyglates.ReconstructModel('coastlines.gpmlz', 'rotations.rot')
+
+  reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(10)
+  reconstruct_coastlines_snapshot.export_reconstructed_geometries('reconstructed_coastlines_10Ma.shp')
 
 The first statement...
 ::
@@ -393,10 +416,13 @@ The first statement...
 
 .. note:: There are other ways to import pyGPlates but this is the simplest and most common way.
 
-The second statement...
+The remaining statements...
 ::
   
-  pygplates.reconstruct('coastlines.gpmlz', 'rotations.rot', 'reconstructed_coastlines_10Ma.shp', 10)
+  reconstruct_coastlines_model = pyglates.ReconstructModel('coastlines.gpmlz', 'rotations.rot')
+
+  reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(10)
+  reconstruct_coastlines_snapshot.export_reconstructed_geometries('reconstructed_coastlines_10Ma.shp')
 
 ...will reconstruct coastlines (loaded from the ``coastlines.gpmlz`` file) to their location
 10 million years ago (Ma) using the plate rotations in the ``rotations.rot`` file, and then save those
@@ -413,8 +439,8 @@ Setting up the script
 
 | Next we need the data files containing the coastlines and rotations.
 | This data is available in the `GPlates geodata <http://www.gplates.org/download.html#download-gplates-compatible-data>`_.
-| For example, in the GPlates 2.3 geodata, the coastlines file is called ``Global_EarthByte_GPlates_PresentDay_Coastlines.gpmlz``
-  and the rotations file is called ``Muller2019-Young2019-Cao2020_CombinedRotations.rot``.
+| For example, in the GPlates 2.5 geodata, the coastlines file is called ``Global_EarthByte_GPlates_PresentDay_Coastlines.gpmlz``
+  and the rotations file is called ``Zahirovic_etal_2022_OptimisedMantleRef_and_NNRMantleRef.rot``.
 | Copy those files to the ``pygplates_tutorial`` directory and rename them as ``coastlines.gpmlz`` and ``rotations.rot``.
   Alternatively the filenames (and paths) could be changed in the ``tutorials.py`` script to match the geodata.
 

--- a/doc-python-api/pygplates_introduction.rst
+++ b/doc-python-api/pygplates_introduction.rst
@@ -46,18 +46,20 @@ There are two ways to interact with GPlates functionality:
      # Import the pyGPlates library.
      import pygplates
      
-     # Load the coastline features and rotation model.
-     coastline_features = pygplates.FeatureCollection('coastlines.gpml')
-     rotation_model = pygplates.RotationModel('rotations.rot')
+     # Load the coastline features and rotation file(s) into a reconstruct model.
+     reconstruct_coastlines_model = pyglates.ReconstructModel('coastlines.gpml', 'rotations.rot')
 
      # Iterate from 200Ma to 0Ma inclusive in steps of 10My.
      for reconstruction_time in range(200,-1,-10):
+
+         # Reconstruct the coastlines to the current reconstruction time.
+         reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(reconstruction_time)
          
-         # Create the output filename using the current reconstruction time.
+         # The filename of the output file to contain the reconstructed coastlines at the current reconstruction time.
          reconstructed_coastlines_filename = 'reconstructed_coastlines_{0:0.2f}Ma.shp'.format(reconstruction_time)
          
-         # Reconstruct the coastlines to the current reconstruction time and save to the output file.
-         pygplates.reconstruct(coastline_features, rotation_model, reconstructed_coastlines_filename, reconstruction_time)
+         # Save the reconstructed coastlines to the output file.
+         reconstruct_coastlines_snapshot.export_reconstructed_geometries(reconstructed_coastlines_filename)
 
 .. _pygplates_introduction_why_use_pygplates:
 
@@ -71,13 +73,15 @@ in their functions and classes to enable this kind of flexibility.
 
 High-level functionality enables common tasks (such as reconstructing entire files of geological data)
 and is typically easier to use but more restrictive in what it can do.
-For example, :func:`pygplates.reconstruct` is a high-level function that can reconstruct geological data
-to a past geological time:
+For example, :class:`pygplates.ReconstructModel` and :class:`pygplates.ReconstructSnapshot` are high-level
+classes that can reconstruct geological data to a past geological time (such as 10 Ma):
 ::
 
-  pygplates.reconstruct('coastlines.gpml', 'rotations.rot', 'reconstructed_coastlines_10Ma.shp', 10)
+  reconstruct_coastlines_model = pyglates.ReconstructModel('coastlines.gpml', 'rotations.rot')
+  reconstruct_coastlines_snapshot = reconstruct_coastlines_model.reconstruct_snapshot(10)
+  reconstruct_coastlines_snapshot.export_reconstructed_geometries('reconstructed_coastlines_10Ma.shp')
 
-...but it cannot restrict reconstructed data to a specific region on the globe.
+...but they cannot restrict reconstructed data to a specific region on the globe.
 To achieve that, some more Python code needs to be written that accesses lower-level pyGPlates functionality
 as shown in the sample code :ref:`pygplates_find_features_overlapping_a_polygon`.
 

--- a/doc-python-api/pygplates_reference.rst
+++ b/doc-python-api/pygplates_reference.rst
@@ -17,6 +17,15 @@ This document lists the Python functions and classes that make up the GPlates Py
 Reconstruction
 --------------
 
+Classes to query the history of reconstructions:
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated
+
+   pygplates.ReconstructModel
+   pygplates.ReconstructSnapshot
+
 Function to reconstruct backward and forward in time:
 
 .. autosummary::

--- a/doc-python-api/sample-code/pygplates_find_overriding_plate_of_closest_subducting_line.rst
+++ b/doc-python-api/sample-code/pygplates_find_overriding_plate_of_closest_subducting_line.rst
@@ -25,8 +25,8 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
     
-    # Load some features to test for closeness to subducting lines.
-    features = pygplates.FeatureCollection('features.gpml')
+    # Create a reconstruct model from some regular (non-topological) features and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
     # Create a topological model from the topological plate polygon features (can also include deforming networks)
     # and the rotation model.
@@ -40,9 +40,9 @@ Sample code
         
         print 'Time %f' % time
         
-        # Reconstruct the features to the current 'time'.
-        reconstructed_features = []
-        pygplates.reconstruct(features, rotation_model, reconstructed_features, time, group_with_feature=True)
+        # Reconstruct the regular features to the current 'time'.
+        reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(time)
+        reconstructed_features = reconstruct_snapshot.get_reconstructed_features()
         
         # Get a snapshot of our resolved topologies at the current 'time'.
         topological_snapshot = topological_model.topological_snapshot(time)
@@ -156,26 +156,26 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
     
-Load the regular features that we want to see which subducting lines (in the topologies) are closest to.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the regular (non-topological) features and the rotation model.
+These are the regular features that we want to see which subducting lines (in the topologies) are closest to.
 ::
 
-    features = pygplates.FeatureCollection('features.gpml')
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
 Create a :class:`topological model<pygplates.TopologicalModel>` from topological features and the rotation model.
 ::
 
     topological_model = pygplates.TopologicalModel('topologies.gpml', rotation_model)
 
-| All regular features are reconstructed to the current ``time`` using :func:`pygplates.reconstruct`.
-| We specify a ``list`` for *reconstructed_features* instead of a filename.
-| We also set the output parameter *group_with_feature* to ``True`` (it defaults to ``False``)
-  so that our :class:`reconstructed feature geometries<pygplates.ReconstructedFeatureGeometry>`
-  are grouped with their :class:`feature<pygplates.Feature>`.
+| All regular features are reconstructed to the current ``time`` using :meth:`pygplates.ReconstructModel.reconstruct_snapshot`
+  that returns a :class:`pygplates.ReconstructSnapshot`.
+| We then call :meth:`pygplates.ReconstructSnapshot.get_reconstructed_features` so that our
+  :class:`reconstructed feature geometries<pygplates.ReconstructedFeatureGeometry>` are grouped with their :class:`feature<pygplates.Feature>`.
 
 ::
 
-    reconstructed_features = []
-    pygplates.reconstruct(features, rotation_model, reconstructed_features, time, group_with_feature=True)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(time)
+    reconstructed_features = reconstruct_snapshot.get_reconstructed_features()
 
 | Each item in the *reconstructed_features* list is a tuple containing a feature and its associated
   reconstructed geometries.

--- a/doc-python-api/sample-code/pygplates_reconstruct_flowline_features.rst
+++ b/doc-python-api/sample-code/pygplates_reconstruct_flowline_features.rst
@@ -36,8 +36,8 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-    # Load some flowline features.
-    flowline_features = pygplates.FeatureCollection('flowline_features.gpml')
+    # Create a reconstruct model from some flowline features and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel('flowline_features.gpml', rotation_model)
 
     # Reconstruct features to this geological time.
     reconstruction_time = 50
@@ -47,7 +47,8 @@ Sample code
     export_filename = 'flowline_output_{0}Ma.shp'.format(reconstruction_time)
 
     # Reconstruct the flowlines to the reconstruction time and export them to a shapefile.
-    pygplates.reconstruct(flowline_features, rotation_model, export_filename, reconstruction_time,
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename,
         reconstruct_type=pygplates.ReconstructType.flowline)
 
 Details
@@ -58,24 +59,25 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The flowline features are loaded into a :class:`pygplates.FeatureCollection`.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the flowline features and the rotation model.
 ::
 
-    flowline_features = pygplates.FeatureCollection('flowline_features.gpml')
+    reconstruct_model = pygplates.ReconstructModel('flowline_features.gpml', rotation_model)
 
 The flowline features will be reconstructed to their 50Ma positions.
 ::
 
     reconstruction_time = 50
 
-| All flowline features are reconstructed to 50Ma using :func:`pygplates.reconstruct`.
+| All flowline features are :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`export the reconstructed geometries <pygplates.ReconstructSnapshot.export_reconstructed_geometries>` to a file.
 | We specify we only want to reconstruct flowline features by specifying
   ``pygplates.ReconstructType.flowline`` for the *reconstruct_type* argument.
-| We specify a filename to export the reconstructed geometries to.
 
 ::
 
-    pygplates.reconstruct(flowline_features, rotation_model, export_filename, reconstruction_time,
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename,
         reconstruct_type=pygplates.ReconstructType.flowline)
 
 Output
@@ -121,13 +123,16 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
+    # Create a reconstruct model from the flowline feature and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel(flowline_feature, rotation_model)
+
     # Reconstruct features to this geological time.
     reconstruction_time = 50
 
     # Reconstruct the flowline feature to the reconstruction time.
-    reconstructed_flowlines = []
-    pygplates.reconstruct(flowline_feature, rotation_model, reconstructed_flowlines, reconstruction_time,
-        reconstruct_type=pygplates.ReconstructType.flowline)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_flowlines = reconstruct_snapshot.get_reconstructed_geometries(
+        reconstruct_types=pygplates.ReconstructType.flowline)
 
     # Iterate over all reconstructed flowlines.
     # There will be two (one for each seed point).
@@ -199,22 +204,26 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The features will be reconstructed to their 50Ma positions.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the flowline feature and the rotation model.
+::
+
+    reconstruct_model = pygplates.ReconstructModel(flowline_feature, rotation_model)
+
+The flowline feature will be reconstructed to its 50Ma position.
 ::
 
     reconstruction_time = 50
 
-| The flowline feature is reconstructed to 50Ma using :func:`pygplates.reconstruct`.
-| We specify a ``list`` for *reconstructed_flowlines* instead of a filename so that we
-  can query the reconstructed flowlines easily.
+| The flowline feature is :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`query the reconstructed geometries <pygplates.ReconstructSnapshot.get_reconstructed_geometries>`.
 | We also specify we only want to reconstruct flowline features by specifying
-  ``pygplates.ReconstructType.flowline`` for the *reconstruct_type* argument.
+  ``pygplates.ReconstructType.flowline`` for the *reconstruct_types* argument.
 
 ::
 
-    reconstructed_flowlines = []
-    pygplates.reconstruct(flowline_feature, rotation_model, reconstructed_flowlines, reconstruction_time,
-        reconstruct_type=pygplates.ReconstructType.flowline)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_flowlines = reconstruct_snapshot.get_reconstructed_geometries(
+        reconstruct_types=pygplates.ReconstructType.flowline)
 
 | We iterate over the points in the :meth:`reconstructed left flowline<pygplates.ReconstructedFlowline.get_left_flowline>`
   and print each point location and its associated time.

--- a/doc-python-api/sample-code/pygplates_reconstruct_motion_path_features.rst
+++ b/doc-python-api/sample-code/pygplates_reconstruct_motion_path_features.rst
@@ -36,8 +36,8 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-    # Load some motion path features.
-    motion_path_features = pygplates.FeatureCollection('motion_path_features.gpml')
+    # Create a reconstruct model from some motion path features and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel('motion_path_features.gpml', rotation_model)
 
     # Reconstruct features to this geological time.
     reconstruction_time = 50
@@ -47,7 +47,8 @@ Sample code
     export_filename = 'motion_path_output_{0}Ma.shp'.format(reconstruction_time)
 
     # Reconstruct the motion paths to the reconstruction time and export them to a shapefile.
-    pygplates.reconstruct(motion_path_features, rotation_model, export_filename, reconstruction_time,
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename,
         reconstruct_type=pygplates.ReconstructType.motion_path)
 
 Details
@@ -58,24 +59,25 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The motion path features are loaded into a :class:`pygplates.FeatureCollection`.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the motion path features and the rotation model.
 ::
 
-    motion_path_features = pygplates.FeatureCollection('motion_path_features.gpml')
+    reconstruct_model = pygplates.ReconstructModel('motion_path_features.gpml', rotation_model)
 
 The motion path features will be reconstructed to their 50Ma positions.
 ::
 
     reconstruction_time = 50
 
-| All motion path features are reconstructed to 50Ma using :func:`pygplates.reconstruct`.
+| All motion path features are :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`export the reconstructed geometries <pygplates.ReconstructSnapshot.export_reconstructed_geometries>` to a file.
 | We specify we only want to reconstruct motion path features by specifying
   ``pygplates.ReconstructType.motion_path`` for the *reconstruct_type* argument.
-| We specify a filename to export the reconstructed geometries to.
 
 ::
 
-    pygplates.reconstruct(motion_path_features, rotation_model, export_filename, reconstruction_time,
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename,
         reconstruct_type=pygplates.ReconstructType.motion_path)
 
 Output
@@ -121,13 +123,16 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
+    # Create a reconstruct model from the motion path feature and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel(motion_path_feature, rotation_model)
+
     # Reconstruct features to this geological time.
     reconstruction_time = 50
 
     # Reconstruct the motion path feature to the reconstruction time.
-    reconstructed_motion_paths = []
-    pygplates.reconstruct(motion_path_feature, rotation_model, reconstructed_motion_paths, reconstruction_time,
-        reconstruct_type=pygplates.ReconstructType.motion_path)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_motion_paths = reconstruct_snapshot.get_reconstructed_geometries(
+        reconstruct_types=pygplates.ReconstructType.motion_path)
 
     # Iterate over all reconstructed motion paths.
     # There will be two (one for each seed point).
@@ -179,22 +184,26 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The features will be reconstructed to their 50Ma positions.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the motion path feature and the rotation model.
+::
+
+    reconstruct_model = pygplates.ReconstructModel(motion_path_feature, rotation_model)
+
+The motion path feature will be reconstructed to its 50Ma position.
 ::
 
     reconstruction_time = 50
 
-| The motion path feature is reconstructed to 50Ma using :func:`pygplates.reconstruct`.
-| We specify a ``list`` for *reconstructed_motion_paths* instead of a filename so that we
-  can query the reconstructed motion paths easily.
+| The motion path feature is :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`query the reconstructed geometries <pygplates.ReconstructSnapshot.get_reconstructed_geometries>`.
 | We also specify we only want to reconstruct motion path features by specifying
-  ``pygplates.ReconstructType.motion_path`` for the *reconstruct_type* argument.
+  ``pygplates.ReconstructType.motion_path`` for the *reconstruct_types* argument.
 
 ::
 
-    reconstructed_motion_paths = []
-    pygplates.reconstruct(motion_path_feature, rotation_model, reconstructed_motion_paths, reconstruction_time,
-        reconstruct_type=pygplates.ReconstructType.motion_path)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_motion_paths = reconstruct_snapshot.get_reconstructed_geometries(
+        reconstruct_types=pygplates.ReconstructType.motion_path)
 
 | We iterate over the points in the :meth:`reconstructed motion path<pygplates.ReconstructedMotionPath.get_motion_path>`
   and print each point location and its associated time.

--- a/doc-python-api/sample-code/pygplates_reconstruct_regular_features.rst
+++ b/doc-python-api/sample-code/pygplates_reconstruct_regular_features.rst
@@ -35,8 +35,8 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-    # Load some features.
-    features = pygplates.FeatureCollection('features.gpml')
+    # Create a reconstruct model from some reconstructable features and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
     # Reconstruct features to this geological time.
     reconstruction_time = 50
@@ -46,7 +46,8 @@ Sample code
     export_filename = 'reconstructed_{0}Ma.shp'.format(reconstruction_time)
 
     # Reconstruct the features to the reconstruction time and export them to a shapefile.
-    pygplates.reconstruct(features, rotation_model, export_filename, reconstruction_time)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename)
 
 Details
 """""""
@@ -56,22 +57,23 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The reconstructable features are loaded into a :class:`pygplates.FeatureCollection`.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the reconstructable features and the rotation model.
 ::
 
-    features = pygplates.FeatureCollection('features.gpml')
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
 The features will be reconstructed to their 50Ma positions.
 ::
 
     reconstruction_time = 50
 
-| All features are reconstructed to 50Ma using :func:`pygplates.reconstruct`.
-| We specify a filename to export the reconstructed geometries to.
+| All features are :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`export the reconstructed geometries <pygplates.ReconstructSnapshot.export_reconstructed_geometries>` to a file.
 
 ::
 
-    pygplates.reconstruct(features, rotation_model, export_filename, reconstruction_time)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstruct_snapshot.export_reconstructed_geometries(export_filename)
 
 Output
 """"""
@@ -110,15 +112,15 @@ Sample code
     # Load one or more rotation files into a rotation model.
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-    # Load some features.
-    features = pygplates.FeatureCollection('features.gpml')
+    # Create a reconstruct model from some reconstructable features and the rotation model.
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
     # Reconstruct features to this geological time.
     reconstruction_time = 50
 
     # Reconstruct the features to the reconstruction time.
-    reconstructed_feature_geometries = []
-    pygplates.reconstruct(features, rotation_model, reconstructed_feature_geometries, reconstruction_time)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_feature_geometries = reconstruct_snapshot.get_reconstructed_geometries()
 
     # Iterate over all reconstructed feature geometries.
     for reconstructed_feature_geometry in reconstructed_feature_geometries:
@@ -160,24 +162,23 @@ The rotations are loaded from a rotation file into a :class:`pygplates.RotationM
 
     rotation_model = pygplates.RotationModel('rotations.rot')
 
-The reconstructable features are loaded into a :class:`pygplates.FeatureCollection`.
+Create a :class:`reconstruct model <pygplates.ReconstructModel>` from the reconstructable features and the rotation model.
 ::
 
-    features = pygplates.FeatureCollection('features.gpml')
+    reconstruct_model = pygplates.ReconstructModel('features.gpml', rotation_model)
 
 The features will be reconstructed to their 50Ma positions.
 ::
 
     reconstruction_time = 50
 
-| All features are reconstructed to 50Ma using :func:`pygplates.reconstruct`.
-| We specify a ``list`` for *reconstructed_feature_geometries* instead of a filename so that we
-  can query the reconstructed geometries easily.
+| All features are :meth:`reconstructed <pygplates.ReconstructModel.reconstruct_snapshot>` to 50Ma.
+| We then :meth:`query the reconstructed geometries <pygplates.ReconstructSnapshot.get_reconstructed_geometries>`.
 
 ::
 
-    reconstructed_feature_geometries = []
-    pygplates.reconstruct(features, rotation_model, reconstructed_feature_geometries, reconstruction_time)
+    reconstruct_snapshot = reconstruct_model.reconstruct_snapshot(reconstruction_time)
+    reconstructed_feature_geometries = reconstruct_snapshot.get_reconstructed_geometries()
 
 | We use our ``get_geometry_centroid()`` function to find the centroid of the
   :meth:`present day<pygplates.ReconstructedFeatureGeometry.get_present_day_geometry>` and
@@ -233,8 +234,5 @@ Output
     Feature: Northwest Africa
       plate ID: 714
       distance reconstructed: 643.521413 kms
-
+    
     ...
-
-.. seealso:: :ref:`pygplates_find_nearest_feature_to_a_point` for an example using the *group_with_feature*
-   argument in :func:`pygplates.reconstruct`

--- a/pygplates/test/test_app_logic/test.py
+++ b/pygplates/test/test_app_logic/test.py
@@ -382,11 +382,12 @@ class ReconstructTestCase(unittest.TestCase):
                 valid_time=(30, 0),
                 relative_plate=201,
                 reconstruction_plate_id=801)
-        reconstructed_motion_paths = []
         # First without specifying motion paths.
+        reconstructed_motion_paths = []
         pygplates.reconstruct(motion_path_feature, rotation_model, reconstructed_motion_paths, reconstruction_time)
         self.assertEqual(len(reconstructed_motion_paths), 0)
         # Now specify motion paths.
+        reconstructed_motion_paths = []
         pygplates.reconstruct(
                 motion_path_feature, rotation_model, reconstructed_motion_paths, reconstruction_time,
                 reconstruct_type=pygplates.ReconstructType.motion_path)

--- a/pygplates/test/test_app_logic/test.py
+++ b/pygplates/test/test_app_logic/test.py
@@ -2810,8 +2810,8 @@ class TopologicalModelTestCase(unittest.TestCase):
 class TopologicalSnapshotTestCase(unittest.TestCase):
     def test(self):
         #
-        # Class pygplates.TopologicalSnapshot is used internally by pygplates.resolved_topologies()
-        # so most of its testing is already done by testing pygplates.resolved_topologies().
+        # Class pygplates.TopologicalSnapshot is used internally by pygplates.resolve_topologies()
+        # so most of its testing is already done by testing pygplates.resolve_topologies().
         #
         # Here we're just making sure we can access the pygplates.TopologicalSnapshot methods.
         #

--- a/pygplates/test/test_app_logic/test.py
+++ b/pygplates/test/test_app_logic/test.py
@@ -157,6 +157,205 @@ class InterpolateTotalReconstructionSequenceTestCase(unittest.TestCase):
         # TODO: Compare pole.
 
 
+class ReconstructModelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.rotations = pygplates.FeatureCollection(os.path.join(FIXTURES, 'rotations.rot'))
+        self.rotation_model = pygplates.RotationModel(self.rotations)
+
+        self.reconstructable_features = pygplates.FeatureCollection(os.path.join(FIXTURES, 'volcanoes.gpml'))
+        self.reconstruct_model = pygplates.ReconstructModel(self.reconstructable_features, self.rotation_model)
+
+    def test_create(self):
+        self.assertRaises(
+                pygplates.OpenFileForReadingError,
+                pygplates.ReconstructModel,
+                'non_existant_reconstructable_file.gpml', self.rotations)
+
+        self.assertTrue(self.reconstruct_model.get_anchor_plate_id() == 0)
+
+        reconstruct_model = pygplates.ReconstructModel(self.reconstructable_features, self.rotation_model, anchor_plate_id=1)
+        self.assertTrue(reconstruct_model.get_anchor_plate_id() == 1)
+
+        # Make sure can specify a reconstruct snapshot cache size.
+        reconstruct_model = pygplates.ReconstructModel(self.reconstructable_features, self.rotation_model, reconstruct_snapshot_cache_size=2)
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            reconstruct_model = pygplates.ReconstructModel(
+                FIXTURES / Path('volcanoes.gpml'),
+                FIXTURES / Path('rotations.rot'))
+
+    def test_get_reconstruct_snapshot(self):
+        reconstruct_snapshot = self.reconstruct_model.reconstruct_snapshot(10.5)  # note: it should allow a non-integral time
+        self.assertTrue(reconstruct_snapshot.get_anchor_plate_id() == self.reconstruct_model.get_anchor_plate_id())
+        self.assertTrue(reconstruct_snapshot.get_rotation_model() == self.reconstruct_model.get_rotation_model())
+
+    def test_get_rotation_model(self):
+        reconstruct_model = pygplates.ReconstructModel(self.reconstructable_features, self.rotation_model, anchor_plate_id=2)
+        self.assertTrue(reconstruct_model.get_rotation_model().get_rotation(1.0, 802) == self.rotation_model.get_rotation(1.0, 802, anchor_plate_id=2))
+        self.assertTrue(reconstruct_model.get_rotation_model().get_default_anchor_plate_id() == 2)
+
+        rotation_model_anchor_2 = pygplates.RotationModel(self.rotations, default_anchor_plate_id=2)
+        reconstruct_model = pygplates.ReconstructModel(self.reconstructable_features, rotation_model_anchor_2)
+        self.assertTrue(reconstruct_model.get_anchor_plate_id() == 2)
+        self.assertTrue(reconstruct_model.get_rotation_model().get_default_anchor_plate_id() == 2)
+    
+    def test_pickle(self):
+        # Pickle a ReconstructModel.
+        pickled_reconstruct_model = pickle.loads(pickle.dumps(self.reconstruct_model))
+        self.assertTrue(pickled_reconstruct_model.get_rotation_model().get_rotation(100, 802) ==
+                        self.reconstruct_model.get_rotation_model().get_rotation(100, 802))
+        # Check snapshots of the original and pickled reconstruct models.
+        reconstructed_geometries = self.reconstruct_model.reconstruct_snapshot(10.0).get_reconstructed_geometries(same_order_as_reconstructable_features=True)
+        pickled_reconstructed_geometries = pickled_reconstruct_model.reconstruct_snapshot(10.0).get_reconstructed_geometries(same_order_as_reconstructable_features=True)
+        self.assertTrue(len(pickled_reconstructed_geometries) == len(reconstructed_geometries))
+        for index in range(len(pickled_reconstructed_geometries)):
+            self.assertTrue(pickled_reconstructed_geometries[index].get_reconstructed_geometry() == reconstructed_geometries[index].get_reconstructed_geometry())
+
+
+class ReconstructSnapshotTestCase(unittest.TestCase):
+    def test(self):
+        #
+        # Class pygplates.ReconstructSnapshot is used internally by pygplates.reconstruct()
+        # so most of its testing is already done by testing pygplates.reconstruct().
+        #
+        # Here we're just making sure we can access the pygplates.ReconstructSnapshot methods.
+        #
+        snapshot = pygplates.ReconstructSnapshot(
+            os.path.join(FIXTURES, 'volcanoes.gpml'),
+            os.path.join(FIXTURES, 'rotations.rot'),
+            pygplates.GeoTimeInstant(10),
+            anchor_plate_id=1)
+        self.assertTrue(snapshot.get_anchor_plate_id() == 1)
+        self.assertTrue(snapshot.get_rotation_model())
+        
+        snapshot = pygplates.ReconstructSnapshot(
+            os.path.join(FIXTURES, 'volcanoes.gpml'),
+            os.path.join(FIXTURES, 'rotations.rot'),
+            pygplates.GeoTimeInstant(10))
+        
+        self.assertTrue(snapshot.get_anchor_plate_id() == 0)
+        self.assertTrue(snapshot.get_rotation_model())
+
+        reconstructed_geometries = snapshot.get_reconstructed_geometries()
+        self.assertTrue(len(reconstructed_geometries) == 4)  # See ReconstructTestCase
+        
+        snapshot.export_reconstructed_geometries(os.path.join(FIXTURES, 'reconstructed_geometries.gmt'))
+        self.assertTrue(os.path.isfile(os.path.join(FIXTURES, 'reconstructed_geometries.gmt')))
+        os.remove(os.path.join(FIXTURES, 'reconstructed_geometries.gmt'))
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            snapshot = pygplates.ReconstructSnapshot(
+                FIXTURES / Path('volcanoes.gpml'),
+                FIXTURES / Path('rotations.rot'),
+                pygplates.GeoTimeInstant(10))
+            
+            self.assertTrue(snapshot.get_anchor_plate_id() == 0)
+            self.assertTrue(snapshot.get_rotation_model())
+    
+    def test_get_reconstructed_features(self):
+        # This example matches use of 'group_with_feature' in ReconstructTestCase.
+        reconstruction_time = 15
+        geometry = pygplates.PolylineOnSphere([(0,0), (10, 10)])
+        feature = pygplates.Feature.create_reconstructable_feature(
+                pygplates.FeatureType.create_gpml('Coastline'),
+                geometry,
+                valid_time=(30, 0),
+                reconstruction_plate_id=801)
+        snapshot = pygplates.ReconstructSnapshot(
+                feature,
+                os.path.join(FIXTURES, 'rotations.rot'),
+                reconstruction_time)
+        
+        grouped_reconstructed_feature_geometries = snapshot.get_reconstructed_features()
+        self.assertTrue(len(grouped_reconstructed_feature_geometries) == 1)
+        grouped_feature, reconstructed_feature_geometries = grouped_reconstructed_feature_geometries[0]
+        self.assertTrue(grouped_feature.get_feature_id() == feature.get_feature_id())
+        self.assertTrue(len(reconstructed_feature_geometries) == 1)
+        self.assertTrue(geometry == reconstructed_feature_geometries[0].get_present_day_geometry())
+
+    def test_reconstructed_export_files(self):
+        reconstructable_features = pygplates.FeatureCollection(os.path.join(FIXTURES, 'volcanoes.gpml')) 
+        rotation_model = pygplates.RotationModel(os.path.join(FIXTURES, 'rotations.rot'))
+        snapshot = pygplates.ReconstructSnapshot(
+            reconstructable_features,
+            rotation_model,
+            pygplates.GeoTimeInstant(10))
+        
+        def _internal_test_export_files(
+                test_case,
+                snapshot,
+                tmp_export_reconstructed_geometries_filename):
+            
+            def _remove_export(tmp_export_filename):
+                os.remove(tmp_export_filename)
+
+                # In case an OGR format file (which also has shapefile mapping XML file).
+                if os.path.isfile(tmp_export_filename + '.gplates.xml'):
+                    os.remove(tmp_export_filename + '.gplates.xml')
+                
+                # For Shapefile.
+                if tmp_export_filename.endswith('.shp'):
+                    tmp_export_base_filename = tmp_export_filename[:-len('.shp')]
+                    if os.path.isfile(tmp_export_base_filename + '.dbf'):
+                        os.remove(tmp_export_base_filename + '.dbf')
+                    if os.path.isfile(tmp_export_base_filename + '.prj'):
+                        os.remove(tmp_export_base_filename + '.prj')
+                    if os.path.isfile(tmp_export_base_filename + '.shx'):
+                        os.remove(tmp_export_base_filename + '.shx')
+            
+            tmp_export_reconstructed_geometries_filename = os.path.join(FIXTURES, tmp_export_reconstructed_geometries_filename)
+            snapshot.export_reconstructed_geometries(tmp_export_reconstructed_geometries_filename)
+            test_case.assertTrue(os.path.isfile(tmp_export_reconstructed_geometries_filename))
+
+            # Read back in the exported file to make sure correct number of reconstructed geometries (except cannot read '.xy' files).
+            if not tmp_export_reconstructed_geometries_filename.endswith('.xy'):
+                reconstructed_features = pygplates.FeatureCollection(tmp_export_reconstructed_geometries_filename) 
+                test_case.assertTrue(len(reconstructed_features) == len(snapshot.get_reconstructed_geometries()))
+            
+            _remove_export(tmp_export_reconstructed_geometries_filename)
+        
+        # Test reconstructed export to different format (eg, GMT, OGRGMT, Shapefile, etc).
+        _internal_test_export_files(self, snapshot, 'tmp.xy')  # GMT
+        _internal_test_export_files(self, snapshot, 'tmp.shp')  # Shapefile
+        _internal_test_export_files(self, snapshot, 'tmp.gmt')  # OGRGMT
+        _internal_test_export_files(self, snapshot, 'tmp.geojson')  # GeoJSON
+        _internal_test_export_files(self, snapshot, 'tmp.json')  # GeoJSON
+
+        # Test PathLike file paths (see PEP 519 and https://docs.python.org/3/library/os.html#os.PathLike).
+        # For example, "pathlib.Path" imported with "from pathlib import Path".
+        if sys.version_info >= (3, 6):  # os.PathLike new in Python 3.6
+            from pathlib import Path
+            
+            tmp_export_reconstructed_geometries_filename = FIXTURES / Path('tmp_export_reconstructed_geometries.gmt')
+            snapshot.export_reconstructed_geometries(tmp_export_reconstructed_geometries_filename)
+            self.assertTrue(tmp_export_reconstructed_geometries_filename.exists())
+            tmp_export_reconstructed_geometries_filename.unlink()
+    
+    def test_pickle(self):
+        snapshot = pygplates.ReconstructSnapshot(
+            os.path.join(FIXTURES, 'volcanoes.gpml'),
+            os.path.join(FIXTURES, 'rotations.rot'),
+            pygplates.GeoTimeInstant(10))
+        
+        # Pickle the ReconstructSnapshot.
+        pickled_snapshot = pickle.loads(pickle.dumps(snapshot))
+        self.assertTrue(pickled_snapshot.get_rotation_model().get_rotation(100, 802) == snapshot.get_rotation_model().get_rotation(100, 802))
+        # Check the original and pickled reconstruct snapshots.
+        reconstructed_geometries = snapshot.get_reconstructed_geometries(same_order_as_reconstructable_features=True)
+        pickled_reconstructed_geometries = pickled_snapshot.get_reconstructed_geometries(same_order_as_reconstructable_features=True)
+        self.assertTrue(len(pickled_reconstructed_geometries) == len(reconstructed_geometries))
+        for index in range(len(pickled_reconstructed_geometries)):
+            self.assertTrue(pickled_reconstructed_geometries[index].get_reconstructed_geometry() == reconstructed_geometries[index].get_reconstructed_geometry())
+
+
 class ReconstructTestCase(unittest.TestCase):
     def test_reconstruct(self):
         pygplates.reconstruct(
@@ -1970,7 +2169,7 @@ class ReconstructionTreeCase(unittest.TestCase):
                 from_reconstruction_tree, self.reconstruction_tree, 10000, 291, use_identity_for_missing_plate_ids=False))
 
 
-class RotationModelCase(unittest.TestCase):
+class RotationModelTestCase(unittest.TestCase):
     def setUp(self):
         self.rotations = pygplates.FeatureCollectionFileFormatRegistry().read(
                 os.path.join(FIXTURES, 'rotations.rot'))
@@ -2170,7 +2369,7 @@ class RotationModelCase(unittest.TestCase):
                         rotation_model_non_zero_default_anchor.get_rotation(self.to_time, 802))
 
 
-class StrainCase(unittest.TestCase):
+class StrainTestCase(unittest.TestCase):
 
     def test_create(self):
         self.assertTrue(pygplates.StrainRate().get_velocity_spatial_gradient() == (0, 0, 0, 0))
@@ -2272,7 +2471,7 @@ class StrainCase(unittest.TestCase):
         self.assertTrue(pickled_strain == strain)
 
 
-class TopologicalModelCase(unittest.TestCase):
+class TopologicalModelTestCase(unittest.TestCase):
     def setUp(self):
         self.rotations = pygplates.FeatureCollection(os.path.join(FIXTURES, 'rotations.rot'))
         self.rotation_model = pygplates.RotationModel(self.rotations)
@@ -2608,7 +2807,7 @@ class TopologicalModelCase(unittest.TestCase):
                             pickled_located_in_resolved_network.get_resolved_geometry() == located_in_resolved_network.get_resolved_geometry())
 
 
-class TopologicalSnapshotCase(unittest.TestCase):
+class TopologicalSnapshotTestCase(unittest.TestCase):
     def test(self):
         #
         # Class pygplates.TopologicalSnapshot is used internally by pygplates.resolved_topologies()
@@ -2616,6 +2815,15 @@ class TopologicalSnapshotCase(unittest.TestCase):
         #
         # Here we're just making sure we can access the pygplates.TopologicalSnapshot methods.
         #
+        snapshot = pygplates.TopologicalSnapshot(
+            os.path.join(FIXTURES, 'topologies.gpml'),
+            os.path.join(FIXTURES, 'rotations.rot'),
+            pygplates.GeoTimeInstant(10),
+            anchor_plate_id=1)
+        
+        self.assertTrue(snapshot.get_anchor_plate_id() == 1)
+        self.assertTrue(snapshot.get_rotation_model())
+        
         snapshot = pygplates.TopologicalSnapshot(
             os.path.join(FIXTURES, 'topologies.gpml'),
             os.path.join(FIXTURES, 'rotations.rot'),
@@ -2858,13 +3066,15 @@ def suite():
             InterpolateTotalReconstructionSequenceTestCase,
             NetRotationTestCase,
             PlatePartitionerTestCase,
+            ReconstructModelTestCase,
+            ReconstructSnapshotTestCase,
             ReconstructTestCase,
             ReconstructionTreeCase,
             ResolvedTopologiesTestCase,
-            RotationModelCase,
-            StrainCase,
-            TopologicalModelCase,
-            TopologicalSnapshotCase
+            RotationModelTestCase,
+            StrainTestCase,
+            TopologicalModelTestCase,
+            TopologicalSnapshotTestCase
         ]
 
     for test_case in test_cases:

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -69,10 +69,14 @@ set(srcs
     PyQualifiedXmlNames.h
     PyReal.cc
     PyReconstruct.cc
+    PyReconstructModel.cc
+    PyReconstructModel.h
     PyReconstructionGeometries.cc
     PyReconstructionGeometries.h
     PyReconstructionTree.cc
     PyReconstructionTree.h
+    PyReconstructSnapshot.cc
+    PyReconstructSnapshot.h
     PyResolveTopologies.cc
     PyResolveTopologyParameters.h
     PyResolveTopologyParameters.cc

--- a/src/api/PyGPlatesModule.cc
+++ b/src/api/PyGPlatesModule.cc
@@ -87,6 +87,8 @@ void export_strain();
 void export_net_rotation();
 void export_plate_partitioner();
 void export_reconstruct();
+void export_reconstruct_model();
+void export_reconstruct_snapshot();
 void export_reconstruction_geometries();
 void export_reconstruction_tree();
 void export_resolve_topologies();
@@ -203,6 +205,8 @@ export_cpp_python_api()
 	export_strain();
 	export_plate_partitioner();
 	export_reconstruct();
+	export_reconstruct_model();
+	export_reconstruct_snapshot();
 	export_reconstruction_geometries();
 	export_reconstruction_tree();
 	export_resolve_topologies();

--- a/src/api/PyReconstruct.cc
+++ b/src/api/PyReconstruct.cc
@@ -751,8 +751,9 @@ export_reconstruct()
 			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n"
 			"\n"
 			"  .. versionchanged:: 0.48\n"
-			"     | Added *export_force_boundary_orientation* argument.\n"
-			"     | *ReconstructType.feature_geometry*, *ReconstructType.motion_path* and *ReconstructType.flowline* have different underlying bit values.\n";
+			"\n"
+			"     * Added *export_force_boundary_orientation* argument.\n"
+			"     * Changed underlying bit values for *ReconstructType.feature_geometry*, *ReconstructType.motion_path* and *ReconstructType.flowline*.\n";
 
 	// Register 'reconstructed feature geometries' variant.
 	GPlatesApi::PythonConverterUtils::register_variant_conversion<

--- a/src/api/PyReconstruct.cc
+++ b/src/api/PyReconstruct.cc
@@ -558,7 +558,7 @@ export_reconstruct()
 	bp::scope().attr(reconstruct_function_name).attr("__doc__") =
 			"reconstruct(reconstructable_features, rotation_model, reconstructed_geometries, "
 			"reconstruction_time, [anchor_plate_id], [**output_parameters])\n"
-			"  Reconstruct regular geological features, motion paths or flowlines to a specific geological time.\n"
+			"  Reconstruct regular geological features (including motion paths and flowlines) to a specific geological time.\n"
 			"\n"
 			"  :param reconstructable_features: the features to reconstruct as a feature collection, or filename, or "
 			"feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) of any "
@@ -745,6 +745,8 @@ export_reconstruct()
 			"    reconstructed_feature_geometries = []\n"
             "    pygplates.reconstruct(feature, rotation_model, reconstructed_feature_geometries, 10)\n"
 			"    # assert(reconstructed_feature_geometries[0].get_feature().get_feature_id() == feature.get_feature_id())\n"
+			"\n"
+			"  .. seealso:: :class:`ReconstructModel` and :class:`ReconstructSnapshot`\n"
 			"\n"
 			"  .. versionchanged:: 0.44\n"
 			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "

--- a/src/api/PyReconstruct.cc
+++ b/src/api/PyReconstruct.cc
@@ -38,6 +38,7 @@
 
 #include "PyFeatureCollectionFunctionArgument.h"
 #include "PyFilePathFunctionArgument.h"
+#include "PyReconstructSnapshot.h"
 #include "PyRotationModel.h"
 #include "PythonConverterUtils.h"
 #include "PythonUtils.h"
@@ -45,21 +46,15 @@
 
 #include "app-logic/ReconstructedFeatureGeometry.h"
 #include "app-logic/ReconstructedFlowline.h"
-#include "app-logic/ReconstructedMotionPath.h"
-#include "app-logic/ReconstructHandle.h"
 #include "app-logic/ReconstructionGeometryUtils.h"
 #include "app-logic/ReconstructMethodInterface.h"
 #include "app-logic/ReconstructMethodRegistry.h"
+#include "app-logic/ReconstructedMotionPath.h"
 
 #include "feature-visitors/GeometrySetter.h"
 
 #include "file-io/FeatureCollectionFileFormatRegistry.h"
 #include "file-io/File.h"
-#include "file-io/ReadErrorAccumulation.h"
-#include "file-io/ReconstructedFeatureGeometryExport.h"
-#include "file-io/ReconstructedFlowlineExport.h"
-#include "file-io/ReconstructedMotionPathExport.h"
-#include "file-io/ReconstructionGeometryExportImpl.h"
 
 // This is not included by <boost/python.hpp>.
 // Also we must include this after <boost/python.hpp> which means after "global/python.h".
@@ -80,26 +75,12 @@ namespace GPlatesApi
 	namespace
 	{
 		/**
-		 * Enumeration to determine which reconstructed feature geometry types to output.
-		 */
-		namespace ReconstructType
-		{
-			enum Value
-			{
-				FEATURE_GEOMETRY,
-				MOTION_PATH,
-				FLOWLINE
-			};
-		};
-
-
-		/**
-		 * The argument types for 'reconstructed feature geometries'.
+		 * The argument types for 'reconstructed geometries'.
 		 */
 		typedef boost::variant<
 				FilePathFunctionArgument,  // export filename
 				bp::list> // list of ReconstructedFeatureGeometry's
-						reconstructed_feature_geometries_argument_type;
+						reconstructed_geometries_argument_type;
 
 
 		/**
@@ -116,9 +97,9 @@ namespace GPlatesApi
 		get_deprecated_reconstruct_args(
 				bp::tuple positional_args,
 				bp::dict keyword_args,
-				std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
-				boost::optional<RotationModel::non_null_ptr_type> &rotation_model,
-				reconstructed_feature_geometries_argument_type &reconstructed_feature_geometries,
+				boost::optional<FeatureCollectionSequenceFunctionArgument> &reconstructable_features,
+				boost::optional<RotationModelFunctionArgument> &rotation_model,
+				reconstructed_geometries_argument_type &reconstructed_geometries,
 				GPlatesPropertyValues::GeoTimeInstant &reconstruction_time,
 				boost::optional<GPlatesModel::integer_plate_id_type> &anchor_plate_id)
 		{
@@ -169,11 +150,11 @@ namespace GPlatesApi
 							boost::none/*unused_positional_args*/,
 							boost::none/*unused_keyword_args*/);
 
-			boost::get<0>(reconstruct_args).get_files(reconstructable_files);
-			rotation_model = boost::get<1>(reconstruct_args).get_rotation_model();
+			reconstructable_features = boost::get<0>(reconstruct_args);
+			rotation_model = boost::get<1>(reconstruct_args);
 			reconstruction_time = GPlatesPropertyValues::GeoTimeInstant(boost::get<2>(reconstruct_args));
 			anchor_plate_id = boost::get<3>(reconstruct_args);
-			reconstructed_feature_geometries = boost::get<4>(reconstruct_args);
+			reconstructed_geometries = boost::get<4>(reconstruct_args);
 
 			return true;
 		}
@@ -186,22 +167,23 @@ namespace GPlatesApi
 		get_reconstruct_args(
 				bp::tuple positional_args,
 				bp::dict keyword_args,
-				std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
-				boost::optional<RotationModel::non_null_ptr_type> &rotation_model,
-				reconstructed_feature_geometries_argument_type &reconstructed_feature_geometries,
+				boost::optional<FeatureCollectionSequenceFunctionArgument> &reconstructable_features,
+				boost::optional<RotationModelFunctionArgument> &rotation_model,
+				reconstructed_geometries_argument_type &reconstructed_geometries,
 				GPlatesPropertyValues::GeoTimeInstant &reconstruction_time,
 				boost::optional<GPlatesModel::integer_plate_id_type> &anchor_plate_id,
 				ReconstructType::Value &reconstruct_type,
 				bool &export_wrap_to_dateline,
-				bool &group_with_feature)
+				bool &group_with_feature,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> &export_force_boundary_orientation)
 		{
 			// First attempt to get arguments from deprecated version of 'reconstruct()'.
 			if (get_deprecated_reconstruct_args(
 					positional_args,
 					keyword_args,
-					reconstructable_files,
+					reconstructable_features,
 					rotation_model,
-					reconstructed_feature_geometries,
+					reconstructed_geometries,
 					reconstruction_time,
 					anchor_plate_id))
 			{
@@ -211,6 +193,7 @@ namespace GPlatesApi
 				reconstruct_type = ReconstructType::FEATURE_GEOMETRY;
 				export_wrap_to_dateline = true;
 				group_with_feature = false;
+				export_force_boundary_orientation = boost::none;
 
 				return;
 			}
@@ -228,7 +211,7 @@ namespace GPlatesApi
 			typedef boost::tuple<
 					FeatureCollectionSequenceFunctionArgument,
 					RotationModelFunctionArgument,
-					reconstructed_feature_geometries_argument_type,
+					reconstructed_geometries_argument_type,
 					GPlatesPropertyValues::GeoTimeInstant,
 					boost::optional<GPlatesModel::integer_plate_id_type>>
 							reconstruct_args_type;
@@ -255,9 +238,9 @@ namespace GPlatesApi
 							boost::none/*unused_positional_args*/,
 							unused_keyword_args);
 
-			boost::get<0>(reconstruct_args).get_files(reconstructable_files);
-			rotation_model = boost::get<1>(reconstruct_args).get_rotation_model();
-			reconstructed_feature_geometries = boost::get<2>(reconstruct_args);
+			reconstructable_features = boost::get<0>(reconstruct_args);
+			rotation_model = boost::get<1>(reconstruct_args);
+			reconstructed_geometries = boost::get<2>(reconstruct_args);
 			reconstruction_time = boost::get<3>(reconstruct_args);
 			anchor_plate_id = boost::get<4>(reconstruct_args);
 
@@ -283,266 +266,16 @@ namespace GPlatesApi
 							"group_with_feature",
 							false);
 
+			export_force_boundary_orientation =
+					VariableArguments::extract_and_remove_or_default<
+									boost::optional<GPlatesMaths::PolygonOrientation::Orientation> >(
+							unused_keyword_args,
+							"export_force_boundary_orientation",
+							boost::none);
+
 			// Raise a python error if there are any unused keyword arguments remaining.
 			// These will be keywords that we didn't recognise.
 			VariableArguments::raise_python_error_if_unused(unused_keyword_args);
-		}
-
-
-		void
-		export_reconstructed_feature_geometries(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &rfgs,
-				const QString &export_file_name,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
-				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
-				const double &reconstruction_time,
-				bool export_wrap_to_dateline)
-		{
-			// Converts to raw pointers.
-			std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_feature_geometries;
-			reconstructed_feature_geometries.reserve(rfgs.size());
-			BOOST_FOREACH(
-					const GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type &rfg,
-					rfgs)
-			{
-				reconstructed_feature_geometries.push_back(rfg.get());
-			}
-
-			GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
-			const GPlatesFileIO::ReconstructedFeatureGeometryExport::Format format =
-					GPlatesFileIO::ReconstructedFeatureGeometryExport::get_export_file_format(
-							export_file_name,
-							file_format_registry);
-
-			// The API docs state that dateline wrapping should be ignored except for Shapefile.
-			//
-			// For example, we don't want to pollute real-world data with dateline vertices when
-			// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
-			if (format != GPlatesFileIO::ReconstructedFeatureGeometryExport::SHAPEFILE)
-			{
-				export_wrap_to_dateline = false;
-			}
-
-			// Export the reconstructed feature geometries.
-			GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_geometries(
-						export_file_name,
-						format,
-						reconstructed_feature_geometries,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						anchor_plate_id,
-						reconstruction_time,
-						// If exporting to Shapefile and there's only *one* input reconstructable file then
-						// shapefile attributes in input reconstructable file will get copied to output...
-						true/*export_single_output_file*/,
-						false/*export_per_input_file*/, // We only generate a single output file.
-						false/*export_output_directory_per_input_file*/, // We only generate a single output file.
-						export_wrap_to_dateline);
-		}
-
-
-		void
-		export_reconstructed_motion_paths(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &rfgs,
-				const QString &export_file_name,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
-				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
-				const double &reconstruction_time,
-				bool export_wrap_to_dateline)
-		{
-			// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedMotionPath.
-			//
-			// Note that, when motion paths are reconstructed, both ReconstructedMotionPath's and
-			// ReconstructedFeatureGeometry's are generated - so this also ensures that the
-			// ReconstructedFeatureGeometry's are ignored when outputting reconstructed motion paths.
-			std::vector<const GPlatesAppLogic::ReconstructedMotionPath *> reconstructed_motion_paths;
-			GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
-					rfgs.begin(),
-					rfgs.end(),
-					reconstructed_motion_paths);
-
-			GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
-			const GPlatesFileIO::ReconstructedMotionPathExport::Format format =
-					GPlatesFileIO::ReconstructedMotionPathExport::get_export_file_format(
-							export_file_name,
-							file_format_registry);
-
-			// The API docs state that dateline wrapping should be ignored except for Shapefile.
-			//
-			// For example, we don't want to pollute real-world data with dateline vertices when
-			// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
-			if (format != GPlatesFileIO::ReconstructedMotionPathExport::SHAPEFILE)
-			{
-				export_wrap_to_dateline = false;
-			}
-
-			// Export the reconstructed motion paths.
-			GPlatesFileIO::ReconstructedMotionPathExport::export_reconstructed_motion_paths(
-						export_file_name,
-						format,
-						reconstructed_motion_paths,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						anchor_plate_id,
-						reconstruction_time,
-						true/*export_single_output_file*/,
-						false/*export_per_input_file*/, // We only generate a single output file.
-						false/*export_output_directory_per_input_file*/, // We only generate a single output file.
-						export_wrap_to_dateline);
-		}
-
-
-		void
-		export_reconstructed_flowlines(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &rfgs,
-				const QString &export_file_name,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
-				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
-				const double &reconstruction_time,
-				bool export_wrap_to_dateline)
-		{
-			// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedFlowline.
-			// In fact they should all be ReconstructedFlowlines.
-			std::vector<const GPlatesAppLogic::ReconstructedFlowline *> reconstructed_flowlines;
-			GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
-					rfgs.begin(),
-					rfgs.end(),
-					reconstructed_flowlines);
-
-			GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
-			const GPlatesFileIO::ReconstructedFlowlineExport::Format format =
-					GPlatesFileIO::ReconstructedFlowlineExport::get_export_file_format(
-							export_file_name,
-							file_format_registry);
-
-			// The API docs state that dateline wrapping should be ignored except for Shapefile.
-			//
-			// For example, we don't want to pollute real-world data with dateline vertices when
-			// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
-			if (format != GPlatesFileIO::ReconstructedFlowlineExport::SHAPEFILE)
-			{
-				export_wrap_to_dateline = false;
-			}
-
-			// Export the reconstructed flowlines.
-			GPlatesFileIO::ReconstructedFlowlineExport::export_reconstructed_flowlines(
-						export_file_name,
-						format,
-						reconstructed_flowlines,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						anchor_plate_id,
-						reconstruction_time,
-						true/*export_single_output_file*/,
-						false/*export_per_input_file*/, // We only generate a single output file.
-						false/*export_output_directory_per_input_file*/, // We only generate a single output file.
-						export_wrap_to_dateline);
-		}
-
-
-		/**
-		 * Append the reconstruction geometries, as type 'ReconstructionGeometryType', to the
-		 * python list @a output_reconstruction_geometries_list.
-		 *
-		 * If @a group_with_feature is true then @a output_reconstruction_geometries_list contains
-		 * tuples of (feature, list of reconstruction geometries).
-		 */
-		template <class ReconstructionGeometryType>
-		void
-		output_reconstruction_geometries(
-				bp::list &output_reconstruction_geometries_list,
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &rfgs,
-				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
-				bool group_with_feature)
-		{
-			// Get any ReconstructedFeatureGeometry objects that are of type ReconstructionGeometryType.
-			//
-			// Note that, when motion paths are reconstructed, both ReconstructedMotionPath's and
-			// ReconstructedFeatureGeometry's are generated - so this also ensures that the
-			// ReconstructedFeatureGeometry's are ignored when outputting reconstructed motion paths.
-			std::vector<const ReconstructionGeometryType *> reconstruction_geometries;
-			GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
-					rfgs.begin(),
-					rfgs.end(),
-					reconstruction_geometries);
-
-			//
-			// Order the reconstruction geometries according to the order of the features in the feature collections.
-			//
-
-			// Get the list of active reconstructable feature collection files that contain
-			// the features referenced by the ReconstructionGeometry objects.
-			GPlatesFileIO::ReconstructionGeometryExportImpl::feature_handle_to_collection_map_type feature_to_collection_map;
-			GPlatesFileIO::ReconstructionGeometryExportImpl::populate_feature_handle_to_collection_map(
-					feature_to_collection_map,
-					reconstructable_file_ptrs);
-
-			// Group the ReconstructionGeometry objects by their feature.
-			typedef GPlatesFileIO::ReconstructionGeometryExportImpl::FeatureGeometryGroup<
-					ReconstructionGeometryType> feature_geometry_group_type;
-			std::list<feature_geometry_group_type> grouped_recon_geoms_seq;
-			GPlatesFileIO::ReconstructionGeometryExportImpl::group_reconstruction_geometries_with_their_feature(
-					grouped_recon_geoms_seq,
-					reconstruction_geometries,
-					feature_to_collection_map);
-
-			//
-			// Append the ordered RFG's to the output list.
-			//
-
-			typename std::list<feature_geometry_group_type>::const_iterator feature_iter;
-			for (feature_iter = grouped_recon_geoms_seq.begin();
-				feature_iter != grouped_recon_geoms_seq.end();
-				++feature_iter)
-			{
-				const feature_geometry_group_type &feature_geom_group = *feature_iter;
-
-				const GPlatesModel::FeatureHandle::const_weak_ref &feature_ref =
-						feature_geom_group.feature_ref;
-				if (!feature_ref.is_valid())
-				{
-					continue;
-				}
-
-				// Group reconstruction geometries with their feature if requested.
-				boost::optional<bp::list> feature_reconstruction_geometries_list;
-				if (group_with_feature)
-				{
-					// Create a Python feature.
-					bp::object feature_object(
-							GPlatesModel::FeatureHandle::non_null_ptr_to_const_type(feature_ref.handle_ptr()));
-					// Create a Python list (of reconstruction geometries).
-					feature_reconstruction_geometries_list = bp::list();
-
-					// Add a tuple containing the feature and its list of reconstruction geometries.
-					output_reconstruction_geometries_list.append(
-							bp::make_tuple(
-									feature_object,
-									feature_reconstruction_geometries_list.get()));
-				}
-
-				// Iterate through the reconstruction geometries of the current feature and write to output.
-				typename std::vector<const ReconstructionGeometryType *>::const_iterator rg_iter;
-				for (rg_iter = feature_geom_group.recon_geoms.begin();
-					rg_iter != feature_geom_group.recon_geoms.end();
-					++rg_iter)
-				{
-					const typename ReconstructionGeometryType::non_null_ptr_to_const_type rg(*rg_iter);
-
-					// Add the reconstruction geometry to python list.
-					if (group_with_feature)
-					{
-						feature_reconstruction_geometries_list->append(rg);
-					}
-					else
-					{
-						output_reconstruction_geometries_list.append(rg);
-					}
-				}
-			}
 		}
 	}
 
@@ -565,26 +298,28 @@ namespace GPlatesApi
 		// Get the explicit function arguments from the variable argument list.
 		//
 
-		std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstructable_files;
-		boost::optional<RotationModel::non_null_ptr_type> rotation_model;
-		reconstructed_feature_geometries_argument_type reconstructed_feature_geometries_argument;
+		boost::optional<FeatureCollectionSequenceFunctionArgument> reconstructable_features_argument;
+		boost::optional<RotationModelFunctionArgument> rotation_model_argument;
+		reconstructed_geometries_argument_type reconstructed_geometries_argument;
 		GPlatesPropertyValues::GeoTimeInstant reconstruction_time(0);
 		boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id;
 		ReconstructType::Value reconstruct_type;
 		bool export_wrap_to_dateline;
 		bool group_with_feature;
+		boost::optional<GPlatesMaths::PolygonOrientation::Orientation> export_force_boundary_orientation;
 
 		get_reconstruct_args(
 				positional_args,
 				keyword_args,
-				reconstructable_files,
-				rotation_model,
-				reconstructed_feature_geometries_argument,
+				reconstructable_features_argument,
+				rotation_model_argument,
+				reconstructed_geometries_argument,
 				reconstruction_time,
 				anchor_plate_id,
 				reconstruct_type,
 				export_wrap_to_dateline,
-				group_with_feature);
+				group_with_feature,
+				export_force_boundary_orientation);
 
 		// Time must not be distant past/future.
 		if (!reconstruction_time.is_real())
@@ -594,210 +329,82 @@ namespace GPlatesApi
 			bp::throw_error_already_set();
 		}
 
-		//
-		// Reconstruct the features in the feature collection files.
-		//
-
-		// Adapt the reconstruction tree creator to a new one that has 'anchor_plate_id' as its default
-		// (which if none, then uses default anchor plate of 'rotation_model' instead).
-		// This ensures 'ReconstructMethodInterface' will reconstruct using the correct anchor plate.
-		GPlatesAppLogic::ReconstructionTreeCreator reconstruction_tree_creator =
-				GPlatesAppLogic::create_cached_reconstruction_tree_adaptor(
-						rotation_model.get()->get_reconstruction_tree_creator(),
-						anchor_plate_id);
-
-		// Create the context state in which to reconstruct.
-		const GPlatesAppLogic::ReconstructMethodInterface::Context reconstruct_method_context(
-				GPlatesAppLogic::ReconstructParams(),
-				reconstruction_tree_creator);
-
-		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> rfgs;
-		GPlatesAppLogic::ReconstructMethodRegistry reconstruct_method_registry;
-
-		// Get the next global reconstruct handle - it'll be stored in each RFG.
-		// It doesn't actually matter in our case though.
-		const GPlatesAppLogic::ReconstructHandle::type reconstruct_handle =
-				GPlatesAppLogic::ReconstructHandle::get_next_reconstruct_handle();
-
-		// Iterate over the files and reconstruct their features.
-		BOOST_FOREACH(GPlatesFileIO::File::non_null_ptr_type reconstruct_file, reconstructable_files)
+		// Reconstruct type must correspond to one of the existing flags.
+		if ((reconstruct_type & ~ReconstructType::ALL_RECONSTRUCT_TYPES) != 0)
 		{
-			const GPlatesModel::FeatureCollectionHandle::weak_ref feature_collection_ref =
-					reconstruct_file->get_reference().get_feature_collection();
-
-			// Iterate over the features in the current file's feature collection.
-			GPlatesModel::FeatureCollectionHandle::iterator features_iter = feature_collection_ref->begin();
-			GPlatesModel::FeatureCollectionHandle::iterator features_end = feature_collection_ref->end();
-			for ( ; features_iter != features_end; ++features_iter)
-			{
-				const GPlatesModel::FeatureHandle::weak_ref feature_ref = (*features_iter)->reference();
-
-				// Determine what type of reconstructed output the current feature will produce (if any).
-				boost::optional<GPlatesAppLogic::ReconstructMethod::Type> reconstruct_method_type =
-						reconstruct_method_registry.get_reconstruct_method_type(feature_ref);
-				if (!reconstruct_method_type)
-				{
-					continue;
-				}
-
-				// Check that the reconstructed type matches that requested by the caller.
-				switch (reconstruct_type)
-				{
-				case ReconstructType::FEATURE_GEOMETRY:
-					// Skip flowlines and motion paths.
-					if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::FLOWLINE ||
-						reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::MOTION_PATH)
-					{
-						continue;
-					}
-					break;
-
-				case ReconstructType::MOTION_PATH:
-					// Skip anything but motion paths.
-					if (reconstruct_method_type.get() != GPlatesAppLogic::ReconstructMethod::MOTION_PATH)
-					{
-						continue;
-					}
-					break;
-
-				case ReconstructType::FLOWLINE:
-					// Skip anything but flowlines.
-					if (reconstruct_method_type.get() != GPlatesAppLogic::ReconstructMethod::FLOWLINE)
-					{
-						continue;
-					}
-					break;
-
-				default:
-					GPlatesGlobal::Abort(GPLATES_ASSERTION_SOURCE);
-					break;
-				}
-
-				GPlatesAppLogic::ReconstructMethodInterface::non_null_ptr_type reconstruct_method =
-						reconstruct_method_registry.create_reconstruct_method(
-								reconstruct_method_type.get(),
-								feature_ref,
-								reconstruct_method_context);
-
-				// Reconstruct the current feature and append the reconstructed feature geoms to 'rfgs'.
-				reconstruct_method->reconstruct_feature_geometries(
-						rfgs,
-						reconstruct_handle,
-						reconstruct_method_context,
-						reconstruction_time.value());
-			}
+			PyErr_SetString(PyExc_ValueError, "Unknown reconstruct type.");
+			bp::throw_error_already_set();
 		}
+
+		//
+		// Reconstruct the features (as a reconstruct snapshot).
+		//
+
+		ReconstructSnapshot::non_null_ptr_type reconstruct_snapshot = ReconstructSnapshot::create(
+				reconstructable_features_argument.get(),
+				rotation_model_argument.get(),
+				reconstruction_time.value(),
+				anchor_plate_id);
 
 		//
 		// Either export the reconstructed geometries to a file or append them to a python list.
 		//
-		// NOTE: In both cases the reconstructed geometries are output in the same order as that of their
-		// respective features with each feature collection (and the order across feature collections).
-		//
 
-		if (const FilePathFunctionArgument *export_file_path = boost::get<FilePathFunctionArgument>(&reconstructed_feature_geometries_argument))
+		if (const FilePathFunctionArgument *reconstructed_geometries_export_file_name =
+			boost::get<FilePathFunctionArgument>(&reconstructed_geometries_argument))
 		{
-			const QString export_file_name = export_file_path->get_file_path();
-
-			// Get the sequence of reconstructable files as File pointers.
-			std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
-			BOOST_FOREACH(GPlatesFileIO::File::non_null_ptr_type reconstructable_file, reconstructable_files)
-			{
-				reconstructable_file_ptrs.push_back(&reconstructable_file->get_reference());
-			}
-
-			// Get the sequence of reconstruction files (if any) from the rotation model.
-			std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstruction_files;
-			rotation_model.get()->get_files(reconstruction_files);
-			std::vector<const GPlatesFileIO::File::Reference *> reconstruction_file_ptrs;
-			BOOST_FOREACH(GPlatesFileIO::File::non_null_ptr_type reconstruction_file, reconstruction_files)
-			{
-				reconstruction_file_ptrs.push_back(&reconstruction_file->get_reference());
-			}
-
-			// Export based on the reconstructed type requested by the caller.
-			switch (reconstruct_type)
-			{
-			case ReconstructType::FEATURE_GEOMETRY:
-				export_reconstructed_feature_geometries(
-						rfgs,
-						export_file_name,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						reconstruction_tree_creator.get_default_anchor_plate_id(),
-						reconstruction_time.value(),
-						export_wrap_to_dateline);
-				break;
-
-			case ReconstructType::MOTION_PATH:
-				export_reconstructed_motion_paths(
-						rfgs,
-						export_file_name,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						reconstruction_tree_creator.get_default_anchor_plate_id(),
-						reconstruction_time.value(),
-						export_wrap_to_dateline);
-				break;
-
-			case ReconstructType::FLOWLINE:
-				export_reconstructed_flowlines(
-						rfgs,
-						export_file_name,
-						reconstructable_file_ptrs,
-						reconstruction_file_ptrs,
-						reconstruction_tree_creator.get_default_anchor_plate_id(),
-						reconstruction_time.value(),
-						export_wrap_to_dateline);
-				break;
-
-			default:
-				GPlatesGlobal::Abort(GPLATES_ASSERTION_SOURCE);
-				break;
-			}
+			// Export reconstructed geometries.
+			reconstruct_snapshot->export_reconstructed_geometries(
+					*reconstructed_geometries_export_file_name,
+					reconstruct_type,
+					export_wrap_to_dateline,
+					export_force_boundary_orientation);
 		}
-		else // list of ReconstructedFeatureGeometry's...
+		else // list of reconstructed geometries...
 		{
-			bp::list output_reconstruction_geometries_list =
-					boost::get<bp::list>(reconstructed_feature_geometries_argument);
+			// Group the reconstructed geometries by their feature.
+			//
+			// Note: The features are sorted in the order of the features in the reconstructable files (and the order across files).
+			const std::list<ReconstructSnapshot::feature_geometry_group_type> reconstructed_features =
+					reconstruct_snapshot->get_reconstructed_features(reconstruct_type);
 
-			// Get the sequence of reconstructable files as File pointers.
-			std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
-			BOOST_FOREACH(GPlatesFileIO::File::non_null_ptr_type reconstructable_file, reconstructable_files)
+			if (group_with_feature)
 			{
-				reconstructable_file_ptrs.push_back(&reconstructable_file->get_reference());
+				// The caller's Python list.
+				bp::list output_reconstructed_features_list = boost::get<bp::list>(reconstructed_geometries_argument);
+
+				// Output the reconstructed geometries of each feature.
+				for (const auto &reconstructed_feature : reconstructed_features)
+				{
+					// Create a Python feature.
+					bp::object feature_object(
+							GPlatesModel::FeatureHandle::non_null_ptr_to_const_type(
+									reconstructed_feature.feature_ref.handle_ptr()));
+
+					// Python list of reconstructed geometries of the current feature.
+					bp::list reconstructed_geometries_list;
+					for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
+					{
+						reconstructed_geometries_list.append(reconstructed_geometry->get_non_null_pointer_to_const());
+					}
+
+					output_reconstructed_features_list.append(
+							bp::make_tuple(feature_object, reconstructed_geometries_list));
+				}
 			}
-
-			// Output based on the reconstructed type requested by the caller.
-			switch (reconstruct_type)
+			else
 			{
-			case ReconstructType::FEATURE_GEOMETRY:
-				output_reconstruction_geometries<GPlatesAppLogic::ReconstructedFeatureGeometry>(
-						output_reconstruction_geometries_list,
-						rfgs,
-						reconstructable_file_ptrs,
-						group_with_feature);
-				break;
+				// The caller's Python list.
+				bp::list output_reconstructed_geometries_list = boost::get<bp::list>(reconstructed_geometries_argument);
 
-			case ReconstructType::MOTION_PATH:
-				output_reconstruction_geometries<GPlatesAppLogic::ReconstructedMotionPath>(
-						output_reconstruction_geometries_list,
-						rfgs,
-						reconstructable_file_ptrs,
-						group_with_feature);
-				break;
-
-			case ReconstructType::FLOWLINE:
-				output_reconstruction_geometries<GPlatesAppLogic::ReconstructedFlowline>(
-						output_reconstruction_geometries_list,
-						rfgs,
-						reconstructable_file_ptrs,
-						group_with_feature);
-				break;
-
-			default:
-				GPlatesGlobal::Abort(GPLATES_ASSERTION_SOURCE);
-				break;
+				// Output the reconstructed geometries of each feature.
+				for (const auto &reconstructed_feature : reconstructed_features)
+				{
+					for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
+					{
+						output_reconstructed_geometries_list.append(reconstructed_geometry->get_non_null_pointer_to_const());
+					}
+				}
 			}
 		}
 
@@ -942,12 +549,6 @@ namespace GPlatesApi
 void
 export_reconstruct()
 {
-	// An enumeration nested within 'pygplates' (ie, current) module.
-	bp::enum_<GPlatesApi::ReconstructType::Value>("ReconstructType")
-			.value("feature_geometry", GPlatesApi::ReconstructType::FEATURE_GEOMETRY)
-			.value("motion_path", GPlatesApi::ReconstructType::MOTION_PATH)
-			.value("flowline", GPlatesApi::ReconstructType::FLOWLINE);
-
 	const char *reconstruct_function_name = "reconstruct";
 	bp::def(reconstruct_function_name, bp::raw_function(&GPlatesApi::reconstruct));
 
@@ -995,36 +596,47 @@ export_reconstruct()
 			"\n"
 			"  The following optional keyword arguments are supported by *output_parameters*:\n"
 			"\n"
-			"  +-------------------------+-----------------+----------------------------------+---------------------------------------------------------------------------+\n"
-			"  | Name                    | Type            | Default                          | Description                                                               |\n"
-			"  +=========================+=================+==================================+===========================================================================+\n"
-			"  | reconstruct_type        | ReconstructType | ReconstructType.feature_geometry | - *ReconstructType.feature_geometry*:                                     |\n"
-			"  |                         |                 |                                  |   only reconstruct regular features (not motion paths or                  |\n"
-			"  |                         |                 |                                  |   flowlines), this generates                                              |\n"
-			"  |                         |                 |                                  |   :class:`reconstructed feature geometries<ReconstructedFeatureGeometry>` |\n"
-			"  |                         |                 |                                  | - *ReconstructType.motion_path*:                                          |\n"
-			"  |                         |                 |                                  |   only reconstruct motion path features, this generates                   |\n"
-			"  |                         |                 |                                  |   :class:`reconstructed motion paths<ReconstructedMotionPath>`            |\n"
-			"  |                         |                 |                                  | - *ReconstructType.flowline*:                                             |\n"
-			"  |                         |                 |                                  |   only reconstruct flowline features, this generates                      |\n"
-			"  |                         |                 |                                  |   :class:`reconstructed flowlines<ReconstructedFlowline>`                 |\n"
-			"  +-------------------------+-----------------+----------------------------------+---------------------------------------------------------------------------+\n"
-			"  | group_with_feature      | bool            | False                            | | Group reconstructed geometries with their feature.                      |\n"
-			"  |                         |                 |                                  | | This can be useful when a feature has more than one geometry and hence  |\n"
-			"  |                         |                 |                                  |   more than one reconstructed geometry.                                   |\n"
-			"  |                         |                 |                                  | | *reconstructed_geometries* then becomes a list of tuples where each     |\n"
-			"  |                         |                 |                                  |   tuple contains a :class:`feature<Feature>` and a ``list`` of            |\n"
-			"  |                         |                 |                                  |   reconstructed geometries.                                               |\n"
-			"  |                         |                 |                                  |                                                                           |\n"
-			"  |                         |                 |                                  | .. note:: Only applies when *reconstructed_geometries* is a ``list``      |\n"
-			"  |                         |                 |                                  |    because exported files are always grouped with feature.                |\n"
-			"  |                         |                 |                                  |                                                                           |\n"
-			"  |                         |                 |                                  | .. note:: Any *ReconstructType* can be grouped.                           |\n"
-			"  +-------------------------+-----------------+----------------------------------+---------------------------------------------------------------------------+\n"
-			"  | export_wrap_to_dateline | bool            | True                             | | Wrap/clip reconstructed geometries to the dateline (currently           |\n"
-			"  |                         |                 |                                  |   ignored unless exporting to an ESRI Shapefile format *file*).           |\n"
-			"  |                         |                 |                                  | | Only applies when exporting to a file (ESRI Shapefile).                 |\n"
-			"  +-------------------------+-----------------+----------------------------------+---------------------------------------------------------------------------+\n"
+			"  +--------------------------------------+-----------------+----------------------------------+----------------------------------------------------------------------------------+\n"
+			"  | Name                                 | Type            | Default                          | Description                                                                      |\n"
+			"  +======================================+=================+==================================+==================================================================================+\n"
+			"  | reconstruct_type                     | ReconstructType | ReconstructType.feature_geometry | - *ReconstructType.feature_geometry*:                                            |\n"
+			"  |                                      |                 |                                  |   only reconstruct regular features (not motion paths or                         |\n"
+			"  |                                      |                 |                                  |   flowlines), this generates                                                     |\n"
+			"  |                                      |                 |                                  |   :class:`reconstructed feature geometries<ReconstructedFeatureGeometry>`        |\n"
+			"  |                                      |                 |                                  | - *ReconstructType.motion_path*:                                                 |\n"
+			"  |                                      |                 |                                  |   only reconstruct motion path features, this generates                          |\n"
+			"  |                                      |                 |                                  |   :class:`reconstructed motion paths<ReconstructedMotionPath>`                   |\n"
+			"  |                                      |                 |                                  | - *ReconstructType.flowline*:                                                    |\n"
+			"  |                                      |                 |                                  |   only reconstruct flowline features, this generates                             |\n"
+			"  |                                      |                 |                                  |   :class:`reconstructed flowlines<ReconstructedFlowline>`                        |\n"
+			"  +--------------------------------------+-----------------+----------------------------------+----------------------------------------------------------------------------------+\n"
+			"  | group_with_feature                   | bool            | False                            | | Group reconstructed geometries with their feature.                             |\n"
+			"  |                                      |                 |                                  | | This can be useful when a feature has more than one geometry and hence         |\n"
+			"  |                                      |                 |                                  |   more than one reconstructed geometry.                                          |\n"
+			"  |                                      |                 |                                  | | *reconstructed_geometries* then becomes a list of tuples where each            |\n"
+			"  |                                      |                 |                                  |   tuple contains a :class:`feature<Feature>` and a ``list`` of                   |\n"
+			"  |                                      |                 |                                  |   reconstructed geometries.                                                      |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | .. note:: Only applies when *reconstructed_geometries* is a ``list``             |\n"
+			"  |                                      |                 |                                  |    because exported files are always grouped with feature.                       |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | .. note:: Any *ReconstructType* can be grouped.                                  |\n"
+			"  +--------------------------------------+-----------------+----------------------------------+----------------------------------------------------------------------------------+\n"
+			"  | export_wrap_to_dateline              | bool            | True                             | | Wrap/clip reconstructed geometries to the dateline (currently                  |\n"
+			"  |                                      |                 |                                  |   ignored unless exporting to an ESRI Shapefile format *file*).                  |\n"
+			"  |                                      |                 |                                  | | Only applies when exporting to a file (ESRI Shapefile).                        |\n"
+			"  +--------------------------------------+-----------------+----------------------------------+----------------------------------------------------------------------------------+\n"
+			"  | export_force_boundary_orientation    | int             | ``None`` (don't force)           | Optionally force boundary orientation (clockwise or counter-clockwise):          |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | - ``PolygonOnSphere.Orientation.clockwise``                                      |\n"
+			"  |                                      |                 |                                  | - ``PolygonOnSphere.Orientation.counter_clockwise``                              |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | .. note:: Only applies to reconstructed feature geometries that are *polygons*.  |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | .. note:: ESRI Shapefiles always use *clockwise* orientation.                    |\n"
+			"  |                                      |                 |                                  |                                                                                  |\n"
+			"  |                                      |                 |                                  | .. warning:: Only applies when exporting to a **file** (except ESRI Shapefile).  |\n"
+			"  +--------------------------------------+-----------------+----------------------------------+----------------------------------------------------------------------------------+\n"
 			"\n"
 			"  Only the :class:`features<Feature>`, in *reconstructable_features*, that match the "
 			"optional keyword argument *reconstruct_type* (see *output_parameters* table) are reconstructed. "
@@ -1136,11 +748,15 @@ export_reconstruct()
 			"\n"
 			"  .. versionchanged:: 0.44\n"
 			"     Filenames can be `os.PathLike <https://docs.python.org/3/library/os.html#os.PathLike>`_ "
-			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n";
+			"(such as `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_) in addition to strings.\n"
+			"\n"
+			"  .. versionchanged:: 0.48\n"
+			"     | Added *export_force_boundary_orientation* argument.\n"
+			"     | *ReconstructType.feature_geometry*, *ReconstructType.motion_path* and *ReconstructType.flowline* have different underlying bit values.\n";
 
 	// Register 'reconstructed feature geometries' variant.
 	GPlatesApi::PythonConverterUtils::register_variant_conversion<
-			GPlatesApi::reconstructed_feature_geometries_argument_type>();
+			GPlatesApi::reconstructed_geometries_argument_type>();
 
 
 	bp::def("reverse_reconstruct",

--- a/src/api/PyReconstructModel.cc
+++ b/src/api/PyReconstructModel.cc
@@ -1,0 +1,505 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <vector>
+#include <boost/bind/bind.hpp>
+#include <boost/cast.hpp>
+#include <boost/foreach.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
+#include <boost/variant.hpp>
+
+#include "PyReconstructModel.h"
+
+#include "PyFeature.h"
+#include "PyFeatureCollectionFunctionArgument.h"
+#include "PyPropertyValues.h"
+#include "PythonConverterUtils.h"
+#include "PythonExtractUtils.h"
+#include "PythonHashDefVisitor.h"
+#include "PythonPickle.h"
+
+#include "app-logic/GeometryUtils.h"
+#include "app-logic/ReconstructParams.h"
+#include "app-logic/VelocityDeltaTime.h"
+#include "app-logic/VelocityUnits.h"
+
+#include "global/AssertionFailureException.h"
+#include "global/GPlatesAssert.h"
+#include "global/python.h"
+
+#include "maths/MathsUtils.h"
+#include "maths/types.h"
+
+#include "model/FeatureCollectionHandle.h"
+#include "model/types.h"
+
+#include "scribe/Scribe.h"
+
+#include "utils/Earth.h"
+
+
+namespace bp = boost::python;
+
+
+namespace GPlatesApi
+{
+	/**
+	 * This is called directly from Python via 'ReconstructModel.__init__()'.
+	 */
+	ReconstructModel::non_null_ptr_type
+	reconstruct_model_create(
+			const FeatureCollectionSequenceFunctionArgument &reconstructable_features,
+			const RotationModelFunctionArgument::function_argument_type &rotation_model_argument,
+			boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id,
+			boost::optional<unsigned int> reconstruct_snapshot_cache_size)
+	{
+		return ReconstructModel::create(
+				reconstructable_features,
+				rotation_model_argument,
+				anchor_plate_id,
+				reconstruct_snapshot_cache_size);
+	}
+
+	/**
+	 * This is called directly from Python via 'ReconstructModel.get_reconstruct_snapshot()'.
+	 */
+	ReconstructSnapshot::non_null_ptr_type
+	reconstruct_model_get_reconstruct_snapshot(
+			ReconstructModel::non_null_ptr_type reconstruct_model,
+			const GPlatesPropertyValues::GeoTimeInstant &reconstruction_time)
+	{
+		// Time must not be distant past/future.
+		if (!reconstruction_time.is_real())
+		{
+			PyErr_SetString(PyExc_ValueError,
+					"Time values cannot be distant-past (float('inf')) or distant-future (float('-inf')).");
+			bp::throw_error_already_set();
+		}
+
+		return reconstruct_model->get_reconstruct_snapshot(reconstruction_time.value());
+	}
+}
+
+
+GPlatesApi::ReconstructModel::non_null_ptr_type
+GPlatesApi::ReconstructModel::create(
+		const FeatureCollectionSequenceFunctionArgument &reconstructable_features,
+		// Note we're using 'RotationModelFunctionArgument::function_argument_type' instead of
+		// just 'RotationModelFunctionArgument' since we want to know if it's an existing RotationModel...
+		const RotationModelFunctionArgument::function_argument_type &rotation_model_argument,
+		boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id,
+		boost::optional<unsigned int> reconstruct_snapshot_cache_size)
+{
+	boost::optional<RotationModel::non_null_ptr_type> rotation_model;
+
+	//
+	// Adapt an existing rotation model, or create a new rotation model.
+	//
+	if (const RotationModel::non_null_ptr_type *existing_rotation_model =
+		boost::get<RotationModel::non_null_ptr_type>(&rotation_model_argument))
+	{
+		// Adapt the existing rotation model.
+		rotation_model = RotationModel::create(
+				*existing_rotation_model,
+				// Start off with a cache size of 1 (later we'll increase it as needed)...
+				1/*reconstruction_tree_cache_size*/,
+				// If anchor plate ID is none then defaults to the default anchor plate of existing rotation model...
+				anchor_plate_id);
+	}
+	else
+	{
+		const FeatureCollectionSequenceFunctionArgument rotation_feature_collections_function_argument =
+				boost::get<FeatureCollectionSequenceFunctionArgument>(rotation_model_argument);
+
+		// Create a new rotation model (from rotation features).
+		//
+		// Note: We're creating our own RotationModel from scratch (as opposed to adapting an existing one)
+		//       to avoid having two rotation models (each with their own cache) thus doubling the cache memory usage.
+		rotation_model = RotationModel::create(
+				rotation_feature_collections_function_argument,
+				// Start off with a cache size of 1 (later we'll increase it as needed)...
+				1/*reconstruction_tree_cache_size*/,
+				false/*extend_total_reconstruction_poles_to_distant_past*/,
+				// We're creating a new RotationModel from scratch (as opposed to adapting an existing one)
+				// so the anchor plate ID defaults to zero if not specified...
+				anchor_plate_id ? anchor_plate_id.get() : 0);
+	}
+
+	// Get the reconstructable files.
+	std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstructable_files;
+	reconstructable_features.get_files(reconstructable_files);
+
+	return non_null_ptr_type(
+			new ReconstructModel(
+					rotation_model.get(),
+					reconstructable_files,
+					reconstruct_snapshot_cache_size));
+}
+
+
+GPlatesApi::ReconstructModel::ReconstructModel(
+		const RotationModel::non_null_ptr_type &rotation_model,
+		const std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+		boost::optional<unsigned int> reconstruct_snapshot_cache_size) :
+	d_rotation_model(rotation_model),
+	d_reconstructable_files(reconstructable_files),
+	d_reconstruct_snapshot_cache_size(reconstruct_snapshot_cache_size),
+	d_reconstruct_snapshot_cache(
+			// Function to create a reconstruct snapshot given a reconstruction time...
+			boost::bind(&ReconstructModel::create_reconstruct_snapshot, this, boost::placeholders::_1),
+			// Initially set cache size to 1 - we'll set it properly in 'initialise_reconstruction()'...
+			1)
+{
+	initialise();
+}
+
+
+void
+GPlatesApi::ReconstructModel::initialise()
+{
+	// Clear the data members we're about to initialise in case this function called during transcribing.
+	d_reconstructable_feature_collections.clear();
+	// Also clear any cached reconstruct snapshots.
+	d_reconstruct_snapshot_cache.clear();
+
+	// Size of topological snapshot cache.
+	const unsigned int reconstruct_snapshot_cache_size = d_reconstruct_snapshot_cache_size
+			? d_reconstruct_snapshot_cache_size.get()
+			// If not specified then default to unlimited - set to a very large value.
+			// But should be *less* than max value so that max value can compare greater than it...
+			: (std::numeric_limits<unsigned int>::max)() - 2;
+	// Set size of reconstruct snapshot cache.
+	d_reconstruct_snapshot_cache.set_maximum_num_values_in_cache(reconstruct_snapshot_cache_size);
+
+	// Size of reconstruction tree cache.
+	//
+	// The +1 accounts for the extra time step used to calculate velocities.
+	const unsigned int reconstruction_tree_cache_size = reconstruct_snapshot_cache_size + 1;
+	d_rotation_model->get_cached_reconstruction_tree_creator_impl()->set_maximum_cache_size(reconstruction_tree_cache_size);
+
+	// Extract a feature collection from each reconstructable file.
+	for (auto reconstructable_file : d_reconstructable_files)
+	{
+		const GPlatesModel::FeatureCollectionHandle::non_null_ptr_type reconstructable_feature_collection(
+				reconstructable_file->get_reference().get_feature_collection().handle_ptr());
+
+		d_reconstructable_feature_collections.push_back(reconstructable_feature_collection);
+	}
+}
+
+
+GPlatesApi::ReconstructSnapshot::non_null_ptr_type
+GPlatesApi::ReconstructModel::get_reconstruct_snapshot(
+		const double &reconstruction_time)
+{
+	return d_reconstruct_snapshot_cache.get_value(reconstruction_time);
+}
+
+
+GPlatesApi::ReconstructSnapshot::non_null_ptr_type
+GPlatesApi::ReconstructModel::create_reconstruct_snapshot(
+		const GPlatesMaths::real_t &reconstruction_time)
+{
+	return ReconstructSnapshot::create(
+			d_reconstructable_files,
+			d_rotation_model,
+			reconstruction_time.dval());
+}
+
+
+GPlatesScribe::TranscribeResult
+GPlatesApi::ReconstructModel::transcribe_construct_data(
+		GPlatesScribe::Scribe &scribe,
+		GPlatesScribe::ConstructObject<ReconstructModel> &reconstruct_model)
+{
+	if (scribe.is_saving())
+	{
+		save_construct_data(scribe, reconstruct_model.get_object());
+	}
+	else // loading
+	{
+		GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> rotation_model;
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstructable_files;
+		boost::optional<unsigned int> reconstruct_snapshot_cache_size;
+		if (!load_construct_data(
+				scribe,
+				rotation_model,
+				reconstructable_files,
+				reconstruct_snapshot_cache_size))
+		{
+			return scribe.get_transcribe_result();
+		}
+
+		// Create the topological model.
+		reconstruct_model.construct_object(
+				rotation_model,
+				reconstructable_files,
+				reconstruct_snapshot_cache_size);
+	}
+
+	return GPlatesScribe::TRANSCRIBE_SUCCESS;
+}
+
+
+GPlatesScribe::TranscribeResult
+GPlatesApi::ReconstructModel::transcribe(
+		GPlatesScribe::Scribe &scribe,
+		bool transcribed_construct_data)
+{
+	if (!transcribed_construct_data)
+	{
+		if (scribe.is_saving())
+		{
+			save_construct_data(scribe, *this);
+		}
+		else // loading
+		{
+			GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> rotation_model;
+			boost::optional<unsigned int> reconstruct_snapshot_cache_size;
+			if (!load_construct_data(
+					scribe,
+					rotation_model,
+					d_reconstructable_files,
+					reconstruct_snapshot_cache_size))
+			{
+				return scribe.get_transcribe_result();
+			}
+			d_rotation_model = rotation_model.get();
+			d_reconstruct_snapshot_cache_size = reconstruct_snapshot_cache_size;
+
+			// Initialise reconstruction (based on the construct parameters we just loaded).
+			//
+			// Note: The existing reconstruction in 'this' reconstruct model must be old data
+			//       because 'transcribed_construct_data' is false (ie, it was not transcribed) and so 'this'
+			//       object must've been created first (using unknown constructor arguments) and *then* transcribed.
+			initialise();
+		}
+	}
+
+	return GPlatesScribe::TRANSCRIBE_SUCCESS;
+}
+
+
+void
+GPlatesApi::ReconstructModel::save_construct_data(
+		GPlatesScribe::Scribe &scribe,
+		const ReconstructModel &reconstruct_model)
+{
+	// Save the rotation model.
+	scribe.save(TRANSCRIBE_SOURCE, reconstruct_model.d_rotation_model, "rotation_model");
+
+	const GPlatesScribe::ObjectTag files_tag("files");
+
+	// Save number of reconstructable files.
+	const unsigned int num_files = reconstruct_model.d_reconstructable_files.size();
+	scribe.save(TRANSCRIBE_SOURCE, num_files, files_tag.sequence_size());
+
+	// Save the topological files (feature collections and their filenames).
+	for (unsigned int file_index = 0; file_index < num_files; ++file_index)
+	{
+		const auto feature_collection_file = reconstruct_model.d_reconstructable_files[file_index];
+
+		const GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection(
+				feature_collection_file->get_reference().get_feature_collection().handle_ptr());
+		const QString filename =
+				feature_collection_file->get_reference().get_file_info().get_qfileinfo().absoluteFilePath();
+
+		scribe.save(TRANSCRIBE_SOURCE, feature_collection, files_tag[file_index]("feature_collection"));
+		scribe.save(TRANSCRIBE_SOURCE, filename, files_tag[file_index]("filename"));
+	}
+
+	// Save the reconstruct snapshot cache size.
+	scribe.save(TRANSCRIBE_SOURCE, reconstruct_model.d_reconstruct_snapshot_cache_size, "reconstruct_snapshot_cache_size");
+}
+
+
+bool
+GPlatesApi::ReconstructModel::load_construct_data(
+		GPlatesScribe::Scribe &scribe,
+		GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> &rotation_model,
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+		boost::optional<unsigned int> &reconstruct_snapshot_cache_size)
+{
+	// Load the rotation model.
+	rotation_model = scribe.load<RotationModel::non_null_ptr_type>(TRANSCRIBE_SOURCE, "rotation_model");
+	if (!rotation_model.is_valid())
+	{
+		return false;
+	}
+
+	const GPlatesScribe::ObjectTag files_tag("files");
+
+	// Number of topological files.
+	unsigned int num_files;
+	if (!scribe.transcribe(TRANSCRIBE_SOURCE, num_files, files_tag.sequence_size()))
+	{
+		return false;
+	}
+
+	// Load the reconstructable files (feature collections and their filenames).
+	for (unsigned int file_index = 0; file_index < num_files; ++file_index)
+	{
+		GPlatesScribe::LoadRef<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> feature_collection =
+				scribe.load<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type>(
+						TRANSCRIBE_SOURCE,
+						files_tag[file_index]("feature_collection"));
+		if (!feature_collection.is_valid())
+		{
+			return false;
+		}
+
+		QString filename;
+		if (!scribe.transcribe(TRANSCRIBE_SOURCE, filename, files_tag[file_index]("filename")))
+		{
+			return false;
+		}
+
+		reconstructable_files.push_back(
+				GPlatesFileIO::File::create_file(GPlatesFileIO::FileInfo(filename), feature_collection));
+	}
+
+	// Load the reconstruct snapshot cache size.
+	if (!scribe.transcribe(TRANSCRIBE_SOURCE, reconstruct_snapshot_cache_size, "reconstruct_snapshot_cache_size"))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+void
+export_reconstruct_model()
+{
+	//
+	// ReconstructModel - docstrings in reStructuredText (see http://sphinx-doc.org/rest.html).
+	//
+	bp::class_<
+			GPlatesApi::ReconstructModel,
+			GPlatesApi::ReconstructModel::non_null_ptr_type,
+			boost::noncopyable>(
+					"ReconstructModel",
+					"A history of reconstructed geometries over geological time.\n"
+					"\n"
+					"A *ReconstructModel* can also be `pickled <https://docs.python.org/3/library/pickle.html>`_.\n"
+					"\n"
+					".. versionadded:: 0.48\n",
+					// We need this (even though "__init__" is defined) since
+					// there is no publicly-accessible default constructor...
+					bp::no_init)
+		.def("__init__",
+				bp::make_constructor(
+						&GPlatesApi::reconstruct_model_create,
+						bp::default_call_policies(),
+						(bp::arg("reconstructable_features"),
+							bp::arg("rotation_model"),
+							bp::arg("anchor_plate_id") = boost::optional<GPlatesModel::integer_plate_id_type>(),
+							bp::arg("reconstruct_snapshot_cache_size") = boost::optional<unsigned int>())),
+			"__init__(reconstructable_features, rotation_model, [anchor_plate_id], [reconstruct_snapshot_cache_size])\n"
+			"  Create from reconstructable features and a rotation model.\n"
+			"\n"
+			"  :param reconstructable_features: The features to reconstruct as a feature collection, "
+			"or filename, or feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) "
+			"of any combination of those four types.\n"
+			"  :type reconstructable_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
+			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
+			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
+			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
+			"  :param anchor_plate_id: The anchored plate id used for reconstructions. "
+			"Defaults to the default anchor plate of *rotation_model* (or zero if *rotation_model* is not a :class:`RotationModel`).\n"
+			"  :type anchor_plate_id: int\n"
+			"  :param reconstruct_snapshot_cache_size: Number of reconstruct snapshots to cache internally. Defaults to unlimited.\n"
+			"  :type reconstruct_snapshot_cache_size: int\n"
+			"\n"
+			"  Load a reconstruct model (and its associated rotation model):\n"
+			"  ::\n"
+			"\n"
+			"    rotation_model = pygplates.RotationModel('rotations.rot')\n"
+			"    reconstruct_model = pygplates.ReconstructModel('reconstructable_features.gpml', rotation_model)\n"
+			"\n"
+			"  ...or alternatively just:"
+			"  ::\n"
+			"\n"
+			"    reconstruct_model = pygplates.ReconstructModel('reconstructable_features.gpml', 'rotations.rot')\n"
+			"\n"
+			"  .. note:: All reconstructions use *anchor_plate_id*. So if you need to use a different "
+			"anchor plate ID then you'll need to create a new :class:`ReconstructModel<__init__>`. However this should "
+			"only be done if necessary since each :class:`ReconstructModel` created can consume a reasonable amount of "
+			"CPU and memory (since it caches reconstructed geometries over geological time).\n"
+			"\n"
+			"  .. note:: The *reconstruct_snapshot_cache_size* parameter controls "
+			"the size of an internal least-recently-used cache of reconstruct snapshots "
+			"(evicts least recently requested reconstruct snapshot when a new reconstruction "
+			"time is requested that does not currently exist in the cache). This enables "
+			"reconstruct snapshots associated with different reconstruction times to be re-used "
+			"instead of re-creating them, provided they have not been evicted from the cache.\n")
+		// Pickle support...
+		//
+		// Note: This adds an __init__ method accepting a single argument (of type 'bytes') that supports pickling.
+		//       So we define this *after* (higher priority) the other __init__ methods in case one of them accepts a single argument
+		//       of type bp::object (which, being more general, would otherwise obscure the __init__ that supports pickling).
+		.def(GPlatesApi::PythonPickle::PickleDefVisitor<GPlatesApi::ReconstructModel::non_null_ptr_type>())
+		.def("reconstruct_snapshot",
+				&GPlatesApi::reconstruct_model_get_reconstruct_snapshot,
+				(bp::arg("reconstruction_time")),
+				"reconstruct_snapshot(reconstruction_time)\n"
+				"  Returns a snapshot of reconstructed geometries at the requested reconstruction time.\n"
+				"\n"
+				"  :param reconstruction_time: the geological time of the snapshot\n"
+				"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
+				"  :rtype: :class:`ReconstructSnapshot`\n"
+				"  :raises: ValueError if *reconstruction_time* is distant-past (``float('inf')``) or distant-future (``float('-inf')``).\n")
+		.def("get_rotation_model",
+				&GPlatesApi::ReconstructModel::get_rotation_model,
+				"get_rotation_model()\n"
+				"  Return the rotation model used internally.\n"
+				"\n"
+				"  :rtype: :class:`RotationModel`\n"
+				"\n"
+				"  .. note:: The :meth:`default anchor plate ID<RotationModel.get_default_anchor_plate_id>` of the returned rotation model "
+				"may be different to that of the rotation model passed into the :meth:`constructor<__init__>` if an anchor plate ID was specified "
+				"in the :meth:`constructor<__init__>`.\n"
+				"\n"
+				"  .. note:: The reconstruction tree cache size of the returned rotation model is equal to the *reconstruct_snapshot_cache_size* "
+				"argument specified in the :meth:`constructor<__init__>` plus one (or unlimited if not specified).\n")
+		.def("get_anchor_plate_id",
+				&GPlatesApi::ReconstructModel::get_anchor_plate_id,
+				"get_anchor_plate_id()\n"
+				"  Return the anchor plate ID (see :meth:`constructor<__init__>`).\n"
+				"\n"
+				"  :rtype: int\n"
+				"\n"
+				"  .. note:: This is the same as the :meth:`default anchor plate ID<RotationModel.get_default_anchor_plate_id>` "
+				"of :meth:`get_rotation_model`.\n")
+		// Make hash and comparisons based on C++ object identity (not python object identity)...
+		.def(GPlatesApi::ObjectIdentityHashDefVisitor())
+	;
+
+	// Register to/from Python conversions of non_null_intrusive_ptr<> including const/non-const and boost::optional.
+	GPlatesApi::PythonConverterUtils::register_all_conversions_for_non_null_intrusive_ptr<GPlatesApi::ReconstructModel>();
+}

--- a/src/api/PyReconstructModel.h
+++ b/src/api/PyReconstructModel.h
@@ -1,0 +1,203 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef GPLATES_API_PY_RECONSTRUCT_MODEL_H
+#define GPLATES_API_PY_RECONSTRUCT_MODEL_H
+
+#include <vector>
+#include <map>
+#include <boost/optional.hpp>
+
+#include "PyFeatureCollectionFunctionArgument.h"
+#include "PyReconstructSnapshot.h"
+#include "PyRotationModel.h"
+
+#include "file-io/File.h"
+
+#include "global/python.h"
+
+#include "maths/types.h"
+
+#include "model/FeatureCollectionHandle.h"
+#include "model/types.h"
+
+#include "property-values/GeoTimeInstant.h"
+
+#include "scribe/ScribeLoadRef.h"
+ // Try to only include the heavyweight "Scribe.h" in '.cc' files where possible.
+#include "scribe/Transcribe.h"
+
+#include "utils/KeyValueCache.h"
+#include "utils/ReferenceCount.h"
+
+
+namespace GPlatesApi
+{
+	/**
+	 * Reconstructed features, and their associated rotation model.
+	 */
+	class ReconstructModel :
+			public GPlatesUtils::ReferenceCount<ReconstructModel>
+	{
+	public:
+
+		typedef GPlatesUtils::non_null_intrusive_ptr<ReconstructModel> non_null_ptr_type;
+		typedef GPlatesUtils::non_null_intrusive_ptr<const ReconstructModel> non_null_ptr_to_const_type;
+
+
+		/**
+		 * Create a reconstruct model from reconstructable features and associated rotation model.
+		 */
+		static
+		non_null_ptr_type
+		create(
+				const FeatureCollectionSequenceFunctionArgument &reconstructable_features,
+				// Note we're using 'RotationModelFunctionArgument::function_argument_type' instead of
+				// just 'RotationModelFunctionArgument' since we want to know if it's an existing RotationModel...
+				const RotationModelFunctionArgument::function_argument_type &rotation_model_argument,
+				boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id,
+				boost::optional<unsigned int> reconstruct_snapshot_cache_size);
+
+
+		/**
+		 * Returns the reconstruct snapshot (reconstructed features) for the specified time (creating and caching them if necessary).
+		 */
+		ReconstructSnapshot::non_null_ptr_type
+		get_reconstruct_snapshot(
+				const double &reconstruction_time);
+
+
+		/**
+		 * Return the feature collections used to create this reconstruct model.
+		 */
+		const std::vector<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> &
+		get_reconstructable_feature_collections() const
+		{
+			return d_reconstructable_feature_collections;
+		}
+
+
+		/**
+		 * Return the feature collection files used to create this reconstruct model.
+		 *
+		 * NOTE: Any feature collections that did not come from files will have empty filenames.
+		 */
+		const std::vector<GPlatesFileIO::File::non_null_ptr_type> &
+		get_reconstructable_files() const
+		{
+			return d_reconstructable_files;
+		}
+
+
+		/**
+		 * Get the rotation model.
+		 */
+		RotationModel::non_null_ptr_type
+		get_rotation_model() const
+		{
+			return d_rotation_model;
+		}
+
+		/**
+		 * Returns the anchor plate ID.
+		 */
+		GPlatesModel::integer_plate_id_type
+		get_anchor_plate_id() const
+		{
+			return get_rotation_model()->get_reconstruction_tree_creator().get_default_anchor_plate_id();
+		}
+
+	private:
+
+		//! Typedef for a least-recently used cache mapping reconstruction times to reconstruct snapshots.
+		typedef GPlatesUtils::KeyValueCache<GPlatesMaths::real_t/*time*/, ReconstructSnapshot::non_null_ptr_type> reconstruct_snapshots_type;
+
+
+		/**
+		 * Rotation model associated with reconstructable features.
+		 */
+		RotationModel::non_null_ptr_type d_rotation_model;
+
+		/**
+		 * Feature collections/files.
+		 */
+		std::vector<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> d_reconstructable_feature_collections;
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> d_reconstructable_files;
+
+		/**
+		 * Number of reconstruct snapshots to cache (at different time instants) - none means unlimited.
+		 */
+		boost::optional<unsigned int> d_reconstruct_snapshot_cache_size;
+
+		/**
+		 * Cache of reconstruct snapshots at various time instants.
+		 */
+		reconstruct_snapshots_type d_reconstruct_snapshot_cache;
+
+
+		ReconstructModel(
+				const RotationModel::non_null_ptr_type &rotation_model,
+				const std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+				boost::optional<unsigned int> reconstruct_snapshot_cache_size);
+
+		/**
+		 * Set up for reconstruction once the files have been constructed.
+		 */
+		void
+		initialise();
+
+		/**
+		 * Reconstructed features for the specified time and returns them as a reconstruct snapshot.
+		 */
+		ReconstructSnapshot::non_null_ptr_type
+		create_reconstruct_snapshot(
+				const GPlatesMaths::real_t &reconstruction_time);
+
+	private: // Transcribe...
+
+		friend class GPlatesScribe::Access;
+
+		static
+		GPlatesScribe::TranscribeResult
+		transcribe_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				GPlatesScribe::ConstructObject<ReconstructModel> &reconstruct_model);
+
+		GPlatesScribe::TranscribeResult
+		transcribe(
+				GPlatesScribe::Scribe &scribe,
+				bool transcribed_construct_data);
+
+		static
+		void
+		save_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				const ReconstructModel &reconstruct_model);
+
+		static
+		bool
+		load_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> &rotation_model,
+				std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+				boost::optional<unsigned int> &reconstruct_snapshot_cache_size);
+	};
+}
+
+#endif // GPLATES_API_PY_RECONSTRUCT_MODEL_H

--- a/src/api/PyReconstructSnapshot.cc
+++ b/src/api/PyReconstructSnapshot.cc
@@ -194,7 +194,7 @@ namespace GPlatesApi
 			const FilePathFunctionArgument &export_file_name,
 			ReconstructType::Value reconstruct_type,
 			bool wrap_to_dateline,
-			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation)
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation)
 	{
 		// Reconstruct type flag must correspond to an existing flag.
 		if ((reconstruct_type & ~ReconstructType::ALL_RECONSTRUCT_TYPES) != 0)
@@ -216,7 +216,7 @@ namespace GPlatesApi
 				export_file_name,
 				reconstruct_type,
 				wrap_to_dateline,
-				force_boundary_orientation);
+				force_polygon_orientation);
 	}
 
 
@@ -461,7 +461,7 @@ namespace GPlatesApi
 			const FilePathFunctionArgument &export_file_path,
 			ReconstructType::Value reconstruct_type,
 			bool wrap_to_dateline,
-			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation) const
 	{
 		const QString export_file_name = export_file_path.get_file_path();
 
@@ -496,7 +496,7 @@ namespace GPlatesApi
 					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
 					d_reconstruction_time,
 					wrap_to_dateline,
-					force_boundary_orientation);
+					force_polygon_orientation);
 			break;
 
 		case ReconstructType::MOTION_PATH:
@@ -506,8 +506,7 @@ namespace GPlatesApi
 					reconstruction_file_ptrs,
 					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
 					d_reconstruction_time,
-					wrap_to_dateline,
-					force_boundary_orientation);
+					wrap_to_dateline);
 			break;
 
 		case ReconstructType::FLOWLINE:
@@ -517,8 +516,7 @@ namespace GPlatesApi
 					reconstruction_file_ptrs,
 					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
 					d_reconstruction_time,
-					wrap_to_dateline,
-					force_boundary_orientation);
+					wrap_to_dateline);
 			break;
 
 		default:
@@ -535,7 +533,7 @@ namespace GPlatesApi
 			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
 			const double &reconstruction_time,
 			bool export_wrap_to_dateline,
-			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation) const
 	{
 		// Converts to raw pointers.
 		std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_feature_geometry_ptrs;
@@ -574,6 +572,7 @@ namespace GPlatesApi
 					true/*export_single_output_file*/,
 					false/*export_per_input_file*/, // We only generate a single output file.
 					false/*export_output_directory_per_input_file*/, // We only generate a single output file.
+					force_polygon_orientation,
 					export_wrap_to_dateline);
 	}
 
@@ -584,8 +583,7 @@ namespace GPlatesApi
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
 			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
 			const double &reconstruction_time,
-			bool export_wrap_to_dateline,
-			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+			bool export_wrap_to_dateline) const
 	{
 		// Converts to raw pointers.
 		std::vector<const GPlatesAppLogic::ReconstructedMotionPath *> reconstructed_motion_path_ptrs;
@@ -632,8 +630,7 @@ namespace GPlatesApi
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
 			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
 			const double &reconstruction_time,
-			bool export_wrap_to_dateline,
-			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+			bool export_wrap_to_dateline) const
 	{
 		// Converts to raw pointers.
 		std::vector<const GPlatesAppLogic::ReconstructedFlowline *> reconstructed_flowline_ptrs;
@@ -905,8 +902,8 @@ export_reconstruct_snapshot()
 				"get_reconstructed_features([reconstruct_types=pygplates.ReconstructType.feature_geometry])\n"
 				"  Returns the reconstructed geometries of the requested type(s) grouped by their feature.\n"
 				"\n"
-				"  :param reconstruct_types: specifies the reconstructed geometry types to return - defaults "
-				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :param reconstruct_types: specifies which types of features to reconstruct - defaults "
+				"to reconstructing only regular features (not motion paths or flowlines)\n"
 				"  :type reconstruct_types: a bitwise combination of any of ``pygplates.ReconstructType.feature_geometry``, "
 				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
 				"  :returns: a list of tuples, where each tuple contains a :class:`Feature` and a ``list`` of reconstructed geometries "
@@ -918,7 +915,8 @@ export_reconstruct_snapshot()
 				"is not one of ``pygplates.ReconstructType.feature_geometry``, ``pygplates.ReconstructType.motion_path`` or "
 				"``pygplates.ReconstructType.flowline``\n"
 				"\n"
-				"  This can be useful when a :class:`feature <Feature>` has more than one geometry and hence more than one reconstructed geometry.\n"
+				"  This can be useful (compared to :meth:`get_reconstructed_geometries`) when a :class:`feature <Feature>` has "
+				"more than one (present day) geometry and hence more than one reconstructed geometry.\n"
 				"\n"
 				"  .. note:: The returned features (and associated reconstructed geometries) are sorted in the order of the reconstructable features "
 				"(including order across reconstructable files, if there were any).\n"
@@ -932,7 +930,7 @@ export_reconstruct_snapshot()
 				"        for feature_reconstructed_geometry in feature_reconstructed_geometries:\n"
 				"            ...\n"
 				"\n"
-				"  .. seealso:: get_reconstructed_geometries\n")
+				"  .. seealso:: :meth:`get_reconstructed_geometries`\n")
 		.def("get_reconstructed_geometries",
 				&GPlatesApi::reconstruct_snapshot_get_reconstructed_geometries,
 				(bp::arg("reconstruct_types") = GPlatesApi::ReconstructType::DEFAULT_RECONSTRUCT_TYPES,
@@ -940,8 +938,8 @@ export_reconstruct_snapshot()
 				"get_reconstructed_geometries([reconstruct_types=pygplates.ReconstructType.feature_geometry], [same_order_as_reconstructable_features=False])\n"
 				"  Returns the reconstructed geometries of the requested type(s).\n"
 				"\n"
-				"  :param reconstruct_types: specifies the reconstructed geometry types to return - defaults "
-				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :param reconstruct_types: specifies which types of features to reconstruct - defaults "
+				"to reconstructing only regular features (not motion paths or flowlines)\n"
 				"  :type reconstruct_types: a bitwise combination of any of ``pygplates.ReconstructType.feature_geometry``, "
 				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
 				"  :param same_order_as_reconstructable_features: whether the returned reconstructed geometries are sorted in "
@@ -957,32 +955,32 @@ export_reconstruct_snapshot()
 				"is not one of ``pygplates.ReconstructType.feature_geometry``, ``pygplates.ReconstructType.motion_path`` or "
 				"``pygplates.ReconstructType.flowline``\n"
 				"\n"
-				"  .. seealso:: get_reconstructed_features\n")
+				"  .. seealso:: :meth:`get_reconstructed_features`\n")
 		.def("export_reconstructed_geometries",
 				&GPlatesApi::reconstruct_snapshot_export_reconstructed_geometries,
 				(bp::arg("export_filename"),
 					bp::arg("reconstruct_type") = GPlatesApi::ReconstructType::DEFAULT_RECONSTRUCT_TYPE,
 					bp::arg("wrap_to_dateline") = true,
-					bp::arg("force_boundary_orientation") = boost::optional<GPlatesMaths::PolygonOrientation::Orientation>()),
+					bp::arg("force_polygon_orientation") = boost::optional<GPlatesMaths::PolygonOrientation::Orientation>()),
 				"export_reconstructed_geometries(export_filename, [reconstruct_type=pygplates.ReconstructType.feature_geometry], "
-				"[wrap_to_dateline=True], [force_boundary_orientation])\n"
+				"[wrap_to_dateline=True], [force_polygon_orientation])\n"
 				"  Exports the reconstructed geometries of the requested type(s) to a file.\n"
 				"\n"
 				"  :param export_filename: the name of the export file\n"
 				"  :type export_filename: string/``os.PathLike``\n"
-				"  :param reconstruct_type: specifies the **single** reconstructed geometry type to export - defaults "
-				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :param reconstruct_type: specifies which type of features to export - defaults "
+				"to exporting only regular features (not motion paths or flowlines)\n"
 				"  :type reconstruct_type: ``pygplates.ReconstructType.feature_geometry``, "
 				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
 				"  :param wrap_to_dateline: Whether to wrap/clip reconstructed geometries to the dateline "
 				"(currently ignored unless exporting to an ESRI Shapefile format *file*). Defaults to ``True``.\n"
 				"  :type wrap_to_dateline: bool\n"
-				"  :param force_boundary_orientation: Optionally force boundary orientation to "
+				"  :param force_polygon_orientation: Optionally force boundary orientation to "
 				"clockwise (``PolygonOnSphere.Orientation.clockwise``) or "
 				"counter-clockwise (``PolygonOnSphere.Orientation.counter_clockwise``). "
-				"Only applies to reconstructed feature geometries (excludes *motion paths* and *flowlines*). "
+				"Only applies to reconstructed feature geometries (excludes *motion paths* and *flowlines*) that are polygons. "
 				"Note that ESRI Shapefiles always use *clockwise* orientation (and so ignore this parameter).\n"
-				"  :type force_boundary_orientation: int\n"
+				"  :type force_polygon_orientation: int\n"
 				"  :raises: ValueError if *reconstruct_type* (if specified) is not **one** of ``pygplates.ReconstructType.feature_geometry``, "
 				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
 				"\n"

--- a/src/api/PyReconstructSnapshot.cc
+++ b/src/api/PyReconstructSnapshot.cc
@@ -849,7 +849,7 @@ export_reconstruct_snapshot()
 			GPlatesApi::ReconstructSnapshot::non_null_ptr_type,
 			boost::noncopyable>(
 					"ReconstructSnapshot",
-					"A snapshot of reconstructed geometries at a specific geological time.\n"
+					"A snapshot of reconstructed regular features (including motion paths and flowlines) at a specific geological time.\n"
 					"\n"
 					"A *ReconstructSnapshot* can also be `pickled <https://docs.python.org/3/library/pickle.html>`_.\n"
 					"\n"

--- a/src/api/PyReconstructSnapshot.cc
+++ b/src/api/PyReconstructSnapshot.cc
@@ -35,9 +35,6 @@
 #include "PythonVariableFunctionArguments.h"
 
 #include "app-logic/ReconstructContext.h"
-#include "app-logic/ReconstructedFeatureGeometry.h"
-#include "app-logic/ReconstructedFlowline.h"
-#include "app-logic/ReconstructedMotionPath.h"
 #include "app-logic/ReconstructHandle.h"
 #include "app-logic/ReconstructionGeometryUtils.h"
 #include "app-logic/ReconstructMethodInterface.h"
@@ -287,6 +284,11 @@ namespace GPlatesApi
 		const GPlatesAppLogic::ReconstructHandle::type reconstruct_handle =
 				GPlatesAppLogic::ReconstructHandle::get_next_reconstruct_handle();
 
+		// For motion paths and flowlines we reconstruct into ReconstructedFeatureGeometry arrays,
+		// and later downcast to ReconstructedMotionPath and ReconstructedFlowline arrays.
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> reconstructed_motion_paths;
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> reconstructed_flowlines;
+
 		// Iterate over the files and reconstruct their features.
 		for (const auto &reconstruct_file : d_reconstructable_files)
 		{
@@ -306,21 +308,6 @@ namespace GPlatesApi
 					continue;
 				}
 
-				// Target reconstructed feature geometries or motion paths or flowlines depending on the reconstruct type.
-				boost::optional<std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &> reconstructed_geometries;
-				if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::FLOWLINE)  // ReconstructType::FLOWLINE
-				{
-					reconstructed_geometries = d_reconstructed_flowlines;
-				}
-				else if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::MOTION_PATH)  // ReconstructType::MOTION_PATH
-				{
-					reconstructed_geometries = d_reconstructed_motion_paths;
-				}
-				else  // ReconstructType::FEATURE_GEOMETRY
-				{
-					reconstructed_geometries = d_reconstructed_feature_geometries;
-				}
-
 				GPlatesAppLogic::ReconstructMethodInterface::non_null_ptr_type reconstruct_method =
 						reconstruct_method_registry.create_reconstruct_method(
 								reconstruct_method_type.get(),
@@ -328,13 +315,56 @@ namespace GPlatesApi
 								reconstruct_method_context);
 
 				// Reconstruct the current feature and append to the target reconstructed geometries array.
-				reconstruct_method->reconstruct_feature_geometries(
-						reconstructed_geometries.get(),
-						reconstruct_handle,
-						reconstruct_method_context,
-						d_reconstruction_time);
+				//
+				// Target reconstructed feature geometries or motion paths or flowlines depending on the reconstruct type.
+				if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::MOTION_PATH)  // ReconstructType::MOTION_PATH
+				{
+					reconstruct_method->reconstruct_feature_geometries(
+							reconstructed_motion_paths,
+							reconstruct_handle,
+							reconstruct_method_context,
+							d_reconstruction_time);
+				}
+				else if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::FLOWLINE)  // ReconstructType::FLOWLINE
+				{
+					reconstruct_method->reconstruct_feature_geometries(
+							reconstructed_flowlines,
+							reconstruct_handle,
+							reconstruct_method_context,
+							d_reconstruction_time);
+				}
+				else  // ReconstructType::FEATURE_GEOMETRY
+				{
+					// Note we don't need to downcast like we do for reconstructed motion paths and flowlines.
+					// So we reconstruct directly into the final ReconstructedFeatureGeometry array.
+					reconstruct_method->reconstruct_feature_geometries(
+							d_reconstructed_feature_geometries,
+							reconstruct_handle,
+							reconstruct_method_context,
+							d_reconstruction_time);
+				}
 			}
 		}
+
+		// From the ReconstructedFeatureGeometry's generated when reconstructing motion paths,
+		// downcast those that are ReconstructedMotionPath's.
+		//
+		// Note that, when motion paths are reconstructed, both ReconstructedMotionPath's and
+		// ReconstructedFeatureGeometry's are generated. So this ensures that the concrete ReconstructedFeatureGeometry's
+		// are ignored (noting that ReconstructedMotionPath is derived from ReconstructedFeatureGeometry).
+		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
+						reconstructed_motion_paths.begin(),
+						reconstructed_motion_paths.end(),
+						d_reconstructed_motion_paths);
+
+		// Downcast the ReconstructedFeatureGeometry's generated when reconstructing flowlines to ReconstructedFlowline's.
+		//
+		// Note that, unlike motion paths, all ReconstructedFeatureGeometry's generated when reconstructing flowlines
+		// are actually ReconstructedFlowline's.
+		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
+						reconstructed_flowlines.begin(),
+						reconstructed_flowlines.end(),
+						d_reconstructed_flowlines);
 	}
 
 	std::list<ReconstructSnapshot::feature_geometry_group_type>
@@ -435,12 +465,6 @@ namespace GPlatesApi
 	{
 		const QString export_file_name = export_file_path.get_file_path();
 
-		// Get the reconstructed geometries.
-		//
-		// Note: We don't need to sort the reconstructed geometries because the following export will do that...
-		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type>
-				reconstructed_geometries = get_reconstructed_geometries(reconstruct_type);
-
 		// Get the sequence of reconstructable files as File pointers.
 		std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
 		for (const auto &reconstructable_file : d_reconstructable_files)
@@ -460,11 +484,12 @@ namespace GPlatesApi
 		}
 
 		// Export based on the reconstructed type requested by the caller.
+		//
+		// Note: We don't need to sort the reconstructed geometries because the following exports will do that.
 		switch (reconstruct_type)
 		{
 		case ReconstructType::FEATURE_GEOMETRY:
 			export_reconstructed_feature_geometries(
-					reconstructed_geometries,
 					export_file_name,
 					reconstructable_file_ptrs,
 					reconstruction_file_ptrs,
@@ -476,7 +501,6 @@ namespace GPlatesApi
 
 		case ReconstructType::MOTION_PATH:
 			export_reconstructed_motion_paths(
-					reconstructed_geometries,
 					export_file_name,
 					reconstructable_file_ptrs,
 					reconstruction_file_ptrs,
@@ -488,7 +512,6 @@ namespace GPlatesApi
 
 		case ReconstructType::FLOWLINE:
 			export_reconstructed_flowlines(
-					reconstructed_geometries,
 					export_file_name,
 					reconstructable_file_ptrs,
 					reconstruction_file_ptrs,
@@ -506,7 +529,6 @@ namespace GPlatesApi
 
 	void
 	ReconstructSnapshot::export_reconstructed_feature_geometries(
-			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 			const QString &export_file_name,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
@@ -516,11 +538,11 @@ namespace GPlatesApi
 			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
 	{
 		// Converts to raw pointers.
-		std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_feature_geometries;
-		reconstructed_feature_geometries.reserve(reconstructed_geometries.size());
-		for (auto rfg : reconstructed_geometries)
+		std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_feature_geometry_ptrs;
+		reconstructed_feature_geometry_ptrs.reserve(d_reconstructed_feature_geometries.size());
+		for (auto rfg : d_reconstructed_feature_geometries)
 		{
-			reconstructed_feature_geometries.push_back(rfg.get());
+			reconstructed_feature_geometry_ptrs.push_back(rfg.get());
 		}
 
 		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
@@ -542,7 +564,7 @@ namespace GPlatesApi
 		GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_geometries(
 					export_file_name,
 					format,
-					reconstructed_feature_geometries,
+					reconstructed_feature_geometry_ptrs,
 					reconstructable_file_ptrs,
 					reconstruction_file_ptrs,
 					anchor_plate_id,
@@ -557,7 +579,6 @@ namespace GPlatesApi
 
 	void
 	ReconstructSnapshot::export_reconstructed_motion_paths(
-			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 			const QString &export_file_name,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
@@ -566,16 +587,13 @@ namespace GPlatesApi
 			bool export_wrap_to_dateline,
 			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
 	{
-		// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedMotionPath.
-		//
-		// Note that, when motion paths are reconstructed, both ReconstructedMotionPath's and
-		// ReconstructedFeatureGeometry's are generated - so this also ensures that the
-		// ReconstructedFeatureGeometry's are ignored when outputting reconstructed motion paths.
-		std::vector<const GPlatesAppLogic::ReconstructedMotionPath *> reconstructed_motion_paths;
-		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
-				reconstructed_geometries.begin(),
-				reconstructed_geometries.end(),
-				reconstructed_motion_paths);
+		// Converts to raw pointers.
+		std::vector<const GPlatesAppLogic::ReconstructedMotionPath *> reconstructed_motion_path_ptrs;
+		reconstructed_motion_path_ptrs.reserve(d_reconstructed_motion_paths.size());
+		for (auto rmp : d_reconstructed_motion_paths)
+		{
+			reconstructed_motion_path_ptrs.push_back(rmp.get());
+		}
 
 		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
 		const GPlatesFileIO::ReconstructedMotionPathExport::Format format =
@@ -596,7 +614,7 @@ namespace GPlatesApi
 		GPlatesFileIO::ReconstructedMotionPathExport::export_reconstructed_motion_paths(
 					export_file_name,
 					format,
-					reconstructed_motion_paths,
+					reconstructed_motion_path_ptrs,
 					reconstructable_file_ptrs,
 					reconstruction_file_ptrs,
 					anchor_plate_id,
@@ -609,7 +627,6 @@ namespace GPlatesApi
 
 	void
 	ReconstructSnapshot::export_reconstructed_flowlines(
-			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 			const QString &export_file_name,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
@@ -618,13 +635,13 @@ namespace GPlatesApi
 			bool export_wrap_to_dateline,
 			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
 	{
-		// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedFlowline.
-		// In fact they should all be ReconstructedFlowlines.
-		std::vector<const GPlatesAppLogic::ReconstructedFlowline *> reconstructed_flowlines;
-		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
-						reconstructed_geometries.begin(),
-						reconstructed_geometries.end(),
-						reconstructed_flowlines);
+		// Converts to raw pointers.
+		std::vector<const GPlatesAppLogic::ReconstructedFlowline *> reconstructed_flowline_ptrs;
+		reconstructed_flowline_ptrs.reserve(d_reconstructed_flowlines.size());
+		for (auto rf : d_reconstructed_flowlines)
+		{
+			reconstructed_flowline_ptrs.push_back(rf.get());
+		}
 
 		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
 		const GPlatesFileIO::ReconstructedFlowlineExport::Format format =
@@ -645,7 +662,7 @@ namespace GPlatesApi
 		GPlatesFileIO::ReconstructedFlowlineExport::export_reconstructed_flowlines(
 				export_file_name,
 				format,
-				reconstructed_flowlines,
+				reconstructed_flowline_ptrs,
 				reconstructable_file_ptrs,
 				reconstruction_file_ptrs,
 				anchor_plate_id,

--- a/src/api/PyReconstructSnapshot.cc
+++ b/src/api/PyReconstructSnapshot.cc
@@ -1,0 +1,1020 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <utility>
+#include <vector>
+#include <boost/foreach.hpp>
+#include <boost/optional.hpp>
+#include <boost/variant.hpp>
+#include <QString>
+
+#include "PyReconstructSnapshot.h"
+
+#include "PyFeatureCollectionFunctionArgument.h"
+#include "PyRotationModel.h"
+#include "PythonConverterUtils.h"
+#include "PythonHashDefVisitor.h"
+#include "PythonPickle.h"
+#include "PythonUtils.h"
+#include "PythonVariableFunctionArguments.h"
+
+#include "app-logic/ReconstructContext.h"
+#include "app-logic/ReconstructedFeatureGeometry.h"
+#include "app-logic/ReconstructedFlowline.h"
+#include "app-logic/ReconstructedMotionPath.h"
+#include "app-logic/ReconstructHandle.h"
+#include "app-logic/ReconstructionGeometryUtils.h"
+#include "app-logic/ReconstructMethodInterface.h"
+#include "app-logic/ReconstructMethodRegistry.h"
+
+#include "file-io/FeatureCollectionFileFormatRegistry.h"
+#include "file-io/File.h"
+#include "file-io/ReconstructedFeatureGeometryExport.h"
+#include "file-io/ReconstructedFlowlineExport.h"
+#include "file-io/ReconstructedMotionPathExport.h"
+
+#include "global/GPlatesAssert.h"
+#include "global/PreconditionViolationError.h"
+
+#include "maths/PolygonOrientation.h"
+
+#include "model/FeatureCollectionHandle.h"
+#include "model/types.h"
+
+#include "property-values/GeoTimeInstant.h"
+
+#include "scribe/Scribe.h"
+
+
+namespace bp = boost::python;
+
+
+namespace GPlatesApi
+{
+	/**
+	 * This is called directly from Python via 'ReconstructSnapshot.__init__()'.
+	 */
+	ReconstructSnapshot::non_null_ptr_type
+	reconstruct_snapshot_create(
+			const FeatureCollectionSequenceFunctionArgument &reconstructable_features,
+			const RotationModelFunctionArgument &rotation_model_argument,
+			const GPlatesPropertyValues::GeoTimeInstant &reconstruction_time,
+			boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id)
+	{
+		// Time must not be distant past/future.
+		if (!reconstruction_time.is_real())
+		{
+			PyErr_SetString(PyExc_ValueError,
+					"Time values cannot be distant-past (float('inf')) or distant-future (float('-inf')).");
+			bp::throw_error_already_set();
+		}
+
+		return ReconstructSnapshot::create(
+				reconstructable_features,
+				rotation_model_argument,
+				reconstruction_time.value(),
+				anchor_plate_id);
+	}
+
+	/**
+	 * This is called directly from Python via 'ReconstructSnapshot.get_reconstructed_features()'.
+	 */
+	bp::list
+	reconstruct_snapshot_get_reconstructed_features(
+			ReconstructSnapshot::non_null_ptr_type reconstruct_snapshot,
+			ReconstructType::flags_type reconstruct_types)
+	{
+		// Reconstruct type flags must correspond to existing flags.
+		if ((reconstruct_types & ~ReconstructType::ALL_RECONSTRUCT_TYPES) != 0)
+		{
+			PyErr_SetString(PyExc_ValueError, "Unknown bit flag specified in reconstruct types.");
+			bp::throw_error_already_set();
+		}
+
+		bp::list reconstructed_features_list;
+
+		// Group the reconstructed geometries by their feature.
+		//
+		// Note: The features are sorted in the order of the features in the reconstructable files (and the order across files).
+		const std::list<ReconstructSnapshot::feature_geometry_group_type> reconstructed_features =
+				reconstruct_snapshot->get_reconstructed_features(reconstruct_types);
+
+		// Output the reconstructed geometries of each feature.
+		for (const auto &reconstructed_feature : reconstructed_features)
+		{
+			// Create a Python feature.
+			bp::object feature_object(
+					GPlatesModel::FeatureHandle::non_null_ptr_to_const_type(
+							reconstructed_feature.feature_ref.handle_ptr()));
+
+			// Python list of reconstructed geometries of the current feature.
+			bp::list reconstructed_geometries_list;
+			for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
+			{
+				reconstructed_geometries_list.append(reconstructed_geometry);
+			}
+
+			reconstructed_features_list.append(
+					bp::make_tuple(feature_object, reconstructed_geometries_list));
+		}
+
+		return reconstructed_features_list;
+	}
+
+	/**
+	 * This is called directly from Python via 'ReconstructSnapshot.get_reconstructed_geometries()'.
+	 */
+	bp::list
+	reconstruct_snapshot_get_reconstructed_geometries(
+			ReconstructSnapshot::non_null_ptr_type reconstruct_snapshot,
+			ReconstructType::flags_type reconstruct_types,
+			bool same_order_as_reconstructable_features)
+	{
+		// Reconstruct type flags must correspond to existing flags.
+		if ((reconstruct_types & ~ReconstructType::ALL_RECONSTRUCT_TYPES) != 0)
+		{
+			PyErr_SetString(PyExc_ValueError, "Unknown bit flag specified in reconstruct types.");
+			bp::throw_error_already_set();
+		}
+
+		bp::list reconstructed_geometries_list;
+
+		if (same_order_as_reconstructable_features)
+		{
+			// Group the reconstructed geometries by their feature.
+			//
+			// Note: The features are sorted in the order of the features in the reconstructable files (and the order across files).
+			const std::list<ReconstructSnapshot::feature_geometry_group_type> reconstructed_features =
+					reconstruct_snapshot->get_reconstructed_features(reconstruct_types);
+
+			// Output the reconstructed geometries of each feature.
+			for (const auto &reconstructed_feature : reconstructed_features)
+			{
+				for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
+				{
+					reconstructed_geometries_list.append(reconstructed_geometry);
+				}
+			}
+		}
+		else
+		{
+			// Get all reconstructed geometries (not sorted by feature).
+			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> reconstructed_geometries =
+					reconstruct_snapshot->get_reconstructed_geometries(reconstruct_types);
+
+			// Output the reconstructed geometries.
+			for (auto reconstructed_geometry : reconstructed_geometries)
+			{
+				reconstructed_geometries_list.append(reconstructed_geometry);
+			}
+		}
+
+		return reconstructed_geometries_list;
+	}
+
+	/**
+	 * This is called directly from Python via 'ReconstructSnapshot.export_reconstructed_geometries()'.
+	 */
+	void
+	reconstruct_snapshot_export_reconstructed_geometries(
+			ReconstructSnapshot::non_null_ptr_type reconstruct_snapshot,
+			const FilePathFunctionArgument &export_file_name,
+			ReconstructType::Value reconstruct_type,
+			bool wrap_to_dateline,
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation)
+	{
+		// Reconstruct type flag must correspond to an existing flag.
+		if ((reconstruct_type & ~ReconstructType::ALL_RECONSTRUCT_TYPES) != 0)
+		{
+			PyErr_SetString(PyExc_ValueError, "Unknown reconstruct type.");
+			bp::throw_error_already_set();
+		}
+
+		// And the reconstruct type can be only one flag.
+		if (reconstruct_type != ReconstructType::FEATURE_GEOMETRY &&
+			reconstruct_type != ReconstructType::MOTION_PATH &&
+			reconstruct_type != ReconstructType::FLOWLINE)
+		{
+			PyErr_SetString(PyExc_ValueError, "Must specify a single reconstruct type.");
+			bp::throw_error_already_set();
+		}
+
+		reconstruct_snapshot->export_reconstructed_geometries(
+				export_file_name,
+				reconstruct_type,
+				wrap_to_dateline,
+				force_boundary_orientation);
+	}
+
+
+	ReconstructSnapshot::non_null_ptr_type
+	ReconstructSnapshot::create(
+			const FeatureCollectionSequenceFunctionArgument &reconstructable_features,
+			const RotationModelFunctionArgument &rotation_model_argument,
+			const double &reconstruction_time,
+			boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id)
+	{
+		// Extract the rotation model from the function argument and adapt it to a new one that has 'anchor_plate_id'
+		// as its default (which if none, then uses default anchor plate of extracted rotation model instead).
+		// This ensures we will reconstruct using the correct anchor plate.
+		RotationModel::non_null_ptr_type rotation_model = RotationModel::create(
+				rotation_model_argument.get_rotation_model(),
+				1/*reconstruction_tree_cache_size*/,
+				anchor_plate_id);
+
+		// Get the reconstructable files.
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstructable_files;
+		reconstructable_features.get_files(reconstructable_files);
+
+		return non_null_ptr_type(
+				new ReconstructSnapshot(
+						rotation_model,
+						reconstructable_files,
+						reconstruction_time));
+	}
+
+	ReconstructSnapshot::ReconstructSnapshot(
+			const RotationModel::non_null_ptr_type &rotation_model,
+			const std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+			const double &reconstruction_time) :
+		d_rotation_model(rotation_model),
+		d_reconstructable_files(reconstructable_files),
+		d_reconstruction_time(reconstruction_time)
+	{
+		initialise_reconstructed_geometries();
+	}
+
+	void
+	ReconstructSnapshot::initialise_reconstructed_geometries()
+	{
+		// Clear the data members we're about to initialise in case this function called during transcribing.
+		d_reconstructed_feature_geometries.clear();
+		d_reconstructed_motion_paths.clear();
+		d_reconstructed_flowlines.clear();
+
+		//
+		// Reconstruct the features in the feature collection files.
+		//
+
+		const GPlatesAppLogic::ReconstructionTreeCreator reconstruction_tree_creator =
+				d_rotation_model->get_reconstruction_tree_creator();
+
+		// Create the context state in which to reconstruct.
+		const GPlatesAppLogic::ReconstructMethodInterface::Context reconstruct_method_context(
+				GPlatesAppLogic::ReconstructParams(),
+				reconstruction_tree_creator);
+
+		GPlatesAppLogic::ReconstructMethodRegistry reconstruct_method_registry;
+
+		// Get the next global reconstruct handle - it'll be stored in each RFG.
+		// It doesn't actually matter in our case though.
+		const GPlatesAppLogic::ReconstructHandle::type reconstruct_handle =
+				GPlatesAppLogic::ReconstructHandle::get_next_reconstruct_handle();
+
+		// Iterate over the files and reconstruct their features.
+		for (const auto &reconstruct_file : d_reconstructable_files)
+		{
+			const GPlatesModel::FeatureCollectionHandle::weak_ref feature_collection_ref =
+					reconstruct_file->get_reference().get_feature_collection();
+
+			// Iterate over the features in the current file's feature collection.
+			for (const auto &feature : *feature_collection_ref)
+			{
+				const GPlatesModel::FeatureHandle::weak_ref feature_ref = feature->reference();
+
+				// Determine what type of reconstructed output the current feature will produce (if any).
+				boost::optional<GPlatesAppLogic::ReconstructMethod::Type> reconstruct_method_type =
+						reconstruct_method_registry.get_reconstruct_method_type(feature_ref);
+				if (!reconstruct_method_type)
+				{
+					continue;
+				}
+
+				// Target reconstructed feature geometries or motion paths or flowlines depending on the reconstruct type.
+				boost::optional<std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &> reconstructed_geometries;
+				if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::FLOWLINE)  // ReconstructType::FLOWLINE
+				{
+					reconstructed_geometries = d_reconstructed_flowlines;
+				}
+				else if (reconstruct_method_type.get() == GPlatesAppLogic::ReconstructMethod::MOTION_PATH)  // ReconstructType::MOTION_PATH
+				{
+					reconstructed_geometries = d_reconstructed_motion_paths;
+				}
+				else  // ReconstructType::FEATURE_GEOMETRY
+				{
+					reconstructed_geometries = d_reconstructed_feature_geometries;
+				}
+
+				GPlatesAppLogic::ReconstructMethodInterface::non_null_ptr_type reconstruct_method =
+						reconstruct_method_registry.create_reconstruct_method(
+								reconstruct_method_type.get(),
+								feature_ref,
+								reconstruct_method_context);
+
+				// Reconstruct the current feature and append to the target reconstructed geometries array.
+				reconstruct_method->reconstruct_feature_geometries(
+						reconstructed_geometries.get(),
+						reconstruct_handle,
+						reconstruct_method_context,
+						d_reconstruction_time);
+			}
+		}
+	}
+
+	std::list<ReconstructSnapshot::feature_geometry_group_type>
+	ReconstructSnapshot::get_reconstructed_features(
+			ReconstructType::flags_type reconstruct_types) const
+	{
+		// Gather all the reconstructed geometries to output.
+		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type>
+				reconstructed_geometries = get_reconstructed_geometries(reconstruct_types);
+
+		// Group features with their reconstructed geometries.
+		//
+		// Note: Features are sorted in the order of the features in the reconstructable files (and the order across files).
+		std::list<ReconstructSnapshot::feature_geometry_group_type> grouped_reconstructed_geometries;
+		find_feature_geometry_groups(grouped_reconstructed_geometries, reconstructed_geometries);
+
+		return grouped_reconstructed_geometries;
+	}
+
+	void
+	ReconstructSnapshot::find_feature_geometry_groups(
+			std::list<ReconstructSnapshot::feature_geometry_group_type> &grouped_reconstructed_geometries,
+			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries) const
+	{
+		// Get the sequence of reconstructable files as File pointers.
+		std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
+		for (auto reconstructable_file : d_reconstructable_files)
+		{
+			reconstructable_file_ptrs.push_back(&reconstructable_file->get_reference());
+		}
+
+		// Converts reconstructed geometries to raw pointers.
+		std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_geometry_ptrs;
+		reconstructed_geometry_ptrs.reserve(reconstructed_geometries.size());
+		for (auto reconstructed_geometry : reconstructed_geometries)
+		{
+			reconstructed_geometry_ptrs.push_back(reconstructed_geometry.get());
+		}
+
+		//
+		// Order the reconstructed geometries according to the order of the features in the feature collections.
+		//
+
+		// Get the list of active reconstructable feature collection files that contain
+		// the features referenced by the ReconstructedFeatureGeometry objects.
+		GPlatesFileIO::ReconstructionGeometryExportImpl::feature_handle_to_collection_map_type feature_to_collection_map;
+		GPlatesFileIO::ReconstructionGeometryExportImpl::populate_feature_handle_to_collection_map(
+				feature_to_collection_map,
+				reconstructable_file_ptrs);
+
+		// Group the ReconstructedFeatureGeometry objects by their feature.
+		GPlatesFileIO::ReconstructionGeometryExportImpl::group_reconstruction_geometries_with_their_feature(
+				grouped_reconstructed_geometries,
+				reconstructed_geometry_ptrs,
+				feature_to_collection_map);
+	}
+
+	std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type>
+	ReconstructSnapshot::get_reconstructed_geometries(
+			ReconstructType::flags_type reconstruct_types) const
+	{
+		// Gather all the reconstructed geometries to output.
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> reconstructed_geometries;
+
+		if ((reconstruct_types & ReconstructType::FEATURE_GEOMETRY) != 0)
+		{
+			reconstructed_geometries.insert(
+					reconstructed_geometries.end(),
+					d_reconstructed_feature_geometries.begin(),
+					d_reconstructed_feature_geometries.end());
+		}
+
+		if ((reconstruct_types & ReconstructType::MOTION_PATH) != 0)
+		{
+			reconstructed_geometries.insert(
+					reconstructed_geometries.end(),
+					d_reconstructed_motion_paths.begin(),
+					d_reconstructed_motion_paths.end());
+		}
+
+		if ((reconstruct_types & ReconstructType::FLOWLINE) != 0)
+		{
+			reconstructed_geometries.insert(
+					reconstructed_geometries.end(),
+					d_reconstructed_flowlines.begin(),
+					d_reconstructed_flowlines.end());
+		}
+
+		return reconstructed_geometries;
+	}
+
+	void
+	ReconstructSnapshot::export_reconstructed_geometries(
+			const FilePathFunctionArgument &export_file_path,
+			ReconstructType::Value reconstruct_type,
+			bool wrap_to_dateline,
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+	{
+		const QString export_file_name = export_file_path.get_file_path();
+
+		// Get the reconstructed geometries.
+		//
+		// Note: We don't need to sort the reconstructed geometries because the following export will do that...
+		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type>
+				reconstructed_geometries = get_reconstructed_geometries(reconstruct_type);
+
+		// Get the sequence of reconstructable files as File pointers.
+		std::vector<const GPlatesFileIO::File::Reference *> reconstructable_file_ptrs;
+		for (const auto &reconstructable_file : d_reconstructable_files)
+		{
+			reconstructable_file_ptrs.push_back(&reconstructable_file->get_reference());
+		}
+
+		// Get the sequence of reconstruction files (if any) from the rotation model.
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstruction_files;
+		d_rotation_model->get_files(reconstruction_files);
+
+		// Convert the sequence of reconstruction files to File pointers.
+		std::vector<const GPlatesFileIO::File::Reference *> reconstruction_file_ptrs;
+		for (const auto &reconstruction_file : reconstruction_files)
+		{
+			reconstruction_file_ptrs.push_back(&reconstruction_file->get_reference());
+		}
+
+		// Export based on the reconstructed type requested by the caller.
+		switch (reconstruct_type)
+		{
+		case ReconstructType::FEATURE_GEOMETRY:
+			export_reconstructed_feature_geometries(
+					reconstructed_geometries,
+					export_file_name,
+					reconstructable_file_ptrs,
+					reconstruction_file_ptrs,
+					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
+					d_reconstruction_time,
+					wrap_to_dateline,
+					force_boundary_orientation);
+			break;
+
+		case ReconstructType::MOTION_PATH:
+			export_reconstructed_motion_paths(
+					reconstructed_geometries,
+					export_file_name,
+					reconstructable_file_ptrs,
+					reconstruction_file_ptrs,
+					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
+					d_reconstruction_time,
+					wrap_to_dateline,
+					force_boundary_orientation);
+			break;
+
+		case ReconstructType::FLOWLINE:
+			export_reconstructed_flowlines(
+					reconstructed_geometries,
+					export_file_name,
+					reconstructable_file_ptrs,
+					reconstruction_file_ptrs,
+					d_rotation_model->get_reconstruction_tree_creator().get_default_anchor_plate_id(),
+					d_reconstruction_time,
+					wrap_to_dateline,
+					force_boundary_orientation);
+			break;
+
+		default:
+			GPlatesGlobal::Abort(GPLATES_ASSERTION_SOURCE);
+			break;
+		}
+	}
+
+	void
+	ReconstructSnapshot::export_reconstructed_feature_geometries(
+			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+			const QString &export_file_name,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+			const double &reconstruction_time,
+			bool export_wrap_to_dateline,
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+	{
+		// Converts to raw pointers.
+		std::vector<const GPlatesAppLogic::ReconstructedFeatureGeometry *> reconstructed_feature_geometries;
+		reconstructed_feature_geometries.reserve(reconstructed_geometries.size());
+		for (auto rfg : reconstructed_geometries)
+		{
+			reconstructed_feature_geometries.push_back(rfg.get());
+		}
+
+		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
+		const GPlatesFileIO::ReconstructedFeatureGeometryExport::Format format =
+						GPlatesFileIO::ReconstructedFeatureGeometryExport::get_export_file_format(
+										export_file_name,
+										file_format_registry);
+
+		// The API docs state that dateline wrapping should be ignored except for Shapefile.
+		//
+		// For example, we don't want to pollute real-world data with dateline vertices when
+		// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
+		if (format != GPlatesFileIO::ReconstructedFeatureGeometryExport::SHAPEFILE)
+		{
+			export_wrap_to_dateline = false;
+		}
+
+		// Export the reconstructed feature geometries.
+		GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_geometries(
+					export_file_name,
+					format,
+					reconstructed_feature_geometries,
+					reconstructable_file_ptrs,
+					reconstruction_file_ptrs,
+					anchor_plate_id,
+					reconstruction_time,
+					// If exporting to Shapefile and there's only *one* input reconstructable file then
+					// shapefile attributes in input reconstructable file will get copied to output...
+					true/*export_single_output_file*/,
+					false/*export_per_input_file*/, // We only generate a single output file.
+					false/*export_output_directory_per_input_file*/, // We only generate a single output file.
+					export_wrap_to_dateline);
+	}
+
+	void
+	ReconstructSnapshot::export_reconstructed_motion_paths(
+			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+			const QString &export_file_name,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+			const double &reconstruction_time,
+			bool export_wrap_to_dateline,
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+	{
+		// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedMotionPath.
+		//
+		// Note that, when motion paths are reconstructed, both ReconstructedMotionPath's and
+		// ReconstructedFeatureGeometry's are generated - so this also ensures that the
+		// ReconstructedFeatureGeometry's are ignored when outputting reconstructed motion paths.
+		std::vector<const GPlatesAppLogic::ReconstructedMotionPath *> reconstructed_motion_paths;
+		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
+				reconstructed_geometries.begin(),
+				reconstructed_geometries.end(),
+				reconstructed_motion_paths);
+
+		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
+		const GPlatesFileIO::ReconstructedMotionPathExport::Format format =
+						GPlatesFileIO::ReconstructedMotionPathExport::get_export_file_format(
+										export_file_name,
+										file_format_registry);
+
+		// The API docs state that dateline wrapping should be ignored except for Shapefile.
+		//
+		// For example, we don't want to pollute real-world data with dateline vertices when
+		// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
+		if (format != GPlatesFileIO::ReconstructedMotionPathExport::SHAPEFILE)
+		{
+			export_wrap_to_dateline = false;
+		}
+
+		// Export the reconstructed motion paths.
+		GPlatesFileIO::ReconstructedMotionPathExport::export_reconstructed_motion_paths(
+					export_file_name,
+					format,
+					reconstructed_motion_paths,
+					reconstructable_file_ptrs,
+					reconstruction_file_ptrs,
+					anchor_plate_id,
+					reconstruction_time,
+					true/*export_single_output_file*/,
+					false/*export_per_input_file*/, // We only generate a single output file.
+					false/*export_output_directory_per_input_file*/, // We only generate a single output file.
+					export_wrap_to_dateline);
+	}
+
+	void
+	ReconstructSnapshot::export_reconstructed_flowlines(
+			const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+			const QString &export_file_name,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+			const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+			const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+			const double &reconstruction_time,
+			bool export_wrap_to_dateline,
+			boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const
+	{
+		// Get any ReconstructedFeatureGeometry objects that are of type ReconstructedFlowline.
+		// In fact they should all be ReconstructedFlowlines.
+		std::vector<const GPlatesAppLogic::ReconstructedFlowline *> reconstructed_flowlines;
+		GPlatesAppLogic::ReconstructionGeometryUtils::get_reconstruction_geometry_derived_type_sequence(
+						reconstructed_geometries.begin(),
+						reconstructed_geometries.end(),
+						reconstructed_flowlines);
+
+		GPlatesFileIO::FeatureCollectionFileFormat::Registry file_format_registry;
+		const GPlatesFileIO::ReconstructedFlowlineExport::Format format =
+						GPlatesFileIO::ReconstructedFlowlineExport::get_export_file_format(
+										export_file_name,
+										file_format_registry);
+
+		// The API docs state that dateline wrapping should be ignored except for Shapefile.
+		//
+		// For example, we don't want to pollute real-world data with dateline vertices when
+		// using GMT software (since it can handle 3D globe data, whereas ESRI handles only 2D).
+		if (format != GPlatesFileIO::ReconstructedFlowlineExport::SHAPEFILE)
+		{
+			export_wrap_to_dateline = false;
+		}
+			
+		// Export the reconstructed flowlines.
+		GPlatesFileIO::ReconstructedFlowlineExport::export_reconstructed_flowlines(
+				export_file_name,
+				format,
+				reconstructed_flowlines,
+				reconstructable_file_ptrs,
+				reconstruction_file_ptrs,
+				anchor_plate_id,
+				reconstruction_time,
+				true/*export_single_output_file*/,
+				false/*export_per_input_file*/, // We only generate a single output file.
+				false/*export_output_directory_per_input_file*/, // We only generate a single output file.
+				export_wrap_to_dateline);
+	}
+
+
+	GPlatesScribe::TranscribeResult
+	ReconstructSnapshot::transcribe_construct_data(
+			GPlatesScribe::Scribe &scribe,
+			GPlatesScribe::ConstructObject<ReconstructSnapshot> &reconstruct_snapshot)
+	{
+		if (scribe.is_saving())
+		{
+			save_construct_data(scribe, reconstruct_snapshot.get_object());
+		}
+		else // loading
+		{
+			GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> rotation_model;
+			std::vector<GPlatesFileIO::File::non_null_ptr_type> reconstructable_files;
+			double reconstruction_time;
+			if (!load_construct_data(
+					scribe,
+					rotation_model,
+					reconstructable_files,
+					reconstruction_time))
+			{
+				return scribe.get_transcribe_result();
+			}
+
+			// Create the reconstruct model.
+			reconstruct_snapshot.construct_object(
+					rotation_model,
+					reconstructable_files,
+					reconstruction_time);
+		}
+
+		return GPlatesScribe::TRANSCRIBE_SUCCESS;
+	}
+
+
+	GPlatesScribe::TranscribeResult
+	ReconstructSnapshot::transcribe(
+			GPlatesScribe::Scribe &scribe,
+			bool transcribed_construct_data)
+	{
+		if (!transcribed_construct_data)
+		{
+			if (scribe.is_saving())
+			{
+				save_construct_data(scribe, *this);
+			}
+			else // loading
+			{
+				GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> rotation_model;
+				if (!load_construct_data(
+						scribe,
+						rotation_model,
+						d_reconstructable_files,
+						d_reconstruction_time))
+				{
+					return scribe.get_transcribe_result();
+				}
+				d_rotation_model = rotation_model.get();
+
+				// Initialise reconstructed geometries (based on the construct parameters we just loaded).
+				//
+				// Note: The existing reconstructed geometries in 'this' reconstructable snapshot must be old data
+				//       because 'transcribed_construct_data' is false (ie, it was not transcribed) and so 'this'
+				//       object must've been created first (using unknown constructor arguments) and *then* transcribed.
+				initialise_reconstructed_geometries();
+			}
+		}
+
+		return GPlatesScribe::TRANSCRIBE_SUCCESS;
+	}
+
+
+	void
+	ReconstructSnapshot::save_construct_data(
+			GPlatesScribe::Scribe &scribe,
+			const ReconstructSnapshot &reconstruct_snapshot)
+	{
+		// Save the rotation model.
+		scribe.save(TRANSCRIBE_SOURCE, reconstruct_snapshot.d_rotation_model, "rotation_model");
+
+		const GPlatesScribe::ObjectTag files_tag("files");
+
+		// Save number of reconstructable files.
+		const unsigned int num_files = reconstruct_snapshot.d_reconstructable_files.size();
+		scribe.save(TRANSCRIBE_SOURCE, num_files, files_tag.sequence_size());
+
+		// Save the reconstructable files (feature collections and their filenames).
+		for (unsigned int file_index = 0; file_index < num_files; ++file_index)
+		{
+			const auto feature_collection_file = reconstruct_snapshot.d_reconstructable_files[file_index];
+
+			const GPlatesModel::FeatureCollectionHandle::non_null_ptr_type feature_collection(
+					feature_collection_file->get_reference().get_feature_collection().handle_ptr());
+			const QString filename =
+					feature_collection_file->get_reference().get_file_info().get_qfileinfo().absoluteFilePath();
+
+			scribe.save(TRANSCRIBE_SOURCE, feature_collection, files_tag[file_index]("feature_collection"));
+			scribe.save(TRANSCRIBE_SOURCE, filename, files_tag[file_index]("filename"));
+		}
+
+		// Save the reconstruction time.
+		scribe.save(TRANSCRIBE_SOURCE, reconstruct_snapshot.d_reconstruction_time, "reconstruction_time");
+	}
+
+
+	bool
+	ReconstructSnapshot::load_construct_data(
+			GPlatesScribe::Scribe &scribe,
+			GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> &rotation_model,
+			std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+			double &reconstruction_time)
+	{
+		// Load the rotation model.
+		rotation_model = scribe.load<RotationModel::non_null_ptr_type>(TRANSCRIBE_SOURCE, "rotation_model");
+		if (!rotation_model.is_valid())
+		{
+			return false;
+		}
+
+		const GPlatesScribe::ObjectTag files_tag("files");
+
+		// Number of reconstructable files.
+		unsigned int num_files;
+		if (!scribe.transcribe(TRANSCRIBE_SOURCE, num_files, files_tag.sequence_size()))
+		{
+			return false;
+		}
+
+		// Load the reconstructable files (feature collections and their filenames).
+		for (unsigned int file_index = 0; file_index < num_files; ++file_index)
+		{
+			GPlatesScribe::LoadRef<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type> feature_collection =
+					scribe.load<GPlatesModel::FeatureCollectionHandle::non_null_ptr_type>(
+							TRANSCRIBE_SOURCE,
+							files_tag[file_index]("feature_collection"));
+			if (!feature_collection.is_valid())
+			{
+				return false;
+			}
+
+			QString filename;
+			if (!scribe.transcribe(TRANSCRIBE_SOURCE, filename, files_tag[file_index]("filename")))
+			{
+				return false;
+			}
+
+			reconstructable_files.push_back(
+					GPlatesFileIO::File::create_file(GPlatesFileIO::FileInfo(filename), feature_collection));
+		}
+
+		// Load the reconstruction time.
+		if (!scribe.transcribe(TRANSCRIBE_SOURCE, reconstruction_time, "reconstruction_time"))
+		{
+			return false;
+		}
+
+		return true;
+	}
+}
+
+	
+void
+export_reconstruct_snapshot()
+{
+	// An enumeration nested within 'pygplates' (ie, current) module.
+	bp::enum_<GPlatesApi::ReconstructType::Value>("ReconstructType")
+			.value("feature_geometry", GPlatesApi::ReconstructType::FEATURE_GEOMETRY)
+			.value("motion_path", GPlatesApi::ReconstructType::MOTION_PATH)
+			.value("flowline", GPlatesApi::ReconstructType::FLOWLINE);
+
+
+	//
+	// ReconstructSnapshot - docstrings in reStructuredText (see http://sphinx-doc.org/rest.html).
+	//
+	bp::class_<
+			GPlatesApi::ReconstructSnapshot,
+			GPlatesApi::ReconstructSnapshot::non_null_ptr_type,
+			boost::noncopyable>(
+					"ReconstructSnapshot",
+					"A snapshot of reconstructed geometries at a specific geological time.\n"
+					"\n"
+					"A *ReconstructSnapshot* can also be `pickled <https://docs.python.org/3/library/pickle.html>`_.\n"
+					"\n"
+					".. versionadded:: 0.48\n",
+					// We need this (even though "__init__" is defined) since
+					// there is no publicly-accessible default constructor...
+					bp::no_init)
+		.def("__init__",
+				bp::make_constructor(
+						&GPlatesApi::reconstruct_snapshot_create,
+						bp::default_call_policies(),
+						(bp::arg("reconstructable_features"),
+							bp::arg("rotation_model"),
+							bp::arg("reconstruction_time"),
+							bp::arg("anchor_plate_id") = boost::optional<GPlatesModel::integer_plate_id_type>())),
+			"__init__(reconstructable_features, rotation_model, reconstruction_time, [anchor_plate_id])\n"
+			"  Create from reconstructable features and a rotation model at a specific reconstruction time.\n"
+			"\n"
+			"  :param reconstructable_features: The reconstructable features as a feature collection, "
+			"or filename, or feature, or sequence of features, or a sequence (eg, ``list`` or ``tuple``) "
+			"of any combination of those four types.\n"
+			"  :type reconstructable_features: :class:`FeatureCollection`, or string/``os.PathLike``, or :class:`Feature`, "
+			"or sequence of :class:`Feature`, or sequence of any combination of those four types\n"
+			"  :param rotation_model: A rotation model or a rotation feature collection or a rotation "
+			"filename or a sequence of rotation feature collections and/or rotation filenames\n"
+			"  :type rotation_model: :class:`RotationModel` or :class:`FeatureCollection` or string/``os.PathLike`` "
+			"or sequence of :class:`FeatureCollection` instances and/or string/``os.PathLike`` instances\n"
+			"  :param reconstruction_time: the specific geological time to reconstruct to\n"
+			"  :type reconstruction_time: float or :class:`GeoTimeInstant`\n"
+			"  :param anchor_plate_id: The anchored plate id used for all reconstructions. "
+			"Defaults to the default anchor plate of *rotation_model* (or zero if *rotation_model* is not a :class:`RotationModel`).\n"
+			"  :type anchor_plate_id: int\n"
+			"\n"
+			"  Create a reconstruct snapshot by reconstructing features at a specific reconstruction time:\n"
+			"  ::\n"
+			"\n"
+			"    reconstruction_time = 100\n"
+			"    reconstructable_features = pygplates.FeatureCollection('reconstructable_features.gpml')\n"
+			"    rotation_model = pygplates.RotationModel('rotations.rot')\n"
+			"    reconstruct_snapshot = pygplates.ReconstructSnapshot(reconstructable_features, rotation_model, reconstruction_time)\n")
+		// Pickle support...
+		//
+		// Note: This adds an __init__ method accepting a single argument (of type 'bytes') that supports pickling.
+		//       So we define this *after* (higher priority) the other __init__ methods in case one of them accepts a single argument
+		//       of type bp::object (which, being more general, would otherwise obscure the __init__ that supports pickling).
+		.def(GPlatesApi::PythonPickle::PickleDefVisitor<GPlatesApi::ReconstructSnapshot::non_null_ptr_type>())
+		.def("get_reconstructed_features",
+				&GPlatesApi::reconstruct_snapshot_get_reconstructed_features,
+				(bp::arg("reconstruct_types") = GPlatesApi::ReconstructType::DEFAULT_RECONSTRUCT_TYPES),
+				"get_reconstructed_features([reconstruct_types=pygplates.ReconstructType.feature_geometry])\n"
+				"  Returns the reconstructed geometries of the requested type(s) grouped by their feature.\n"
+				"\n"
+				"  :param reconstruct_types: specifies the reconstructed geometry types to return - defaults "
+				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :type reconstruct_types: a bitwise combination of any of ``pygplates.ReconstructType.feature_geometry``, "
+				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
+				"  :returns: a list of tuples, where each tuple contains a :class:`Feature` and a ``list`` of reconstructed geometries "
+				"(each reconstructed geometry is a :class:`reconstructed feature geometry <ReconstructedFeatureGeometry>`, "
+				":class:`reconstructed motion path <ReconstructedMotionPath>` or :class:`reconstructed flowline <ReconstructedFlowline>` - "
+				"depending on the optional argument *reconstruct_types*)\n"
+				"  :rtype: ``list``\n"
+				"  :raises: ValueError if *reconstruct_types* (if specified) contains a flag that "
+				"is not one of ``pygplates.ReconstructType.feature_geometry``, ``pygplates.ReconstructType.motion_path`` or "
+				"``pygplates.ReconstructType.flowline``\n"
+				"\n"
+				"  This can be useful when a :class:`feature <Feature>` has more than one geometry and hence more than one reconstructed geometry.\n"
+				"\n"
+				"  .. note:: The returned features (and associated reconstructed geometries) are sorted in the order of the reconstructable features "
+				"(including order across reconstructable files, if there were any).\n"
+				"\n"
+				"  To get the :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>` grouped by their :class:`Feature`:\n"
+				"  ::\n"
+				"\n"
+				"    reconstructed_features = reconstruct_snapshot.get_reconstructed_features()\n"
+				"    for feature, feature_reconstructed_geometries in reconstructed_features:\n"
+				"        # Note that 'feature' is the same as 'feature_reconstructed_geometry.get_feature()'.\n"
+				"        for feature_reconstructed_geometry in feature_reconstructed_geometries:\n"
+				"            ...\n"
+				"\n"
+				"  .. seealso:: get_reconstructed_geometries\n")
+		.def("get_reconstructed_geometries",
+				&GPlatesApi::reconstruct_snapshot_get_reconstructed_geometries,
+				(bp::arg("reconstruct_types") = GPlatesApi::ReconstructType::DEFAULT_RECONSTRUCT_TYPES,
+					bp::arg("same_order_as_reconstructable_features") = false),
+				"get_reconstructed_geometries([reconstruct_types=pygplates.ReconstructType.feature_geometry], [same_order_as_reconstructable_features=False])\n"
+				"  Returns the reconstructed geometries of the requested type(s).\n"
+				"\n"
+				"  :param reconstruct_types: specifies the reconstructed geometry types to return - defaults "
+				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :type reconstruct_types: a bitwise combination of any of ``pygplates.ReconstructType.feature_geometry``, "
+				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
+				"  :param same_order_as_reconstructable_features: whether the returned reconstructed geometries are sorted in "
+				"the order of the reconstructable features (including order across reconstructable files, if there were any) - "
+				"defaults to ``False``\n"
+				"  :type same_order_as_reconstructable_features: bool\n"
+				"  :returns: the :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`, "
+				":class:`reconstructed motion paths <ReconstructedMotionPath>` and :class:`reconstructed flowlines <ReconstructedFlowline>` "
+				"(depending on the optional argument *reconstruct_types*) - by default :class:`reconstructed motion paths <ReconstructedMotionPath>` "
+				"and :class:`reconstructed flowlines <ReconstructedFlowline>` are excluded\n"
+				"  :rtype: ``list``\n"
+				"  :raises: ValueError if *reconstruct_types* (if specified) contains a flag that "
+				"is not one of ``pygplates.ReconstructType.feature_geometry``, ``pygplates.ReconstructType.motion_path`` or "
+				"``pygplates.ReconstructType.flowline``\n"
+				"\n"
+				"  .. seealso:: get_reconstructed_features\n")
+		.def("export_reconstructed_geometries",
+				&GPlatesApi::reconstruct_snapshot_export_reconstructed_geometries,
+				(bp::arg("export_filename"),
+					bp::arg("reconstruct_type") = GPlatesApi::ReconstructType::DEFAULT_RECONSTRUCT_TYPE,
+					bp::arg("wrap_to_dateline") = true,
+					bp::arg("force_boundary_orientation") = boost::optional<GPlatesMaths::PolygonOrientation::Orientation>()),
+				"export_reconstructed_geometries(export_filename, [reconstruct_type=pygplates.ReconstructType.feature_geometry], "
+				"[wrap_to_dateline=True], [force_boundary_orientation])\n"
+				"  Exports the reconstructed geometries of the requested type(s) to a file.\n"
+				"\n"
+				"  :param export_filename: the name of the export file\n"
+				"  :type export_filename: string/``os.PathLike``\n"
+				"  :param reconstruct_type: specifies the **single** reconstructed geometry type to export - defaults "
+				"to :class:`reconstructed feature geometries <ReconstructedFeatureGeometry>`\n"
+				"  :type reconstruct_type: ``pygplates.ReconstructType.feature_geometry``, "
+				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
+				"  :param wrap_to_dateline: Whether to wrap/clip reconstructed geometries to the dateline "
+				"(currently ignored unless exporting to an ESRI Shapefile format *file*). Defaults to ``True``.\n"
+				"  :type wrap_to_dateline: bool\n"
+				"  :param force_boundary_orientation: Optionally force boundary orientation to "
+				"clockwise (``PolygonOnSphere.Orientation.clockwise``) or "
+				"counter-clockwise (``PolygonOnSphere.Orientation.counter_clockwise``). "
+				"Only applies to reconstructed feature geometries (excludes *motion paths* and *flowlines*). "
+				"Note that ESRI Shapefiles always use *clockwise* orientation (and so ignore this parameter).\n"
+				"  :type force_boundary_orientation: int\n"
+				"  :raises: ValueError if *reconstruct_type* (if specified) is not **one** of ``pygplates.ReconstructType.feature_geometry``, "
+				"``pygplates.ReconstructType.motion_path`` or ``pygplates.ReconstructType.flowline``\n"
+				"\n"
+				"  .. note:: *reconstruct_type* must be a **single** reconstruct type.  This is different than "
+				":meth:`get_reconstructed_geometries` and :meth:`get_reconstructed_features` which can specify multiple types.\n"
+				"\n"
+				"  The following *export* file formats are currently supported:\n"
+				"\n"
+				"  =============================== =======================\n"
+				"  Export File Format              Filename Extension     \n"
+				"  =============================== =======================\n"
+				"  ESRI Shapefile                  '.shp'                 \n"
+				"  GeoJSON                         '.geojson' or '.json'  \n"
+				"  OGR GMT                         '.gmt'                 \n"
+				"  GMT xy                          '.xy'                  \n"
+				"  =============================== =======================\n"
+				"\n"
+				"  .. note:: Reconstructed geometries are exported in the same order as that of their "
+				"respective reconstructable features (see :meth:`constructor<__init__>`) and the order across "
+				"reconstructable feature collections (if any) is also retained.\n")
+		.def("get_rotation_model",
+				&GPlatesApi::ReconstructSnapshot::get_rotation_model,
+				"get_rotation_model()\n"
+				"  Return the rotation model used internally.\n"
+				"\n"
+				"  :rtype: :class:`RotationModel`\n"
+				"\n"
+				"  .. note:: The :meth:`default anchor plate ID<RotationModel.get_default_anchor_plate_id>` of the returned rotation model "
+				"may be different to that of the rotation model passed into the :meth:`constructor<__init__>` if an anchor plate ID was specified "
+				"in the :meth:`constructor<__init__>`.\n")
+		.def("get_reconstruction_time",
+				&GPlatesApi::ReconstructSnapshot::get_reconstruction_time,
+				"get_reconstruction_time()\n"
+				"  Return the reconstruction time of this snapshot.\n"
+				"\n"
+				"  :rtype: float\n")
+		.def("get_anchor_plate_id",
+				&GPlatesApi::ReconstructSnapshot::get_anchor_plate_id,
+				"get_anchor_plate_id()\n"
+				"  Return the anchor plate ID (see :meth:`constructor<__init__>`).\n"
+				"\n"
+				"  :rtype: int\n"
+				"\n"
+				"  .. note:: This is the same as the :meth:`default anchor plate ID<RotationModel.get_default_anchor_plate_id>` "
+				"of :meth:`get_rotation_model`.\n")
+		// Make hash and comparisons based on C++ object identity (not python object identity)...
+		.def(GPlatesApi::ObjectIdentityHashDefVisitor())
+	;
+
+	// Register to/from Python conversions of non_null_intrusive_ptr<> including const/non-const and boost::optional.
+	GPlatesApi::PythonConverterUtils::register_all_conversions_for_non_null_intrusive_ptr<GPlatesApi::ReconstructSnapshot>();
+}

--- a/src/api/PyReconstructSnapshot.cc
+++ b/src/api/PyReconstructSnapshot.cc
@@ -124,7 +124,7 @@ namespace GPlatesApi
 			bp::list reconstructed_geometries_list;
 			for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
 			{
-				reconstructed_geometries_list.append(reconstructed_geometry);
+				reconstructed_geometries_list.append(reconstructed_geometry->get_non_null_pointer_to_const());
 			}
 
 			reconstructed_features_list.append(
@@ -165,7 +165,7 @@ namespace GPlatesApi
 			{
 				for (auto reconstructed_geometry : reconstructed_feature.recon_geoms)
 				{
-					reconstructed_geometries_list.append(reconstructed_geometry);
+					reconstructed_geometries_list.append(reconstructed_geometry->get_non_null_pointer_to_const());
 				}
 			}
 		}
@@ -178,7 +178,7 @@ namespace GPlatesApi
 			// Output the reconstructed geometries.
 			for (auto reconstructed_geometry : reconstructed_geometries)
 			{
-				reconstructed_geometries_list.append(reconstructed_geometry);
+				reconstructed_geometries_list.append(reconstructed_geometry->get_non_null_pointer_to_const());
 			}
 		}
 

--- a/src/api/PyReconstructSnapshot.h
+++ b/src/api/PyReconstructSnapshot.h
@@ -30,6 +30,8 @@
 #include "PyFeatureCollectionFunctionArgument.h"
 
 #include "app-logic/ReconstructedFeatureGeometry.h"
+#include "app-logic/ReconstructedFlowline.h"
+#include "app-logic/ReconstructedMotionPath.h"
 
 #include "file-io/File.h"
 #include "file-io/ReconstructionGeometryExportImpl.h"
@@ -144,7 +146,7 @@ namespace GPlatesApi
 		/**
 		 * Get reconstructed motion paths.
 		 */
-		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &
+		const std::vector<GPlatesAppLogic::ReconstructedMotionPath::non_null_ptr_type> &
 		get_reconstructed_motion_paths() const
 		{
 			return d_reconstructed_motion_paths;
@@ -153,7 +155,7 @@ namespace GPlatesApi
 		/**
 		 * Get reconstructed flowlines.
 		 */
-		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &
+		const std::vector<GPlatesAppLogic::ReconstructedFlowline::non_null_ptr_type> &
 		get_reconstructed_flowlines() const
 		{
 			return d_reconstructed_flowlines;
@@ -254,8 +256,8 @@ namespace GPlatesApi
 		double d_reconstruction_time;
 
 		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_feature_geometries;
-		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_motion_paths;
-		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_flowlines;
+		std::vector<GPlatesAppLogic::ReconstructedMotionPath::non_null_ptr_type> d_reconstructed_motion_paths;
+		std::vector<GPlatesAppLogic::ReconstructedFlowline::non_null_ptr_type> d_reconstructed_flowlines;
 
 
 		ReconstructSnapshot(
@@ -281,7 +283,6 @@ namespace GPlatesApi
 
 		void
 		export_reconstructed_feature_geometries(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 				const QString &export_file_name,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
@@ -292,7 +293,6 @@ namespace GPlatesApi
 
 		void
 		export_reconstructed_motion_paths(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 				const QString &export_file_name,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
@@ -303,7 +303,6 @@ namespace GPlatesApi
 
 		void
 		export_reconstructed_flowlines(
-				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
 				const QString &export_file_name,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,

--- a/src/api/PyReconstructSnapshot.h
+++ b/src/api/PyReconstructSnapshot.h
@@ -190,7 +190,8 @@ namespace GPlatesApi
 		 * (currently ignored unless exporting to an ESRI Shapefile format file). Defaults to true.
 		 *
 		 * If @a force_boundary_orientation is not none then force boundary orientation (clockwise or counter-clockwise)
-		 * of those reconstructed geometries that are polygons. Currently ignored by ESRI Shapefile which always uses clockwise.
+		 * of those reconstructed feature geometries (excludes *motion paths* and *flowlines*) that are polygons.
+		 * Currently ignored by ESRI Shapefile which always uses clockwise.
 		 *
 		 * By default exports only reconstructed feature geometries (excludes motion paths and flowlines).
 		 */
@@ -298,8 +299,7 @@ namespace GPlatesApi
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
 				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
 				const double &reconstruction_time,
-				bool export_wrap_to_dateline,
-				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const;
+				bool export_wrap_to_dateline) const;
 
 		void
 		export_reconstructed_flowlines(
@@ -308,8 +308,7 @@ namespace GPlatesApi
 				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
 				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
 				const double &reconstruction_time,
-				bool export_wrap_to_dateline,
-				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const;
+				bool export_wrap_to_dateline) const;
 
 	private: // Transcribe...
 

--- a/src/api/PyReconstructSnapshot.h
+++ b/src/api/PyReconstructSnapshot.h
@@ -1,0 +1,346 @@
+/**
+ * Copyright (C) 2024 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef GPLATES_API_PY_RECONSTRUCT_SNAPSHOT_H
+#define GPLATES_API_PY_RECONSTRUCT_SNAPSHOT_H
+
+#include <utility>  // std::pair
+#include <vector>
+#include <map>
+#include <boost/optional.hpp>
+
+#include "PyFilePathFunctionArgument.h"
+#include "PyRotationModel.h"
+#include "PyFeatureCollectionFunctionArgument.h"
+
+#include "app-logic/ReconstructedFeatureGeometry.h"
+
+#include "file-io/File.h"
+#include "file-io/ReconstructionGeometryExportImpl.h"
+
+#include "global/python.h"
+
+#include "maths/PolygonOrientation.h"
+#include "maths/types.h"
+
+#include "model/FeatureHandle.h"
+#include "model/types.h"
+
+#include "property-values/GeoTimeInstant.h"
+
+#include "scribe/ScribeLoadRef.h"
+ // Try to only include the heavyweight "Scribe.h" in '.cc' files where possible.
+#include "scribe/Transcribe.h"
+
+#include "utils/ReferenceCount.h"
+
+
+namespace GPlatesApi
+{
+	/**
+	 * Enumeration to determine which reconstructed feature geometry types to output.
+	 *
+	 * This can be used as a bitwise combination of flags.
+	 */
+	namespace ReconstructType
+	{
+		enum Value
+		{
+			FEATURE_GEOMETRY = (1 << 0),
+			MOTION_PATH = (1 << 1),
+			FLOWLINE = (1 << 2)
+		};
+
+		// Use this (integer) type when extracting flags (of reconstructed feature geometry types).
+		typedef unsigned int flags_type;
+
+		// Mask of allowed bit flags for 'ReconstructType'.
+		constexpr flags_type ALL_RECONSTRUCT_TYPES = (FEATURE_GEOMETRY | MOTION_PATH | FLOWLINE);
+
+		// Default reconstructed feature geometry type.
+		//
+		// Note: 'pygplates.reconstruct()' and 'pygplates.ReconstructSnapshot.export_reconstructed_geometries()'
+		//       only accept a *single* type.
+		constexpr Value DEFAULT_RECONSTRUCT_TYPE = FEATURE_GEOMETRY;
+
+		// Default reconstructed feature geometry types excludes motion paths and flowlines.
+		//
+		// Note: 'pygplates.ReconstructSnapshot.get_reconstructed_geometries()' accepts *multiple* types.
+		constexpr flags_type DEFAULT_RECONSTRUCT_TYPES = DEFAULT_RECONSTRUCT_TYPE;
+	};
+
+
+	/**
+	 * Snapshot, at a specific reconstruction time, of the reconstruction of reconstructable features.
+	 */
+	class ReconstructSnapshot :
+			public GPlatesUtils::ReferenceCount<ReconstructSnapshot>
+	{
+	public:
+
+		typedef GPlatesUtils::non_null_intrusive_ptr<ReconstructSnapshot> non_null_ptr_type;
+		typedef GPlatesUtils::non_null_intrusive_ptr<const ReconstructSnapshot> non_null_ptr_to_const_type;
+
+		//! Typedef for reconstructed geometries grouped by feature.
+		typedef GPlatesFileIO::ReconstructionGeometryExportImpl::FeatureGeometryGroup<GPlatesAppLogic::ReconstructedFeatureGeometry>
+				feature_geometry_group_type;
+
+
+		/**
+		 * Create a reconstruct snapshot, at specified reconstruction time, from reconstructable features and associated rotation model.
+		 */
+		static
+		non_null_ptr_type
+		create(
+				const FeatureCollectionSequenceFunctionArgument &reconstructable_features_argument,
+				const RotationModelFunctionArgument &rotation_model_argument,
+				const double &reconstruction_time,
+				boost::optional<GPlatesModel::integer_plate_id_type> anchor_plate_id);
+
+		/**
+		 * Create a reconstruct snapshot, at specified reconstruction time, from reconstructable files and
+		 * associated rotation model (with embedded anchor plate ID).
+		 */
+		static
+		non_null_ptr_type
+		create(
+				const std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+				const RotationModel::non_null_ptr_type &rotation_model,
+				const double &reconstruction_time)
+		{
+			return non_null_ptr_type(
+					new ReconstructSnapshot(
+							rotation_model,
+							reconstructable_files,
+							reconstruction_time));
+		}
+
+
+		/**
+		 * Get reconstructed feature geometries.
+		 */
+		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &
+		get_reconstructed_feature_geometries() const
+		{
+			return d_reconstructed_feature_geometries;
+		}
+
+		/**
+		 * Get reconstructed motion paths.
+		 */
+		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &
+		get_reconstructed_motion_paths() const
+		{
+			return d_reconstructed_motion_paths;
+		}
+
+		/**
+		 * Get reconstructed flowlines.
+		 */
+		const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &
+		get_reconstructed_flowlines() const
+		{
+			return d_reconstructed_flowlines;
+		}
+
+		/**
+		 * Get features grouped with their reconstructed geometries (feature geometries, motion paths and flowlines).
+		 *
+		 * The features are sorted in the order of the features in the reconstructable files (and the order across files).
+		 *
+		 * By default returns only features associated with reconstructed feature geometries (excludes motion paths and flowlines).
+		 */
+		std::list<feature_geometry_group_type>
+		get_reconstructed_features(
+				ReconstructType::flags_type reconstruct_types = ReconstructType::DEFAULT_RECONSTRUCT_TYPES) const;
+
+		/**
+		 * Get reconstructed geometries (feature geometries, motion paths and flowlines).
+		 *
+		 * The reconstructed geometries are NOT sorted (use @a get_reconstructed_features if you want sorting).
+		 *
+		 * By default returns only reconstructed feature geometries (excludes motion paths and flowlines).
+		 */
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type>
+		get_reconstructed_geometries(
+				ReconstructType::flags_type reconstruct_types = ReconstructType::DEFAULT_RECONSTRUCT_TYPES) const;
+
+		/**
+		 * Export reconstructed geometries (feature geometries, motion paths and flowlines) to a file.
+		 *
+		 * If @a wrap_to_dateline is true then wrap/clip reconstructed geometries to the dateline
+		 * (currently ignored unless exporting to an ESRI Shapefile format file). Defaults to true.
+		 *
+		 * If @a force_boundary_orientation is not none then force boundary orientation (clockwise or counter-clockwise)
+		 * of those reconstructed geometries that are polygons. Currently ignored by ESRI Shapefile which always uses clockwise.
+		 *
+		 * By default exports only reconstructed feature geometries (excludes motion paths and flowlines).
+		 */
+		void
+		export_reconstructed_geometries(
+				const FilePathFunctionArgument &export_file_name,
+				ReconstructType::Value reconstruct_type = ReconstructType::DEFAULT_RECONSTRUCT_TYPE,
+				bool wrap_to_dateline = true,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation = boost::none) const;
+
+
+		/**
+		 * Get the reconstructable files.
+		 */
+		const std::vector<GPlatesFileIO::File::non_null_ptr_type> &
+		get_reconstructable_files() const
+		{
+			return d_reconstructable_files;
+		}
+
+		/**
+		 * Get the rotation model.
+		 */
+		RotationModel::non_null_ptr_type
+		get_rotation_model() const
+		{
+			return d_rotation_model;
+		}
+
+		/**
+		 * Returns the reconstruction time of this snapshot.
+		 */
+		double
+		get_reconstruction_time() const
+		{
+			return d_reconstruction_time;
+		}
+
+		/**
+		 * Returns the anchor plate ID.
+		 */
+		GPlatesModel::integer_plate_id_type
+		get_anchor_plate_id() const
+		{
+			return get_rotation_model()->get_reconstruction_tree_creator().get_default_anchor_plate_id();
+		}
+
+	private:
+
+		/**
+		 * Rotation model associated with reconstructable features.
+		 */
+		RotationModel::non_null_ptr_type d_rotation_model;
+
+		/**
+		 * Reconstructable files.
+		 */
+		std::vector<GPlatesFileIO::File::non_null_ptr_type> d_reconstructable_files;
+
+		/**
+		 * Reconstruction time of snapshot.
+		 */
+		double d_reconstruction_time;
+
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_feature_geometries;
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_motion_paths;
+		std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> d_reconstructed_flowlines;
+
+
+		ReconstructSnapshot(
+				const RotationModel::non_null_ptr_type &rotation_model,
+				const std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+				const double &reconstruction_time);
+
+		/**
+		 * Set up for reconstruction once the reconstructable files/parameters have been constructed.
+		 */
+		void
+		initialise_reconstructed_geometries();
+
+		/**
+		 * Group features with their reconstructed geometries.
+		 *
+		 * Note: Features are sorted in the order of the features in the reconstructable files (and the order across files).
+		 */
+		void
+		find_feature_geometry_groups(
+				std::list<ReconstructSnapshot::feature_geometry_group_type> &grouped_reconstructed_geometries,
+				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries) const;
+
+		void
+		export_reconstructed_feature_geometries(
+				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+				const QString &export_file_name,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+				const double &reconstruction_time,
+				bool export_wrap_to_dateline,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const;
+
+		void
+		export_reconstructed_motion_paths(
+				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+				const QString &export_file_name,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+				const double &reconstruction_time,
+				bool export_wrap_to_dateline,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const;
+
+		void
+		export_reconstructed_flowlines(
+				const std::vector<GPlatesAppLogic::ReconstructedFeatureGeometry::non_null_ptr_type> &reconstructed_geometries,
+				const QString &export_file_name,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstructable_file_ptrs,
+				const std::vector<const GPlatesFileIO::File::Reference *> &reconstruction_file_ptrs,
+				const GPlatesModel::integer_plate_id_type &anchor_plate_id,
+				const double &reconstruction_time,
+				bool export_wrap_to_dateline,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_boundary_orientation) const;
+
+	private: // Transcribe...
+
+		friend class GPlatesScribe::Access;
+
+		static
+		GPlatesScribe::TranscribeResult
+		transcribe_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				GPlatesScribe::ConstructObject<ReconstructSnapshot> &reconstruct_snapshot);
+
+		GPlatesScribe::TranscribeResult
+		transcribe(
+				GPlatesScribe::Scribe &scribe,
+				bool transcribed_construct_data);
+
+		static
+		void
+		save_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				const ReconstructSnapshot &reconstruct_snapshot);
+
+		static
+		bool
+		load_construct_data(
+				GPlatesScribe::Scribe &scribe,
+				GPlatesScribe::LoadRef<RotationModel::non_null_ptr_type> &rotation_model,
+				std::vector<GPlatesFileIO::File::non_null_ptr_type> &reconstructable_files,
+				double &reconstruction_time);
+	};
+}
+
+#endif // GPLATES_API_PY_RECONSTRUCT_SNAPSHOT_H

--- a/src/api/PyResolveTopologies.cc
+++ b/src/api/PyResolveTopologies.cc
@@ -589,6 +589,8 @@ export_resolve_topologies()
 			"        'plate_polygons_and_networks.gpml', 'rotations.rot', resolved_topologies, 10,\n"
 			"         resolved_topological_sections)\n"
 			"\n"
+			"  .. seealso:: :class:`TopologicalModel` and :class:`TopologicalSnapshot`\n"
+			"\n"
 			"  .. versionchanged:: 0.29\n"
 			"     The output order of *resolved_topological_sections* is now same as that of their "
 			"respective features in *topological_features* (the order across feature collections is also retained). "

--- a/src/api/PyResolveTopologies.cc
+++ b/src/api/PyResolveTopologies.cc
@@ -295,7 +295,7 @@ namespace GPlatesApi
 		else // list of resolved topologies...
 		{
 			// Gather all the resolved topologies to output (limited to the resolve types requested).
-			std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_type> resolved_topologies =
+			const std::vector<GPlatesAppLogic::ReconstructionGeometry::non_null_ptr_type> resolved_topologies =
 					topological_snapshot->get_resolved_topologies(
 							resolve_topology_types,
 							// Sort the resolved topologies in the order of the features in the

--- a/src/api/PyTopologicalModel.cc
+++ b/src/api/PyTopologicalModel.cc
@@ -1875,7 +1875,7 @@ export_topological_model()
 								boost::optional<GPlatesApi::ResolveTopologyParameters::non_null_ptr_to_const_type>(),
 							bp::arg("topological_snapshot_cache_size") = boost::optional<unsigned int>())),
 			"__init__(topological_features, rotation_model, [anchor_plate_id], [default_resolve_topology_parameters], [topological_snapshot_cache_size])\n"
-			"  Create from topological features, a rotation model and a time span.\n"
+			"  Create from topological features and a rotation model.\n"
 			"\n"
 			"  :param topological_features: The topological boundary and/or network features and the "
 			"topological section features they reference (regular and topological lines) as a feature collection, "

--- a/src/api/PyTopologicalSnapshot.cc
+++ b/src/api/PyTopologicalSnapshot.cc
@@ -1846,7 +1846,8 @@ export_topological_snapshot()
 				&GPlatesApi::topological_snapshot_get_resolved_topologies,
 				(bp::arg("resolve_topology_types") = GPlatesApi::ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGY_TYPES,
 					bp::arg("same_order_as_topological_features") = false),
-				"get_resolved_topologies([resolve_topology_types], [same_order_as_topological_features=False])\n"
+				"get_resolved_topologies([resolve_topology_types=(pygplates.ResolveTopologyType.boundary|pygplates.ResolveTopologyType.network)], "
+				"[same_order_as_topological_features=False])\n"
 				"  Returns the resolved topologies of the requested type(s).\n"
 				"\n"
 				"  :param resolve_topology_types: specifies the resolved topology types to return - defaults "
@@ -1873,8 +1874,9 @@ export_topological_snapshot()
 					bp::arg("resolve_topology_types") = GPlatesApi::ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGY_TYPES,
 					bp::arg("wrap_to_dateline") = true,
 					bp::arg("force_boundary_orientation") = boost::optional<GPlatesMaths::PolygonOrientation::Orientation>()),
-				"export_resolved_topologies(export_filename, [resolve_topology_types], [wrap_to_dateline=True], [force_boundary_orientation])\n"
-				"  Exports the resolved topologies to a file.\n"
+				"export_resolved_topologies(export_filename, [resolve_topology_types=(pygplates.ResolveTopologyType.boundary|pygplates.ResolveTopologyType.network)], "
+				"[wrap_to_dateline=True], [force_boundary_orientation])\n"
+				"  Exports the resolved topologies of the requested type(s) to a file.\n"
 				"\n"
 				"  :param export_filename: the name of the export file\n"
 				"  :type export_filename: string/``os.PathLike``\n"
@@ -1919,7 +1921,8 @@ export_topological_snapshot()
 				&GPlatesApi::topological_snapshot_get_resolved_topological_sections,
 				(bp::arg("resolve_topological_section_types") = GPlatesApi::ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGICAL_SECTION_TYPES,
 					bp::arg("same_order_as_topological_features") = false),
-				"get_resolved_topological_sections([resolve_topological_section_types], [same_order_as_topological_features=False])\n"
+				"get_resolved_topological_sections([resolve_topological_section_types=(pygplates.ResolveTopologyType.boundary|pygplates.ResolveTopologyType.network)], "
+				"[same_order_as_topological_features=False])\n"
 				"  Returns the resolved topological sections of the requested type(s).\n"
 				"\n"
 				"  :param resolve_topological_section_types: Determines whether :class:`ResolvedTopologicalBoundary` or "
@@ -1942,9 +1945,10 @@ export_topological_snapshot()
 					bp::arg("resolve_topological_section_types") = GPlatesApi::ResolveTopologyType::DEFAULT_RESOLVE_TOPOLOGY_TYPES,
 					bp::arg("export_topological_line_sub_segments") = true,
 					bp::arg("wrap_to_dateline") = true),
-				"export_resolved_topological_sections(export_filename, [resolve_topological_section_types], "
+				"export_resolved_topological_sections(export_filename, "
+				"[resolve_topological_section_types=(pygplates.ResolveTopologyType.boundary|pygplates.ResolveTopologyType.network)], "
 				"[export_topological_line_sub_segments=True], [wrap_to_dateline=True])\n"
-				"  Exports the resolved topological sections to a file.\n"
+				"  Exports the resolved topological sections of the requested type(s) to a file.\n"
 				"\n"
 				"  :param export_filename: the name of the export file\n"
 				"  :type export_filename: string/``os.PathLike``\n"

--- a/src/api/PyTopologicalSnapshot.cc
+++ b/src/api/PyTopologicalSnapshot.cc
@@ -1776,7 +1776,7 @@ export_topological_snapshot()
 			GPlatesApi::TopologicalSnapshot::non_null_ptr_type,
 			boost::noncopyable>(
 					"TopologicalSnapshot",
-					"A snapshot of topologies at a specific geological time.\n"
+					"A snapshot of resolved topological features (lines, boundaries and networks) at a specific geological time.\n"
 					"\n"
 					"A *TopologicalSnapshot* can also be `pickled <https://docs.python.org/3/library/pickle.html>`_.\n"
 					"\n"

--- a/src/file-io/GMTFormatReconstructedFeatureGeometryExport.cc
+++ b/src/file-io/GMTFormatReconstructedFeatureGeometryExport.cc
@@ -34,6 +34,7 @@
 #include "GMTFormatGeometryExporter.h"
 #include "GMTFormatHeader.h"
 
+#include "app-logic/GeometryUtils.h"
 #include "app-logic/ReconstructedFeatureGeometry.h"
 
 #include "file-io/FileInfo.h"
@@ -111,7 +112,8 @@ GPlatesFileIO::GMTFormatReconstructedFeatureGeometryExport::export_geometries(
 		const referenced_files_collection_type &referenced_files,
 		const referenced_files_collection_type &active_reconstruction_files,
 		const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
-		const double &reconstruction_time)
+		const double &reconstruction_time,
+		boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation)
 {
 	// Open the file.
 	QFile output_file(file_info.filePath());
@@ -178,8 +180,19 @@ GPlatesFileIO::GMTFormatReconstructedFeatureGeometryExport::export_geometries(
 			// Print the header lines.
 			gmt_header_printer.print_feature_header_lines(output_stream, header_lines);
 
+			GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type
+					reconstructed_geometry = rfg->reconstructed_geometry();
+
+			// Orient polygon if forcing orientation and geometry is a polygon.
+			if (force_polygon_orientation)
+			{
+				reconstructed_geometry = GPlatesAppLogic::GeometryUtils::convert_geometry_to_oriented_geometry(
+						reconstructed_geometry,
+						force_polygon_orientation.get());
+			}
+
 			// Write the reconstructed geometry.
-			geom_exporter.export_geometry(rfg->reconstructed_geometry()); 
+			geom_exporter.export_geometry(reconstructed_geometry);
 		}
 	}
 }

--- a/src/file-io/GMTFormatReconstructedFeatureGeometryExport.h
+++ b/src/file-io/GMTFormatReconstructedFeatureGeometryExport.h
@@ -26,9 +26,12 @@
 #ifndef GPLATES_FILEIO_GMTFORMATRECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 #define GPLATES_FILEIO_GMTFORMATRECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 
+#include <boost/optional.hpp>
 #include <QFileInfo>
 
 #include "ReconstructionGeometryExportImpl.h"
+
+#include "maths/PolygonOrientation.h"
 
 #include "model/types.h"
 
@@ -56,8 +59,11 @@ namespace GPlatesFileIO
 
 
 		/**
-		* Exports @a ReconstructedFeatureGeometry objects to GMT format.
-		*/
+		 * Exports @a ReconstructedFeatureGeometry objects to GMT format.
+		 *
+		 * @param force_polygon_orientation optionally force polygon orientation (clockwise or counter-clockwise)
+		 * for those geometries that are polygons.
+		 */
 		void
 		export_geometries(
 				const std::list<feature_geometry_group_type> &feature_geometry_group_seq,
@@ -65,7 +71,8 @@ namespace GPlatesFileIO
 				const referenced_files_collection_type &referenced_files,
 				const referenced_files_collection_type &active_reconstruction_files,
 				const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
-				const double &reconstruction_time);
+				const double &reconstruction_time,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation = boost::none);
 	}
 }
 

--- a/src/file-io/OgrFormatReconstructedFeatureGeometryExport.cc
+++ b/src/file-io/OgrFormatReconstructedFeatureGeometryExport.cc
@@ -36,10 +36,13 @@
 #include "OgrGeometryExporter.h"
 #include "OgrUtils.h"
 
+#include "app-logic/GeometryUtils.h"
 #include "app-logic/ReconstructedFeatureGeometry.h"
+
 #include "feature-visitors/GeometryTypeFinder.h"
 #include "feature-visitors/KeyValueDictionaryFinder.h"
 #include "feature-visitors/PropertyValueFinder.h"
+
 #include "property-values/GpmlKeyValueDictionary.h"
 #include "property-values/GpmlPlateId.h"
 #include "property-values/XsDouble.h"
@@ -107,6 +110,7 @@ GPlatesFileIO::OgrFormatReconstructedFeatureGeometryExport::export_geometries(
 		const referenced_files_collection_type &active_reconstruction_files,
 		const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 		const double &reconstruction_time,
+		boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 		bool wrap_to_dateline)
 {
 
@@ -200,7 +204,25 @@ GPlatesFileIO::OgrFormatReconstructedFeatureGeometryExport::export_geometries(
 		{
 			const GPlatesAppLogic::ReconstructedFeatureGeometry *rfg = *rfg_iter;
 
-			reconstructed_geometries.push_back(rfg->reconstructed_geometry());
+			GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type
+					reconstructed_geometry = rfg->reconstructed_geometry();
+
+			// Orient polygon if forcing orientation and geometry is a polygon.
+			//
+			// NOTE: This only works for non-Shapefile OGR formats because the OGR Shapefile
+			// driver stores exterior rings as clockwise and interior as counter-clockwise -
+			// so whatever we do here could just get undone by the Shapefile driver.
+			// The Shapefile OGR driver will also combine two polygons into a single polygon with
+			// an exterior and interior ring (provided one polygon is fully contained inside
+			// the other - ie, if they don't intersect) and orient the rings as mentioned above.
+			if (force_polygon_orientation)
+			{
+				reconstructed_geometry = GPlatesAppLogic::GeometryUtils::convert_geometry_to_oriented_geometry(
+						reconstructed_geometry,
+						force_polygon_orientation.get());
+			}
+
+			reconstructed_geometries.push_back(reconstructed_geometry);
 		}
 
 		// Write the reconstructed geometries as a single feature.
@@ -220,6 +242,7 @@ GPlatesFileIO::OgrFormatReconstructedFeatureGeometryExport::export_geometries_pe
 		const referenced_files_collection_type &active_reconstruction_files,
 		const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 		const double &reconstruction_time,
+		boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 		bool wrap_to_dateline)
 {
 	// Iterate through the reconstructed geometries and check which geometry types we have.
@@ -334,7 +357,25 @@ GPlatesFileIO::OgrFormatReconstructedFeatureGeometryExport::export_geometries_pe
 		{
 			const GPlatesAppLogic::ReconstructedFeatureGeometry *rfg = *rfg_iter;
 
-			reconstructed_geometries.push_back(rfg->reconstructed_geometry());
+			GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type
+					reconstructed_geometry = rfg->reconstructed_geometry();
+
+			// Orient polygon if forcing orientation and geometry is a polygon.
+			//
+			// NOTE: This only works for non-Shapefile OGR formats because the OGR Shapefile
+			// driver stores exterior rings as clockwise and interior as counter-clockwise -
+			// so whatever we do here could just get undone by the Shapefile driver.
+			// The Shapefile OGR driver will also combine two polygons into a single polygon with
+			// an exterior and interior ring (provided one polygon is fully contained inside
+			// the other - ie, if they don't intersect) and orient the rings as mentioned above.
+			if (force_polygon_orientation)
+			{
+				reconstructed_geometry = GPlatesAppLogic::GeometryUtils::convert_geometry_to_oriented_geometry(
+						reconstructed_geometry,
+						force_polygon_orientation.get());
+			}
+
+			reconstructed_geometries.push_back(reconstructed_geometry);
 		}
 
 		// Write the reconstructed geometries as a single feature.

--- a/src/file-io/OgrFormatReconstructedFeatureGeometryExport.h
+++ b/src/file-io/OgrFormatReconstructedFeatureGeometryExport.h
@@ -26,11 +26,15 @@
 #ifndef GPLATES_FILEIO_SHAPEFILEFORMATRECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 #define GPLATES_FILEIO_SHAPEFILEFORMATRECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 
+#include <boost/optional.hpp>
 #include <QFileInfo>
 
 #include "ReconstructionGeometryExportImpl.h"
 
+#include "maths/PolygonOrientation.h"
+
 #include "model/types.h"
+
 #include "property-values/GpmlKeyValueDictionary.h"
 
 
@@ -58,6 +62,9 @@ namespace GPlatesFileIO
 
 		/**
 		* Exports @a ReconstructedFeatureGeometry objects to ESRI Shapefile format.
+		 *
+		 * @param force_polygon_orientation optionally force polygon orientation (clockwise or counter-clockwise)
+		 * for those geometries that are polygons.
 		*
 		* If @a wrap_to_dateline is true then exported polyline/polygon geometries are wrapped/clipped to the dateline.
 		*/
@@ -69,10 +76,14 @@ namespace GPlatesFileIO
 				const referenced_files_collection_type &active_reconstruction_files,
 				const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 				const double &reconstruction_time,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 				bool wrap_to_dateline);
 
 		/**
 		* Exports @a ReconstructedFeatureGeometry objects to ESRI Shapefile format.
+		 *
+		 * @param force_polygon_orientation optionally force polygon orientation (clockwise or counter-clockwise)
+		 * for those geometries that are polygons.
 		*
 		* If @a wrap_to_dateline is true then exported polyline/polygon geometries are wrapped/clipped to the dateline.
 		*/
@@ -84,6 +95,7 @@ namespace GPlatesFileIO
 				const referenced_files_collection_type &active_reconstruction_files,
 				const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 				const double &reconstruction_time,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 				bool wrap_to_dateline);
 	}
 }

--- a/src/file-io/ReconstructedFeatureGeometryExport.cc
+++ b/src/file-io/ReconstructedFeatureGeometryExport.cc
@@ -62,6 +62,7 @@ namespace GPlatesFileIO
 					const std::vector<const File::Reference *> &active_reconstruction_files,
 					const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 					const double &reconstruction_time,
+					boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 					bool wrap_to_dateline)
 			{
 				switch (export_format)
@@ -76,6 +77,7 @@ namespace GPlatesFileIO
 						active_reconstruction_files,
 						reconstruction_anchor_plate_id,
 						reconstruction_time,
+						force_polygon_orientation,
 						wrap_to_dateline);
 					break;
 
@@ -86,7 +88,8 @@ namespace GPlatesFileIO
 						referenced_files,
 						active_reconstruction_files,
 						reconstruction_anchor_plate_id,
-						reconstruction_time);
+						reconstruction_time,
+						force_polygon_orientation);
 					break;
 
 				default:
@@ -104,6 +107,7 @@ namespace GPlatesFileIO
 					const std::vector<const File::Reference *> &active_reconstruction_files,
 					const GPlatesModel::integer_plate_id_type &reconstruction_anchor_plate_id,
 					const double &reconstruction_time,
+					boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 					bool wrap_to_dateline)
 			{
 				switch(export_format)
@@ -118,6 +122,7 @@ namespace GPlatesFileIO
 						active_reconstruction_files,
 						reconstruction_anchor_plate_id,
 						reconstruction_time,
+						force_polygon_orientation,
 						wrap_to_dateline);
 					break;
 				case GMT:
@@ -127,7 +132,8 @@ namespace GPlatesFileIO
 						referenced_files,
 						active_reconstruction_files,
 						reconstruction_anchor_plate_id,
-						reconstruction_time);
+						reconstruction_time,
+						force_polygon_orientation);
 					break;
 				default:
 					throw FileFormatNotSupportedException(GPLATES_EXCEPTION_SOURCE,
@@ -188,6 +194,7 @@ GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_
 		bool export_single_output_file,
 		bool export_per_input_file,
 		bool export_separate_output_directory_per_input_file,
+		boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 		bool wrap_to_dateline)
 {
 	// Get the list of active reconstructable feature collection files that contain
@@ -228,6 +235,7 @@ GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_
 					active_reconstruction_files,
 					reconstruction_anchor_plate_id,
 					reconstruction_time,
+					force_polygon_orientation,
 					wrap_to_dateline);
 		}
 		else
@@ -245,6 +253,7 @@ GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_
 					active_reconstruction_files,
 					reconstruction_anchor_plate_id,
 					reconstruction_time,
+					force_polygon_orientation,
 					wrap_to_dateline);
 		}
 	}
@@ -272,6 +281,7 @@ GPlatesFileIO::ReconstructedFeatureGeometryExport::export_reconstructed_feature_
 					active_reconstruction_files,
 					reconstruction_anchor_plate_id,
 					reconstruction_time,
+					force_polygon_orientation,
 					wrap_to_dateline);
 		}
 	}

--- a/src/file-io/ReconstructedFeatureGeometryExport.h
+++ b/src/file-io/ReconstructedFeatureGeometryExport.h
@@ -27,11 +27,14 @@
 #ifndef GPLATES_FILEIO_RECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 #define GPLATES_FILEIO_RECONSTRUCTEDFEATUREGEOMETRYEXPORT_H
 
+#include <boost/optional.hpp>
 #include <vector>
 #include <QFileInfo>
 #include <QString>
 
 #include "file-io/File.h"
+
+#include "maths/PolygonOrientation.h"
 
 #include "model/types.h"
 
@@ -85,6 +88,9 @@ namespace GPlatesFileIO
 		 * @param export_separate_output_directory_per_input_file
 		 *        Save each exported file to a different directory based on the file basename.
 		 *        Only applies if @a export_per_input_file is 'true'.
+		 * @param force_polygon_orientation
+		 *        Optionally force polygon orientation (clockwise or counter-clockwise).
+		 *        Only applies to reconstructed geometries that are polygons.
 		 * @param wrap_to_dateline if true then exported geometries are wrapped/clipped to
 		 *        the dateline (currently ignored by GMT '.xy' format).
 		 *
@@ -106,6 +112,7 @@ namespace GPlatesFileIO
 				bool export_single_output_file,
 				bool export_per_input_file,
 				bool export_separate_output_directory_per_input_file,
+				boost::optional<GPlatesMaths::PolygonOrientation::Orientation> force_polygon_orientation,
 				bool wrap_to_dateline);
 	}
 }

--- a/src/view-operations/VisibleReconstructionGeometryExport.cc
+++ b/src/view-operations/VisibleReconstructionGeometryExport.cc
@@ -287,6 +287,7 @@ GPlatesViewOperations::VisibleReconstructionGeometryExport::export_visible_recon
 			export_single_output_file,
 			export_per_input_file,
 			export_separate_output_directory_per_input_file,
+			boost::none/*force_polygon_orientation*/,
 			wrap_to_dateline);
 }
 


### PR DESCRIPTION
- Added `ReconstructModel` and `ReconstructSnapshot` classes.
  - Similar to `TopologicalModel` and `TopologicalSnapshot`, but for regular reconstruction instead of resolving topologies.
  - Better than using the `pygplates.reconstruct()` function.
  - Just like `TopologicalModel` and `TopologicalSnapshot` are better than using the `pygplates.resolve_topologies()` function.