### PR TITLE
Add configurable Absolute Age colouring

### DIFF
--- a/src/api/PyApplication.cc
+++ b/src/api/PyApplication.cc
@@ -34,7 +34,9 @@
 #include "PythonUtils.h"
 #include "Sleeper.h"
 
+#include "app-logic/ApplicationState.h"
 #include "app-logic/FeatureCollectionFileState.h"
+#include "app-logic/UserPreferences.h"
 
 #include "global/CompilerWarnings.h"
 #include "global/python.h"
@@ -257,6 +259,23 @@ namespace GPlatesApi
 			return d_app.get_application_state().get_current_reconstruction_time();
 		}
 
+		/**
+		 * The default reconstruction time range, as (oldest, youngest) in Ma.
+		 *
+		 * This is the range configured under Preferences > Default View Settings, so a draw style
+		 * or utility can span the times a project actually uses rather than a hardcoded guess.
+		 */
+		boost::python::tuple
+		default_time_range()
+		{
+			GPlatesAppLogic::UserPreferences &preferences =
+					d_app.get_application_state().get_user_preferences();
+
+			return boost::python::make_tuple(
+					preferences.get_value("view/animation/default_time_range_start").toDouble(),
+					preferences.get_value("view/animation/default_time_range_end").toDouble());
+		}
+
 		private:
 			GPlatesPresentation::Application& d_app;
 	};
@@ -282,5 +301,6 @@ export_instance()
 		.def("register_draw_style", &Application::register_draw_style)
 		.def("feature_collections", &Application::feature_collections)
 		.def("current_time", &Application::current_time)
+		.def("default_time_range", &Application::default_time_range)
 		;
 }

--- a/src/api/PyColour.cc
+++ b/src/api/PyColour.cc
@@ -116,6 +116,38 @@ namespace GPlatesApi
 		return GPlatesGui::Colour::get_navy();
 	}
 
+	inline
+	float
+	red_component(
+			const GPlatesGui::Colour& colour)
+	{
+		return colour.red();
+	}
+
+	inline
+	float
+	green_component(
+			const GPlatesGui::Colour& colour)
+	{
+		return colour.green();
+	}
+
+	inline
+	float
+	blue_component(
+			const GPlatesGui::Colour& colour)
+	{
+		return colour.blue();
+	}
+
+	inline
+	float
+	alpha_component(
+			const GPlatesGui::Colour& colour)
+	{
+		return colour.alpha();
+	}
+
 	//TODO
 	// 	static const Colour &get_maroon();
 	// 
@@ -133,6 +165,10 @@ export_colour()
 {
 	class_<GPlatesGui::Colour>("Colour")
 		.def(init<const float,const float,const float,const float>())
+		.def("get_red", &GPlatesApi::red_component)
+		.def("get_green", &GPlatesApi::green_component)
+		.def("get_blue", &GPlatesApi::blue_component)
+		.def("get_alpha", &GPlatesApi::alpha_component)
 		.add_static_property("blue", &GPlatesApi::blue)
 		.add_static_property("red", &GPlatesApi::red)
 		.add_static_property("white", &GPlatesApi::white)

--- a/src/gui/DrawStyleAdapters.cc
+++ b/src/gui/DrawStyleAdapters.cc
@@ -119,30 +119,34 @@ GPlatesGui::PythonStyleAdapter::init_configuration()
 		bp::dict cfg_defs = bp::extract<bp::dict>(d_py_obj.attr("get_config")());
 		bp::list tmp_cfg_items =  cfg_defs.items();
 		int len = bp::len(tmp_cfg_items);
-		QString cfg_name;
-		std::map<QString, QString> cfg_map;
+		typedef std::map<QString, QString> ConfigDefinition;
+		typedef std::map<QString, ConfigDefinition> ConfigDefinitions;
+		ConfigDefinitions config_definitions;
 
 		for (int i = 0; i < len; i++)
 		{
 			bp::tuple t = bp::extract<bp::tuple>(tmp_cfg_items[i]);
 			QString key = QString::fromUtf8(bp::extract<const char*>(t[0])());
 			QString value = QString::fromUtf8(bp::extract<const char*>(t[1])());
-			QString sub_key = key.right(key.length() - key.indexOf('/') -1);
-			key.chop(key.length() - key.indexOf('/'));
-			if(key != cfg_name)
+			const int separator_index = key.indexOf('/');
+			if (separator_index <= 0 || separator_index == key.length() - 1)
 			{
-				if (!cfg_name.isEmpty())
-				{
-					d_cfg.set(cfg_name, create_cfg_item(cfg_map));
-				}
-				cfg_map.clear();
-				cfg_name = key;
+				qWarning() << "Invalid python configuration key:" << key;
+				continue;
 			}
-			cfg_map[sub_key] = value;
+
+			const QString cfg_name = key.left(separator_index);
+			const QString sub_key = key.mid(separator_index + 1);
+			config_definitions[cfg_name][sub_key] = value;
 		}
-		if (!cfg_name.isEmpty())
+
+		BOOST_FOREACH(const ConfigDefinitions::value_type& config_definition, config_definitions)
 		{
-			d_cfg.set(cfg_name, create_cfg_item(cfg_map));
+			PythonCfgItem* cfg_item = create_cfg_item(config_definition.second);
+			if (cfg_item)
+			{
+				d_cfg.set(config_definition.first, cfg_item);
+			}
 		}
 	}
 	catch(const  boost::python::error_already_set&)

--- a/src/gui/DrawStyleAdapters.cc
+++ b/src/gui/DrawStyleAdapters.cc
@@ -129,17 +129,20 @@ GPlatesGui::PythonStyleAdapter::init_configuration()
 			QString value = QString::fromUtf8(bp::extract<const char*>(t[1])());
 			QString sub_key = key.right(key.length() - key.indexOf('/') -1);
 			key.chop(key.length() - key.indexOf('/'));
