### PR TITLE
Change GDAL metadata type to auto to support both 2.X and 3.X

### DIFF
--- a/src/file-io/GdalRasterWriter.cc
+++ b/src/file-io/GdalRasterWriter.cc
@@ -101,7 +101,7 @@ namespace
 			return false;
 		}
 
-		char **driver_metadata = driver->GetMetadata();
+		auto driver_metadata = driver->GetMetadata();
 		if (driver_metadata == NULL)
 		{
 			qWarning() << "Unable to get metadata for GDAL raster driver '" << driver_name << "'.";
@@ -135,7 +135,7 @@ namespace
 			return supported_band_types;
 		}
 
-		char **driver_metadata = driver->GetMetadata();
+		auto driver_metadata = driver->GetMetadata();
 		if (driver_metadata == NULL)
 		{
 			qWarning() << "Unable to get metadata for GDAL raster driver '" << driver_name << "'.";
@@ -437,7 +437,7 @@ GPlatesFileIO::GDALRasterWriter::GDALRasterWriter(
 			<< d_filename << "'.";
 		return;
 	}
-	char **file_driver_metadata = d_file_driver->GetMetadata();
+	auto file_driver_metadata = d_file_driver->GetMetadata();
 	if (file_driver_metadata == NULL)
 	{
 		qWarning() << "Unable to get metadata for GDAL raster driver '" << file_driver_name.c_str() << "'.";


### PR DESCRIPTION
Had some trouble building on Arch Linux with GDL 3.X. This simple fix seemed to fix the compilation for me.