### PR TITLE
Pygplates CI via GitHub actions

### DIFF
--- a/.github/condaenvs/env.LINUX.yml
+++ b/.github/condaenvs/env.LINUX.yml
@@ -1,0 +1,44 @@
+name: pygplates
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy
+  - cmake
+  - gcc
+  - gxx
+  - make
+  - patchelf
+  - scikit-build-core<0.11
+  - cgal-cpp
+  - gmp
+  - mpfr
+  - glew
+  - qt-main
+  - libboost-devel
+  - libboost-python-devel
+  - libgdal
+  - proj
+  - qwt
+  - mesalib
+  - libgl-devel
+  - libglx-devel
+  - zlib
+  - xorg-libxfixes
+  - xorg-libx11
+  - xorg-libxcomposite
+  - xorg-libxau
+  - xorg-libxcursor
+#  - libglu
+#  - libopengl-devel
+#  - libdrm
+#  - libegl-devel
+#  - xorg-libxdamage
+#  - xorg-libxext
+#  - xorg-libxi
+#  - xorg-libxrandr
+#  - xorg-libxrender
+#  - xorg-libxscrnsaver
+#  - xorg-libxtst
+#  - xorg-libxxf86vm
+#  - xorg-xorgproto

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -37,7 +37,7 @@ jobs:
         use-mamba: true
         # use the matrix python versio
         python-version: ${{ matrix.python-version }}
-        environment-file: .github/workflows/env.LINUX.yml
+        environment-file: .github/condaenvs/env.LINUX.yml
         activate-environment: pygplates
 
     - name: Conda diagnostic

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -1,0 +1,55 @@
+# This workflow builds and tests pygplates 
+# Dependencies run from conda, installed via `environment.yml` 
+# Tests run from in pygplates/test/test.py
+name: pygplates build and test
+
+on:
+  push:
+    branches: [ "pygplates" ]
+  pull_request:
+    branches: [ "pygplates" ]
+  workflow_dispatch:
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build-test:
+    strategy:
+      matrix:
+        os: ["ubuntu"] #, "macos"] #, "windows"]
+        python-version: ["3.11", "3.12"]
+
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: true # debugging for now
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        ref: pygplates
+
+    - name: Set up Micromamba
+      uses: conda-incubator/setup-miniconda@v3
+      #uses: mamba-org/setup-micromamba@v2
+      with:
+        use-mamba: true
+        # use the matrix python versio
+        python-version: ${{ matrix.python-version }}
+        environment-file: .github/workflows/env.LINUX.yml
+        activate-environment: pygplates
+
+    - name: Conda diagnostic
+      run: |
+        conda info
+
+    - name: Build pygplates
+      run: |
+        env
+        pip install -vv \
+        -C "cmake.define.CMAKE_PREFIX_PATH=/usr/share/miniconda/envs/pygplates/" \
+        .
+
+    - name: Test pygplates
+      run: python pygplates/test/test.py

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         env
         pip install -vv \
-        -C "cmake.define.CMAKE_PREFIX_PATH=${CONDA_PREFIX}" \
+        -C "cmake.define.CMAKE_PREFIX_PATH=/usr/share/miniconda/envs/pygplates" \
         .
 
     - name: Test pygplates

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -11,8 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  ENV_NAME: pygplates # the conda environment name
 
 jobs:
   build-test:
@@ -28,7 +27,6 @@ jobs:
       uses: actions/checkout@v6
 
 
-
     - name: Set up Miniconda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -36,7 +34,7 @@ jobs:
         # use the matrix python version
         python-version: ${{ matrix.python-version }}
         environment-file: .github/condaenvs/env.LINUX.yml
-        activate-environment: pygplates
+        activate-environment: $ENV_NAME
 
     - name: Conda diagnostic
       run: |
@@ -46,7 +44,7 @@ jobs:
       run: |
         env
         pip install -vv \
-        -C "cmake.define.CMAKE_PREFIX_PATH=/usr/share/miniconda/envs/pygplates" \
+        -C "cmake.define.CMAKE_PREFIX_PATH=$CONDA/envs/$ENV_NAME/" \
         .
 
     - name: Test pygplates

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -30,12 +30,11 @@ jobs:
       with:
         ref: pygplates
 
-    - name: Set up Micromamba
+    - name: Set up Miniconda
       uses: conda-incubator/setup-miniconda@v3
-      #uses: mamba-org/setup-micromamba@v2
       with:
         use-mamba: true
-        # use the matrix python versio
+        # use the matrix python version
         python-version: ${{ matrix.python-version }}
         environment-file: .github/condaenvs/env.LINUX.yml
         activate-environment: pygplates

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -34,7 +34,7 @@ jobs:
         # use the matrix python version
         python-version: ${{ matrix.python-version }}
         environment-file: .github/condaenvs/env.LINUX.yml
-        activate-environment: $ENV_NAME
+        activate-environment: ${{ env.ENV_NAME }}
 
     - name: Conda diagnostic
       run: |

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -1,6 +1,6 @@
 # This workflow builds and tests pygplates 
-# Dependencies run from conda, installed via `environment.yml` 
-# Tests run from in pygplates/test/test.py
+# Dependencies run from conda, installed via `.github/condaenvs/env.LINUX.yml` 
+# Tests run from pygplates/test/test.py
 name: pygplates build and test
 
 on:
@@ -22,13 +22,12 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: true # debugging for now
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        ref: pygplates
+
+
 
     - name: Set up Miniconda
       uses: conda-incubator/setup-miniconda@v3
@@ -47,7 +46,7 @@ jobs:
       run: |
         env
         pip install -vv \
-        -C "cmake.define.CMAKE_PREFIX_PATH=/usr/share/miniconda/envs/pygplates/" \
+        -C "cmake.define.CMAKE_PREFIX_PATH=${CONDA_PREFIX}" \
         .
 
     - name: Test pygplates


### PR DESCRIPTION
CI testing for pygplates. 

This workflow builds and tests pygplates against a conda environment setup with `conda-incubator/setup-miniconda@v3`.
The environment find is located in `~/.github/condaenvs/env.LINUX.yml`. For mac-arm and windows we will need separate environments files.

The environment files could also feed into the documentation of DEPs.LINUX and the installation instructions.

@jcannon-gplates - let's discuss.