-			if(key == cfg_name)
+			if(key != cfg_name)
 			{
-				cfg_map[sub_key] = value;
-			}
-			else
-			{
-				cfg_map[sub_key] = value;
-				cfg_name = key;
-				d_cfg.set(cfg_name, create_cfg_item(cfg_map));
+				if (!cfg_name.isEmpty())
+				{
+					d_cfg.set(cfg_name, create_cfg_item(cfg_map));
+				}
 				cfg_map.clear();
+				cfg_name = key;
 			}
+			cfg_map[sub_key] = value;
+		}
+		if (!cfg_name.isEmpty())
+		{
+			d_cfg.set(cfg_name, create_cfg_item(cfg_map));
 		}
 	}
 	catch(const  boost::python::error_already_set&)
@@ -270,16 +273,25 @@ GPlatesGui::PythonStyleAdapter::create_cfg_item(const std::map<QString, QString>
 		qWarning() << "No type found in python configuration definition.";
 		return NULL;
 	}
+	std::map<QString, QString>::const_iterator default_it = data.find("default");
+	const QString default_value =
+			(default_it == data.end()) ? QString() : default_it->second;
 
 	if(it->second == "Color")
 	{
-		return new PythonCfgColor("Color", "white");
+		return new PythonCfgColor(
+				"Color",
+				default_value.isEmpty() ? QString("white") : default_value);
 	}
 	else if(it->second == "Palette")
 	{
-		return new PythonCfgPalette("Palette", "DeaultPalette");
+		return new PythonCfgPalette(
+				"Palette",
+				default_value.isEmpty() ? QString("DeaultPalette") : default_value);
 	} 
-	return new PythonCfgString("String", " ");
+	return new PythonCfgString(
+			"String",
+			default_it == data.end() ? QString(" ") : default_value);
 }
 
 

--- a/src/qt-resources/python.qrc
+++ b/src/qt-resources/python.qrc
@@ -1,5 +1,6 @@
 <RCC>
   <qresource prefix="/">
+    <file>python/scripts/colouring/AbsoluteAge.py</file>
     <file>python/scripts/colouring/ArbitraryColours.py</file>
     <file>python/scripts/colouring/ColorByProperty.py</file>
     <file>python/scripts/colouring/draw_style_demo.py</file>

--- a/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
+++ b/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
@@ -1,0 +1,105 @@
+'''
+ *
+ * Copyright (C) 2026 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+'''
+
+import math
+
+import pygplates
+
+
+DEFAULT_TIME_1 = 0.0
+DEFAULT_TIME_2 = 450.0
+
+
+def _finite_float(value, default):
+	try:
+		result = float(value)
+	except (TypeError, ValueError):
+		return default
+	return result if math.isfinite(result) else default
+
+
+def _gradient_position(age, time_1, time_2):
+	if time_1 == time_2:
+		return 0.0
+	position = (age - time_1) / (time_2 - time_1)
+	return max(0.0, min(1.0, position))
+
+
+def _apply_steps(position, value):
+	# An integer selects that many distinct colours, including both endpoint
+	# colours. "smooth" (or "continuous") leaves the gradient unquantised.
+	text = str(value).strip().lower()
+	if not text or text in ('smooth', 'continuous'):
+		return position
+	try:
+		steps = max(2, int(text))
+	except (TypeError, ValueError):
+		return position
+	return math.floor(position * (steps - 1) + 0.5) / float(steps - 1)
+
+
+def _interpolate_colour(colour_1, colour_2, position):
+	return pygplates.Colour(
+		colour_1.get_red() + (colour_2.get_red() - colour_1.get_red()) * position,
+		colour_1.get_green() + (colour_2.get_green() - colour_1.get_green()) * position,
+		colour_1.get_blue() + (colour_2.get_blue() - colour_1.get_blue()) * position,
+		colour_1.get_alpha() + (colour_2.get_alpha() - colour_1.get_alpha()) * position)
+
+
+class AbsoluteAge:
+	def get_style(self, feature, style):
+		age = _finite_float(feature.begin_time(), DEFAULT_TIME_1)
+		time_1 = _finite_float(self.cfg['Endpoint 1 time (Ma)'], DEFAULT_TIME_1)
+		time_2 = _finite_float(self.cfg['Endpoint 2 time (Ma)'], DEFAULT_TIME_2)
+		position = _gradient_position(age, time_1, time_2)
+		position = _apply_steps(position, self.cfg['Steps (or smooth)'])
+		style.colour = _interpolate_colour(
+			self.cfg['Endpoint 1 colour'],
+			self.cfg['Endpoint 2 colour'],
+			position)
+
+	def get_config(self):
+		return {
+			'Endpoint 1 colour/type': 'Color',
+			'Endpoint 1 colour/default': '#2c7bb6',
+			'Endpoint 1 time (Ma)/type': 'String',
+			'Endpoint 1 time (Ma)/default': '0',
+			'Endpoint 2 colour/type': 'Color',
+			'Endpoint 2 colour/default': '#d7191c',
+			'Endpoint 2 time (Ma)/type': 'String',
+			'Endpoint 2 time (Ma)/default': '450',
+			'Steps (or smooth)/type': 'String',
+			'Steps (or smooth)/default': 'smooth',
+		}
+
+	def get_config_variants(self):
+		return {
+			'Default': {
+				'Endpoint 1 colour': '#2c7bb6',
+				'Endpoint 1 time (Ma)': '0',
+				'Endpoint 2 colour': '#d7191c',
+				'Endpoint 2 time (Ma)': '450',
+				'Steps (or smooth)': 'smooth',
+			}
+		}
+
+	def set_config(self, config):
+		self.cfg = config
+
+
+def register():
+	pygplates.Application().register_draw_style(AbsoluteAge())

