### PR TITLE
Fix boost 1.89 compatibility issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,9 +202,10 @@ endif()
 # Minimum required Boost version.
 #
 if (CMAKE_VERSION VERSION_LESS 3.30)
+	# Version 1.69 is when the boost::system became header-only and no longer required adding the boost::system module (which was removed in 1.89).
 	# Version 1.55 is when boost::is_copy_constructible<T> was introduced (although can use std version in C++11 compilers now).
 	# Version 1.39 is when <boost/bind/bind.hpp> was added (before that there was just <boost/bind.hpp>).
-	set(_GPLATES_MIN_BOOST_VERSION 1.55)
+	set(_GPLATES_MIN_BOOST_VERSION 1.69)
 else()  # CMake >= 3.30 ...
 	# CMake 3.30 removed the FindBoost module, which means Boost needs to provide a CMake package configuration file and
 	# only Boost >= 1.70 provides that.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,7 +246,7 @@ endif()
 # Now find the Boost library components.
 find_package(Boost ${_GPLATES_MIN_BOOST_VERSION} REQUIRED
 		# These components are required (including boost python)...
-		COMPONENTS program_options thread system ${GPLATES_BOOST_PYTHON_COMPONENT_NAME}
+		COMPONENTS program_options thread ${GPLATES_BOOST_PYTHON_COMPONENT_NAME}
 		#
 		# These components are optional...
 		OPTIONAL_COMPONENTS
@@ -854,7 +854,7 @@ target_link_libraries(${SOURCE_TARGET} PUBLIC ZLIB::ZLIB)
 # Boost dependency.
 #
 # Add required Boost components.
-target_link_libraries(${SOURCE_TARGET} PUBLIC Boost::boost Boost::program_options Boost::thread Boost::system Boost::${GPLATES_BOOST_PYTHON_COMPONENT_NAME})
+target_link_libraries(${SOURCE_TARGET} PUBLIC Boost::boost Boost::program_options Boost::thread Boost::${GPLATES_BOOST_PYTHON_COMPONENT_NAME})
 # Disable Boost auto-linking.
 # This solves the issue whereby, for example, Boost is compiled with Visual Studio 2015 but we're compiling GPlates/pyGPlates
 # with Visual Studio 2019 (which causes auto-linking to look for Boost libs with 'vc142' in their name) and hence cannot find


### PR DESCRIPTION
Boost removed the system stubs in version 1.89, causing builds of gplates to fail with the following error:

```
CMake Error at /usr/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /usr/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  src/CMakeLists.txt:247 (find_package)
```

This PR removes the references to system in CMakeLists, as per recommendations here: https://www.boost.org/releases/1.89.0/. This will break compatibility with boost versions older than 1.69 (2018); the boost website suggests an alternative if you want to keep compatibility with old boost versions.