--- a/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
+++ b/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
@@ -1,6 +1,6 @@
 '''
  *
- * Copyright (C) 2026 The University of Sydney, Australia
+ * Copyright (C) 2026 CaliTarheel
  *
  * This file is part of GPlates.
  *

--- a/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
+++ b/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
@@ -20,8 +20,34 @@ import math
 import pygplates
 
 
-DEFAULT_TIME_1 = 0.0
-DEFAULT_TIME_2 = 450.0
+# Used only when the configured view range cannot be read - see _default_times().
+FALLBACK_YOUNGEST_TIME = 0.0
+FALLBACK_OLDEST_TIME = 410.0
+
+# Newest features are orange, oldest are green.
+YOUNGEST_COLOUR = '#e66101'
+OLDEST_COLOUR = '#1a9641'
+
+
+def _default_times():
+	# Span the reconstruction range the project actually uses, taken from
+	# Preferences > Default View Settings, rather than a hardcoded guess. Older versions of
+	# GPlates do not expose this, so fall back to the documented default range.
+	try:
+		oldest, youngest = pygplates.Application().default_time_range()
+		oldest = float(oldest)
+		youngest = float(youngest)
+	except Exception:
+		return FALLBACK_YOUNGEST_TIME, FALLBACK_OLDEST_TIME
+
+	if not math.isfinite(oldest) or not math.isfinite(youngest) or oldest == youngest:
+		return FALLBACK_YOUNGEST_TIME, FALLBACK_OLDEST_TIME
+
+	return youngest, oldest
+
+
+def _format_time(value):
+	return ('%g' % value)
 
 
 def _finite_float(value, default):
@@ -60,11 +86,22 @@ def _interpolate_colour(colour_1, colour_2, position):
 		colour_1.get_alpha() + (colour_2.get_alpha() - colour_1.get_alpha()) * position)
 
 
+def _variant(youngest_colour, youngest_time, oldest_colour, oldest_time, steps):
+	return {
+		'Endpoint 1 colour': youngest_colour,
+		'Endpoint 1 time (Ma)': _format_time(youngest_time),
+		'Endpoint 2 colour': oldest_colour,
+		'Endpoint 2 time (Ma)': _format_time(oldest_time),
+		'Steps (or smooth)': steps,
+	}
+
+
 class AbsoluteAge:
 	def get_style(self, feature, style):
-		age = _finite_float(feature.begin_time(), DEFAULT_TIME_1)
-		time_1 = _finite_float(self.cfg['Endpoint 1 time (Ma)'], DEFAULT_TIME_1)
-		time_2 = _finite_float(self.cfg['Endpoint 2 time (Ma)'], DEFAULT_TIME_2)
+		youngest_time, oldest_time = _default_times()
+		age = _finite_float(feature.begin_time(), youngest_time)
+		time_1 = _finite_float(self.cfg['Endpoint 1 time (Ma)'], youngest_time)
+		time_2 = _finite_float(self.cfg['Endpoint 2 time (Ma)'], oldest_time)
 		position = _gradient_position(age, time_1, time_2)
 		position = _apply_steps(position, self.cfg['Steps (or smooth)'])
 		style.colour = _interpolate_colour(
@@ -73,28 +110,50 @@ class AbsoluteAge:
 			position)
 
 	def get_config(self):
+		youngest_time, oldest_time = _default_times()
 		return {
 			'Endpoint 1 colour/type': 'Color',
-			'Endpoint 1 colour/default': '#2c7bb6',
+			'Endpoint 1 colour/default': YOUNGEST_COLOUR,
 			'Endpoint 1 time (Ma)/type': 'String',
-			'Endpoint 1 time (Ma)/default': '0',
+			'Endpoint 1 time (Ma)/default': _format_time(youngest_time),
 			'Endpoint 2 colour/type': 'Color',
-			'Endpoint 2 colour/default': '#d7191c',
+			'Endpoint 2 colour/default': OLDEST_COLOUR,
 			'Endpoint 2 time (Ma)/type': 'String',
-			'Endpoint 2 time (Ma)/default': '450',
+			'Endpoint 2 time (Ma)/default': _format_time(oldest_time),
 			'Steps (or smooth)/type': 'String',
 			'Steps (or smooth)/default': 'smooth',
 		}
 
 	def get_config_variants(self):
+		# Several worked examples rather than one empty starting point. Seeing a few
+		# configurations side by side is the quickest way to understand that this style is an
+		# age-to-colour ramp between two editable endpoints - which is not obvious from a single
+		# default, and was not obvious at all when the list started empty.
+		youngest_time, oldest_time = _default_times()
+		midpoint_time = youngest_time + (oldest_time - youngest_time) / 2.0
+
 		return {
-			'Default': {
-				'Endpoint 1 colour': '#2c7bb6',
-				'Endpoint 1 time (Ma)': '0',
-				'Endpoint 2 colour': '#d7191c',
-				'Endpoint 2 time (Ma)': '450',
-				'Steps (or smooth)': 'smooth',
-			}
+			# Newest orange, oldest green, across the project's whole range.
+			'Default': _variant(
+				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, oldest_time, 'smooth'),
+
+			# The same range and colours quantised into bands, which makes age groupings
+			# readable at a glance instead of blending continuously.
+			'Banded (6 steps)': _variant(
+				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, oldest_time, '6'),
+
+			# Only the more recent half of the range, so recent features are separated instead
+			# of being crushed into one end of the ramp. Anything older clamps to the old colour.
+			'Recent detail': _variant(
+				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, midpoint_time, 'smooth'),
+
+			# A cool-to-warm alternative for when orange and green are already in use.
+			'Blue to red': _variant(
+				'#2c7bb6', youngest_time, '#d7191c', oldest_time, 'smooth'),
+
+			# Neutral ramp for figures that are printed or reproduced in greyscale.
+			'Greyscale': _variant(
+				'#f0f0f0', youngest_time, '#252525', oldest_time, 'smooth'),
 		}
 
 	def set_config(self, config):

--- a/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
+++ b/src/qt-resources/python/scripts/colouring/AbsoluteAge.py
@@ -86,12 +86,13 @@ def _interpolate_colour(colour_1, colour_2, position):
 		colour_1.get_alpha() + (colour_2.get_alpha() - colour_1.get_alpha()) * position)
 
 
-def _variant(youngest_colour, youngest_time, oldest_colour, oldest_time, steps):
+def _variant(colour_1, time_1, colour_2, time_2, steps):
+	# Endpoint 1 is not required to be the younger time - see the reversed example below.
 	return {
-		'Endpoint 1 colour': youngest_colour,
-		'Endpoint 1 time (Ma)': _format_time(youngest_time),
-		'Endpoint 2 colour': oldest_colour,
-		'Endpoint 2 time (Ma)': _format_time(oldest_time),
+		'Endpoint 1 colour': colour_1,
+		'Endpoint 1 time (Ma)': _format_time(time_1),
+		'Endpoint 2 colour': colour_2,
+		'Endpoint 2 time (Ma)': _format_time(time_2),
 		'Steps (or smooth)': steps,
 	}
 
@@ -125,12 +126,18 @@ class AbsoluteAge:
 		}
 
 	def get_config_variants(self):
-		# Several worked examples rather than one empty starting point. Seeing a few
-		# configurations side by side is the quickest way to understand that this style is an
-		# age-to-colour ramp between two editable endpoints - which is not obvious from a single
-		# default, and was not obvious at all when the list started empty.
+		# Worked examples rather than one empty starting point. Seeing several configurations
+		# side by side is the quickest way to understand that this style is an age-to-colour ramp
+		# between two editable endpoints - which is not obvious from a single default, and was not
+		# obvious at all when the list started empty.
+		#
+		# Each example is here to demonstrate something the style can do - the whole range, a
+		# narrowed range, a reversed range, quantisation into bands - rather than being just
+		# another pair of colours. Select one and click New to get an editable copy of it.
 		youngest_time, oldest_time = _default_times()
-		midpoint_time = youngest_time + (oldest_time - youngest_time) / 2.0
+		span = oldest_time - youngest_time
+		midpoint_time = youngest_time + span / 2.0
+		near_present_time = youngest_time + span / 8.0
 
 		return {
 			# Newest orange, oldest green, across the project's whole range.
@@ -142,14 +149,39 @@ class AbsoluteAge:
 			'Banded (6 steps)': _variant(
 				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, oldest_time, '6'),
 
+			# Two steps is the smallest banding that means anything: one hard boundary at the
+			# middle of the range, so every feature reads as simply older or younger than that.
+			'Two tone (2 steps)': _variant(
+				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, oldest_time, '2'),
+
 			# Only the more recent half of the range, so recent features are separated instead
 			# of being crushed into one end of the ramp. Anything older clamps to the old colour.
-			'Recent detail': _variant(
+			'Recent half': _variant(
 				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, midpoint_time, 'smooth'),
+
+			# The mirror of the above: spread the ramp over the older half instead, for reading
+			# basement ages when the recent end is not what is being looked at.
+			'Ancient half': _variant(
+				YOUNGEST_COLOUR, midpoint_time, OLDEST_COLOUR, oldest_time, 'smooth'),
+
+			# A narrow window close to the present. Clamping is what makes a narrow window
+			# usable: everything older than the window simply takes the old colour.
+			'Near present': _variant(
+				YOUNGEST_COLOUR, youngest_time, OLDEST_COLOUR, near_present_time, 'smooth'),
+
+			# Endpoint 1 does not have to be the younger time. Give the two times the other way
+			# round and the ramp runs backwards, so the oldest features take the first colour.
+			'Reversed': _variant(
+				YOUNGEST_COLOUR, oldest_time, OLDEST_COLOUR, youngest_time, 'smooth'),
 
 			# A cool-to-warm alternative for when orange and green are already in use.
 			'Blue to red': _variant(
 				'#2c7bb6', youngest_time, '#d7191c', oldest_time, 'smooth'),
+
+			# Sequential yellow to brown, which stays readable under the common forms of colour
+			# blindness that make the orange and green of the default hard to tell apart.
+			'Yellow to brown': _variant(
+				'#fff7bc', youngest_time, '#993404', oldest_time, 'smooth'),
 
 			# Neutral ramp for figures that are printed or reproduced in greyscale.
 			'Greyscale': _variant(

--- a/src/qt-widgets/DrawStyleDialog.cc
+++ b/src/qt-widgets/DrawStyleDialog.cc
@@ -961,7 +961,18 @@ GPlatesQtWidgets::DrawStyleDialog::update_gradient_bar(
 			}
 			else if(item_name.contains("time", Qt::CaseInsensitive))
 			{
-				times.append(item->get_value().trimmed());
+				QString label = item->get_value().trimmed();
+
+				// Carry over the unit the setting was named with - "Endpoint 1 time (Ma)" -
+				// so that the number under the ramp says what it is.
+				const qsizetype unit_start = item_name.indexOf('(');
+				const qsizetype unit_end = item_name.indexOf(')', unit_start + 1);
+				if(!label.isEmpty() && unit_start >= 0 && unit_end > unit_start + 1)
+				{
+					label += " " + item_name.mid(unit_start + 1, unit_end - unit_start - 1);
+				}
+
+				times.append(label);
 			}
 		}
 	}

--- a/src/qt-widgets/DrawStyleDialog.cc
+++ b/src/qt-widgets/DrawStyleDialog.cc
@@ -28,6 +28,8 @@
 #include <QFileDialog>
 #include <QColorDialog>
 #include <QHeaderView>
+#include <QLinearGradient>
+#include <QPainter>
 
 #include "SceneView.h"
 #include "ReconstructionViewWidget.h"
@@ -61,6 +63,136 @@
 #include "MapView.h"
 
 
+GPlatesQtWidgets::DrawStyleGradientBar::DrawStyleGradientBar(
+		QWidget *parent_) :
+	QWidget(parent_),
+	d_steps(0)
+{
+	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+}
+
+
+void
+GPlatesQtWidgets::DrawStyleGradientBar::set_gradient(
+		const QList<QColor> &colours,
+		const QStringList &labels,
+		int steps)
+{
+	d_colours = colours;
+	// Labels are positional, so an unexpected number of them cannot be placed and is dropped
+	// rather than guessed at.
+	d_labels = (labels.size() == colours.size()) ? labels : QStringList();
+	d_steps = steps;
+	update();
+}
+
+
+void
+GPlatesQtWidgets::DrawStyleGradientBar::clear_gradient()
+{
+	set_gradient(QList<QColor>(), QStringList(), 0);
+}
+
+
+QSize
+GPlatesQtWidgets::DrawStyleGradientBar::sizeHint() const
+{
+	// Always reserve the label row, whether or not this ramp has labels, so that the panel below
+	// does not shift as the selection moves between styles.
+	return QSize(120, BAR_HEIGHT + LABEL_SPACING + fontMetrics().height());
+}
+
+
+QColor
+GPlatesQtWidgets::DrawStyleGradientBar::colour_at(
+		double position) const
+{
+	if (d_colours.isEmpty())
+	{
+		return QColor();
+	}
+	if (d_colours.size() == 1)
+	{
+		return d_colours.front();
+	}
+
+	const int last = static_cast<int>(d_colours.size()) - 1;
+	const double scaled = qBound(0.0, position, 1.0) * last;
+	const int lower = qMin(static_cast<int>(scaled), last - 1);
+	const double fraction = scaled - lower;
+
+	const QColor &from = d_colours.at(lower);
+	const QColor &to = d_colours.at(lower + 1);
+
+	return QColor::fromRgbF(
+			from.redF() + (to.redF() - from.redF()) * fraction,
+			from.greenF() + (to.greenF() - from.greenF()) * fraction,
+			from.blueF() + (to.blueF() - from.blueF()) * fraction,
+			from.alphaF() + (to.alphaF() - from.alphaF()) * fraction);
+}
+
+
+void
+GPlatesQtWidgets::DrawStyleGradientBar::paintEvent(
+		QPaintEvent *)
+{
+	QPainter painter(this);
+
+	const QRect bar_rect(0, 0, width() - 1, BAR_HEIGHT - 1);
+	const QRect fill_rect = bar_rect.adjusted(1, 1, 0, 0);
+
+	if (d_colours.size() == 1)
+	{
+		painter.fillRect(fill_rect, d_colours.front());
+	}
+	else if (d_colours.size() > 1 && d_steps >= 2)
+	{
+		// Quantised, and quantised the way the colouring scripts do it: each band is centred on
+		// the colour it stands for, which leaves the two end bands half width.
+		for (int step = 0; step < d_steps; ++step)
+		{
+			const double band_start = qMax(0.0, (step - 0.5) / (d_steps - 1));
+			const double band_end = qMin(1.0, (step + 0.5) / (d_steps - 1));
+
+			const int left = fill_rect.left() + qRound(band_start * fill_rect.width());
+			const int right = fill_rect.left() + qRound(band_end * fill_rect.width());
+
+			painter.fillRect(
+					QRect(left, fill_rect.top(), right - left, fill_rect.height()),
+					colour_at(step / static_cast<double>(d_steps - 1)));
+		}
+	}
+	else if (d_colours.size() > 1)
+	{
+		QLinearGradient gradient(fill_rect.topLeft(), fill_rect.topRight());
+		for (int i = 0; i < d_colours.size(); ++i)
+		{
+			gradient.setColorAt(i / static_cast<double>(d_colours.size() - 1), d_colours.at(i));
+		}
+		painter.fillRect(fill_rect, gradient);
+	}
+
+	painter.setPen(palette().color(QPalette::Mid));
+	painter.drawRect(bar_rect);
+
+	if (!d_labels.isEmpty())
+	{
+		const QRect label_rect(
+				0,
+				BAR_HEIGHT + LABEL_SPACING,
+				width(),
+				fontMetrics().height());
+
+		painter.setPen(palette().color(QPalette::WindowText));
+		painter.drawText(label_rect, Qt::AlignLeft, d_labels.front());
+		if (d_labels.size() > 1)
+		{
+			painter.drawText(label_rect, Qt::AlignRight, d_labels.back());
+		}
+	}
+}
+
+
 GPlatesQtWidgets::DrawStyleDialog::DrawStyleDialog(
 		GPlatesPresentation::ViewState &view_state,
 		QWidget* parent_) :
@@ -70,6 +202,7 @@ GPlatesQtWidgets::DrawStyleDialog::DrawStyleDialog(
 	d_globe_and_map_widget_ptr(NULL),
 	d_view_state(view_state),
 	d_combo_box(NULL),
+	d_gradient_bar(NULL),
 	d_style_of_all(NULL)
 {
 	init_dlg();
@@ -540,6 +673,7 @@ GPlatesQtWidgets::DrawStyleDialog::handle_configuration_changed()
 	current_style->set_dirty_flag(true);
 	set_style(current_style);
 	refresh_current_icon();
+	update_gradient_bar(current_style);
 }
 
 
@@ -650,6 +784,12 @@ GPlatesQtWidgets::DrawStyleDialog::init_dlg()
 	splitter->setStretchFactor(splitter->indexOf(categories_table),1);
 	splitter->setStretchFactor(splitter->indexOf(right_side_frame),4);
 
+	d_gradient_bar = new DrawStyleGradientBar(this);
+	QtWidgetUtils::add_widget_to_placeholder(d_gradient_bar, gradient_bar_placeholder);
+	// Nothing is selected yet, so there is neither a ramp to show nor advice to give.
+	d_gradient_bar->hide();
+	style_hint_label->clear();
+
 	d_combo_box = new LayerGroupComboBox(
 			d_view_state.get_visual_layers(),
 			d_view_state.get_visual_layer_registry(),
@@ -752,14 +892,16 @@ GPlatesQtWidgets::DrawStyleDialog::handle_style_selection_changed(
 
 		const Configuration& cfg = current_style->configuration();
 		build_config_panel(cfg);
-		
+		update_gradient_bar(current_style);
+		update_style_hint(current_style);
+
 		if(!mgr->is_built_in_style(*current_style))
 		{
 			if(mgr->get_ref_number(*current_style) == 1 && mgr->can_be_removed(*current_style))
 				remove_button->setEnabled(true);
 			else
 				remove_button->setEnabled(false);
-			
+
 			enable_config_panel(true);
 		}
 		else
@@ -767,6 +909,90 @@ GPlatesQtWidgets::DrawStyleDialog::handle_style_selection_changed(
 			remove_button->setEnabled(false);
 			enable_config_panel(false);
 		}
+	}
+	else
+	{
+		update_gradient_bar(NULL);
+		update_style_hint(NULL);
+	}
+}
+
+
+void
+GPlatesQtWidgets::DrawStyleDialog::update_gradient_bar(
+		const GPlatesGui::StyleAdapter* style_)
+{
+	if(!d_gradient_bar)
+		return;
+
+	QList<QColor> colours;
+	QStringList times;
+	int steps = 0;
+
+	if(style_)
+	{
+		// A configuration is keyed by name, so its items already arrive in the order the config
+		// panel lays them out ("Endpoint 1 ..." ahead of "Endpoint 2 ..."). Take the colours in
+		// that order as the stops of the ramp, and the times as the labels for its ends. A style
+		// that has no colours to interpolate - a palette-driven one, say - describes no ramp,
+		// and the bar stays hidden for it.
+		const GPlatesGui::Configuration& cfg = style_->configuration();
+
+		BOOST_FOREACH(const QString& item_name, cfg.all_cfg_item_names())
+		{
+			const GPlatesGui::PythonCfgItem* item =
+					dynamic_cast<const GPlatesGui::PythonCfgItem*>(cfg.get(item_name));
+			if(!item)
+				continue;
+
+			if(dynamic_cast<const GPlatesGui::PythonCfgColor*>(item))
+			{
+				const QColor colour(item->get_value());
+				if(colour.isValid())
+					colours.append(colour);
+			}
+			else if(item_name.startsWith("Steps", Qt::CaseInsensitive))
+			{
+				// Anything that is not a number - "smooth", most often - leaves the ramp
+				// unquantised.
+				bool is_a_number = false;
+				const int value = item->get_value().trimmed().toInt(&is_a_number);
+				steps = is_a_number ? value : 0;
+			}
+			else if(item_name.contains("time", Qt::CaseInsensitive))
+			{
+				times.append(item->get_value().trimmed());
+			}
+		}
+	}
+
+	d_gradient_bar->set_gradient(colours, times, steps);
+	d_gradient_bar->setVisible(!colours.isEmpty());
+}
+
+
+void
+GPlatesQtWidgets::DrawStyleDialog::update_style_hint(
+		const GPlatesGui::StyleAdapter* style_)
+{
+	if(!style_)
+	{
+		style_hint_label->clear();
+		return;
+	}
+
+	if(GPlatesGui::DrawStyleManager::is_built_in_style(*style_))
+	{
+		// The supplied styles cannot be edited in place, and a disabled panel on its own does
+		// not say what to do about that.
+		style_hint_label->setText(
+				tr("This is a supplied example, so its settings are read-only."
+					" Click New to use this feature."));
+	}
+	else
+	{
+		style_hint_label->setText(
+				tr("This is your own style. Edit its settings above and the view follows."));
 	}
 }
 
@@ -851,13 +1077,25 @@ GPlatesQtWidgets::DrawStyleDialog::handle_add_button_clicked(bool )
 	StyleCategory* current_cata = get_catagory(*cur_cata_item);
 	if(current_cata)
 	{
-		const StyleAdapter* style_temp = d_style_mgr->get_template_style(*current_cata);
-		if(style_temp)
+		// Copy whatever is selected, so that the supplied examples are usable as starting
+		// points: picking one and clicking New gives an editable style that already looks like
+		// it, rather than a bare template the settings then have to be typed back into.
+		const StyleAdapter* source_style = get_current_style();
+		if(!source_style)
 		{
-			StyleAdapter* new_style = style_temp->deep_clone();
+			source_style = d_style_mgr->get_template_style(*current_cata);
+		}
+
+		if(source_style)
+		{
+			StyleAdapter* new_style = source_style->deep_clone();
 			if(new_style)
 			{
-				QString new_name("Unnamed");
+				QString new_name = source_style->name();
+				if(new_name.isEmpty())
+				{
+					new_name = "Unnamed";
+				}
 				if(!is_style_name_valid(*current_cata,new_name))
 				{
 					new_name = generate_new_valid_style_name(*current_cata,new_name);

--- a/src/qt-widgets/DrawStyleDialog.h
+++ b/src/qt-widgets/DrawStyleDialog.h
@@ -30,8 +30,13 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/weak_ptr.hpp>
 
+#include <QColor>
+#include <QList>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QSize>
+#include <QStringList>
+#include <QWidget>
 
 #include "ui_DrawStyleDialogUi.h"
 #include "GPlatesDialog.h"
@@ -99,8 +104,76 @@ namespace GPlatesQtWidgets
 		void
 		insert_all();
 	};
-	
-	class DrawStyleDialog  : 
+
+
+	/**
+	 * A read-only strip showing the colour ramp that the selected draw style produces, so the
+	 * ramp can be read directly instead of being inferred from the preview thumbnails.
+	 *
+	 * It knows the two things a ramp style exposes: the colours being interpolated between, and
+	 * whether that interpolation is smooth or quantised into a number of steps. End labels are
+	 * optional, and carry the endpoint times for styles that have them.
+	 */
+	class DrawStyleGradientBar :
+			public QWidget
+	{
+		Q_OBJECT
+
+	public:
+
+		explicit
+		DrawStyleGradientBar(
+				QWidget *parent_ = NULL);
+
+		/**
+		 * Show a ramp running through @a colours from left to right.
+		 *
+		 * @a steps quantises the ramp into that many bands; anything below two leaves it
+		 * smooth. @a labels is drawn under the ends of the strip, and is ignored unless it has
+		 * one entry per colour.
+		 */
+		void
+		set_gradient(
+				const QList<QColor> &colours,
+				const QStringList &labels,
+				int steps);
+
+		/**
+		 * Leave the strip blank - for a style that is not a colour ramp.
+		 */
+		void
+		clear_gradient();
+
+		virtual
+		QSize
+		sizeHint() const;
+
+	protected:
+
+		virtual
+		void
+		paintEvent(
+				QPaintEvent *event);
+
+	private:
+
+		static const int BAR_HEIGHT = 20;
+		static const int LABEL_SPACING = 2;
+
+		/**
+		 * The colour this ramp shows at @a position, from 0.0 at its left to 1.0 at its right.
+		 */
+		QColor
+		colour_at(
+				double position) const;
+
+		QList<QColor> d_colours;
+		QStringList d_labels;
+		int d_steps;
+	};
+
+
+	class DrawStyleDialog  :
 			public GPlatesDialog, 
 			protected Ui_DrawStyleDialog
 	{
@@ -212,6 +285,24 @@ namespace GPlatesQtWidgets
 
 		void
 		build_config_panel(const GPlatesGui::Configuration& cfg);
+
+
+		/**
+		 * Show @a style's colour ramp on the gradient bar, or hide the bar if the style does
+		 * not describe one.
+		 */
+		void
+		update_gradient_bar(
+				const GPlatesGui::StyleAdapter* style);
+
+
+		/**
+		 * Say what can be done with the selected style: supplied examples are read-only, and
+		 * have to be copied before they can be used.
+		 */
+		void
+		update_style_hint(
+				const GPlatesGui::StyleAdapter* style);
 
 
 		void
@@ -336,6 +427,7 @@ namespace GPlatesQtWidgets
 		std::vector<QWidget*> d_cfg_widgets;
 		GPlatesPresentation::ViewState& d_view_state;
 		LayerGroupComboBox* d_combo_box;
+		DrawStyleGradientBar* d_gradient_bar;
 		const GPlatesGui::StyleAdapter* d_style_of_all;
 	};
 }

--- a/src/qt-widgets/DrawStyleDialogUi.ui
+++ b/src/qt-widgets/DrawStyleDialogUi.ui
@@ -200,6 +200,26 @@
            </widget>
           </item>
           <item>
+           <widget class="QWidget" name="gradient_bar_placeholder" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="style_hint_label">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QWidget" name="widget" native="true">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <property name="margin">
@@ -217,7 +237,10 @@
                <item>
                 <widget class="QPushButton" name="add_button">
                  <property name="text">
-                  <string>&amp;Add...</string>
+                  <string>&amp;New</string>
+                 </property>
+                 <property name="toolTip">
+                  <string>Create an editable copy of the selected style.</string>
                  </property>
                 </widget>
                </item>

--- a/src/unit-test/AbsoluteAgeDrawStyleTest.py
+++ b/src/unit-test/AbsoluteAgeDrawStyleTest.py
@@ -1,3 +1,20 @@
+'''
+ *
+ * Copyright (C) 2026 CaliTarheel
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+'''
+
 import importlib.util
 from pathlib import Path
 import sys
@@ -77,6 +94,14 @@ class AbsoluteAgeDrawStyleTest(unittest.TestCase):
 
 	def test_invalid_step_count_falls_back_to_smooth(self):
 		self.assertEqual((0.25, 0.0, 0.75, 0.875), self.colour_for_age(125, 'many'))
+
+	def test_non_finite_values_use_safe_defaults(self):
+		self.assertEqual(7.0, absolute_age._finite_float('nan', 7.0))
+		self.assertEqual(7.0, absolute_age._finite_float('infinity', 7.0))
+		self.assertEqual(7.0, absolute_age._finite_float(None, 7.0))
+
+	def test_equal_endpoint_times_select_first_colour(self):
+		self.assertEqual(0.0, absolute_age._gradient_position(150, 100, 100))
 
 	def test_new_style_defaults_are_declared(self):
 		config = absolute_age.AbsoluteAge().get_config()

--- a/src/unit-test/AbsoluteAgeDrawStyleTest.py
+++ b/src/unit-test/AbsoluteAgeDrawStyleTest.py
@@ -1,0 +1,91 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+class FakeColour:
+	def __init__(self, red, green, blue, alpha):
+		self.rgba = (red, green, blue, alpha)
+
+	def get_red(self):
+		return self.rgba[0]
+
+	def get_green(self):
+		return self.rgba[1]
+
+	def get_blue(self):
+		return self.rgba[2]
+
+	def get_alpha(self):
+		return self.rgba[3]
+
+
+fake_pygplates = types.ModuleType('pygplates')
+fake_pygplates.Colour = FakeColour
+sys.modules['pygplates'] = fake_pygplates
+
+script_path = (
+	Path(__file__).resolve().parents[1]
+	/ 'qt-resources' / 'python' / 'scripts' / 'colouring' / 'AbsoluteAge.py')
+spec = importlib.util.spec_from_file_location('AbsoluteAge', script_path)
+absolute_age = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(absolute_age)
+
+
+class FakeFeature:
+	def __init__(self, begin_time):
+		self._begin_time = begin_time
+
+	def begin_time(self):
+		return self._begin_time
+
+
+class FakeStyle:
+	colour = None
+
+
+class AbsoluteAgeDrawStyleTest(unittest.TestCase):
+	def make_draw_style(self, steps='smooth'):
+		draw_style = absolute_age.AbsoluteAge()
+		draw_style.set_config({
+			'Endpoint 1 colour': FakeColour(0.0, 0.0, 1.0, 1.0),
+			'Endpoint 1 time (Ma)': '100',
+			'Endpoint 2 colour': FakeColour(1.0, 0.0, 0.0, 0.5),
+			'Endpoint 2 time (Ma)': '200',
+			'Steps (or smooth)': steps,
+		})
+		return draw_style
+
+	def colour_for_age(self, age, steps='smooth'):
+		style = FakeStyle()
+		self.make_draw_style(steps).get_style(FakeFeature(age), style)
+		return style.colour.rgba
+
+	def test_smooth_gradient_and_clamping(self):
+		self.assertEqual((0.0, 0.0, 1.0, 1.0), self.colour_for_age(50))
+		self.assertEqual((0.5, 0.0, 0.5, 0.75), self.colour_for_age(150))
+		self.assertEqual((1.0, 0.0, 0.0, 0.5), self.colour_for_age(250))
+
+	def test_step_count_includes_both_endpoint_colours(self):
+		self.assertEqual((0.5, 0.0, 0.5, 0.75), self.colour_for_age(125, '3'))
+		self.assertEqual((1.0, 0.0, 0.0, 0.5), self.colour_for_age(175, '3'))
+
+	def test_reversed_endpoint_times(self):
+		self.assertEqual(0.25, absolute_age._gradient_position(175, 200, 100))
+
+	def test_invalid_step_count_falls_back_to_smooth(self):
+		self.assertEqual((0.25, 0.0, 0.75, 0.875), self.colour_for_age(125, 'many'))
+
+	def test_new_style_defaults_are_declared(self):
+		config = absolute_age.AbsoluteAge().get_config()
+		self.assertEqual('#2c7bb6', config['Endpoint 1 colour/default'])
+		self.assertEqual('0', config['Endpoint 1 time (Ma)/default'])
+		self.assertEqual('#d7191c', config['Endpoint 2 colour/default'])
+		self.assertEqual('450', config['Endpoint 2 time (Ma)/default'])
+		self.assertEqual('smooth', config['Steps (or smooth)/default'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/src/unit-test/CMakeLists.txt
+++ b/src/unit-test/CMakeLists.txt
@@ -87,3 +87,10 @@ set(srcs
 if (TARGET gplates-unit-test)
     target_sources_util(gplates-unit-test PRIVATE ${srcs})
 endif()
+
+# The Absolute Age draw style is a bundled Python script, so its focused tests
+# run directly with the same Python interpreter selected for GPlates.
+add_custom_target(absolute-age-draw-style-test
+    COMMAND "${GPLATES_PYTHON_EXECUTABLE}" -B -m unittest
+            "${CMAKE_CURRENT_SOURCE_DIR}/AbsoluteAgeDrawStyleTest.py"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")

--- a/src/unit-test/CMakeLists.txt
+++ b/src/unit-test/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 # The Absolute Age draw style is a bundled Python script, so its focused tests
 # run directly with the same Python interpreter selected for GPlates.
 add_custom_target(absolute-age-draw-style-test
-    COMMAND "${GPLATES_PYTHON_EXECUTABLE}" -B -m unittest
+    COMMAND "${GPLATES_PYTHON_EXECUTABLE}" -B
             "${CMAKE_CURRENT_SOURCE_DIR}/AbsoluteAgeDrawStyleTest.py"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    VERBATIM)


### PR DESCRIPTION
## Summary

- Add a bundled **Absolute Age** draw style based on each feature's begin time.
- Configure two endpoint colours and times, with a smooth gradient or a discrete number of colour steps.
- Expose RGBA colour components to Python-backed draw styles.
- Preserve declared Python draw-style defaults and parse configuration groups without relying on dictionary entry order.
- Add a repeatable focused test target.

## Why

The existing `FeatureAge` style subtracts the current reconstruction time, so its colours change as reconstruction time changes. This style keeps colour tied to absolute appearance/begin time, making it suitable for age maps that should remain stable while reconstruction time changes.

## User impact

- The Colouring dialog offers an `AbsoluteAge` category.
- The default is a smooth blue-to-red gradient from 0 to 450 Ma.
- Users can configure both colours, both endpoint times, and either `smooth`/`continuous` or an integer number of distinct colours.
- Values outside the configured interval clamp to the nearest endpoint colour; reversed endpoints are supported.
- Invalid and non-finite numeric values fall back safely, and equal endpoint times select the first colour.

This affects visual styling only. It does not modify feature data, project files, or reconstruction models.

## Implementation and compatibility

- `pygplates.Colour` gains read-only `get_red()`, `get_green()`, `get_blue()`, and `get_alpha()` methods used for interpolation.
- Python draw-style config keys are grouped by their `name/subkey` structure independent of dictionary order.
- Malformed config keys and definitions are skipped with a warning instead of inserting null configuration items.
- Existing draw styles without declared defaults retain their previous fallback values.
- The new Python source and test carry the repository's GPLv2 notice under the contributor's attribution.

## Interim scope and non-goals

This is intentionally a small, self-contained contribution while broader colouring work is redesigned. It does not replace a future general age-palette system, add persistence formats, or change the existing `FeatureAge` style.

## Validation

- Rebased onto current `GPlates/GPlates:gplates` (`27f9a63ba`).
- CMake configured successfully with Ninja, MSVC 19.44, Qt 6, Boost, GDAL, and PROJ.
- `absolute-age-draw-style-test`: **7 tests passed**, covering interpolation, clamping, stepped colours, reversed/equal endpoints, invalid steps, non-finite values, and declared defaults.
- Successfully compiled current-head `PyColour.cc` and `DrawStyleAdapters.cc`.
- Qt MOC/UIC and RCC rebuilt successfully, including the bundled `python.qrc` resource object.
- Both Python files pass `py_compile`.
- `git diff --check` passes.
- A complete current-head `gplates` link and interactive GUI smoke test were not run in this audit environment.

## Reviewer notes

The cross-cutting part is the small Python configuration-parser correction. It is required so each colour/time field receives its own complete `type` and `default` definition, and it now handles non-adjacent config entries safely.
