### PR TITLE
Fix flowlines breaking when the left and right plates do not coincide

### DIFF
--- a/src/app-logic/FlowlineGeometryPopulator.cc
+++ b/src/app-logic/FlowlineGeometryPopulator.cc
@@ -109,6 +109,7 @@ GPlatesAppLogic::FlowlineGeometryPopulator::initialise_pre_feature_properties(
     d_right_rotations.clear();
     d_left_seed_point_rotations.clear();
     d_right_seed_point_rotations.clear();
+    d_left_to_right_plate_frame_rotation = boost::none;
 
     //Detect Flowline features.
     FlowlineUtils::DetectFlowlineFeatures detector;
@@ -163,6 +164,16 @@ GPlatesAppLogic::FlowlineGeometryPopulator::initialise_pre_feature_properties(
 			*d_flowline_property_finder->get_left_plate(),
 			d_reconstruction_tree_creator,
 			d_right_seed_point_rotations);
+
+		// The seed point is stored in the left plate's frame, but the right-hand half of the
+		// flowline is built up in the right plate's frame, so we'll need to move the seed point
+		// between the two frames.
+		d_left_to_right_plate_frame_rotation =
+			FlowlineUtils::get_left_to_right_plate_frame_rotation(
+				times.front()/*the flowline's youngest time*/,
+				*d_flowline_property_finder->get_left_plate(),
+				*d_flowline_property_finder->get_right_plate(),
+				d_reconstruction_tree_creator);
 
 		// This will now hold the times we need to use for flowline rotations, from the current reconstruction time to
 		// the oldest time in the flowline.
@@ -403,9 +414,19 @@ GPlatesAppLogic::FlowlineGeometryPopulator::create_flowline_geometry(
 			present_day_seed_point,
 			d_left_seed_point_rotations);
 
+		// The seed point is stored in the left plate's frame, so it can be used as-is to seed the
+		// left-hand half of the flowline (above), but it must first be moved into the right plate's
+		// frame to seed the right-hand half. Without this the two halves of the flowline start from
+		// different places whenever the left and right plates do not coincide at the flowline's
+		// youngest time.
+		const GPlatesMaths::PointOnSphere right_plate_seed_point =
+			d_left_to_right_plate_frame_rotation
+			? *d_left_to_right_plate_frame_rotation * present_day_seed_point
+			: present_day_seed_point;
+
 		const GPlatesMaths::PointOnSphere reconstructed_right_seed_point =
 			FlowlineUtils::reconstruct_seed_point(
-			present_day_seed_point,
+			right_plate_seed_point,
 			d_right_seed_point_rotations);
 
 

--- a/src/app-logic/FlowlineGeometryPopulator.h
+++ b/src/app-logic/FlowlineGeometryPopulator.h
@@ -150,10 +150,18 @@ namespace GPlatesAppLogic
 		std::vector<GPlatesMaths::FiniteRotation> d_right_rotations;
 		
 		/**
-		 * Rotations for moving the seed point prior to building the rest of the flowline.                                                                    
+		 * Rotations for moving the seed point prior to building the rest of the flowline.
 		 */
 		std::vector<GPlatesMaths::FiniteRotation> d_left_seed_point_rotations;
 		std::vector<GPlatesMaths::FiniteRotation> d_right_seed_point_rotations;
+
+		/**
+		 * Moves the seed point from the left plate's frame (the frame it is stored in) into the
+		 * right plate's frame, before the right-hand half of the flowline is built up.
+		 *
+		 * See FlowlineUtils::get_left_to_right_plate_frame_rotation().
+		 */
+		boost::optional<GPlatesMaths::FiniteRotation> d_left_to_right_plate_frame_rotation;
 
 	};
 }

--- a/src/app-logic/FlowlineUtils.cc
+++ b/src/app-logic/FlowlineUtils.cc
@@ -402,6 +402,27 @@ GPlatesAppLogic::FlowlineUtils::reconstruct_seed_points(
     return current_points;
 }
 
+GPlatesMaths::FiniteRotation
+GPlatesAppLogic::FlowlineUtils::get_left_to_right_plate_frame_rotation(
+	const double &flowline_start_time,
+	const GPlatesModel::integer_plate_id_type &left_plate_id,
+	const GPlatesModel::integer_plate_id_type &right_plate_id,
+	const ReconstructionTreeCreator &reconstruction_tree_creator)
+{
+	// R(0->t,right->left)
+	//    = R(0->t,right->A) * R(0->t,A->left)
+	//    = inverse[R(0->t,A->right)] * R(0->t,A->left)
+	//
+	// ...where 'A' is the anchor plate and 't' is the flowline's start time.
+	ReconstructionTree::non_null_ptr_to_const_type reconstruction_tree =
+			reconstruction_tree_creator.get_reconstruction_tree(flowline_start_time);
+
+	return GPlatesMaths::compose(
+			GPlatesMaths::get_reverse(
+					reconstruction_tree->get_composed_absolute_rotation(right_plate_id)),
+			reconstruction_tree->get_composed_absolute_rotation(left_plate_id));
+}
+
 void
 GPlatesAppLogic::FlowlineUtils::fill_seed_point_rotations(
     const double &current_time,

--- a/src/app-logic/FlowlineUtils.h
+++ b/src/app-logic/FlowlineUtils.h
@@ -318,6 +318,33 @@ namespace GPlatesAppLogic
 			bool reverse = false);
 
 		/**
+		 * Returns the rotation which transfers a flowline's seed point from the frame of the
+		 * left plate into the frame of the right plate.
+		 *
+		 * A flowline's seed point is stored in the frame of its *left* plate - that is the frame
+		 * @a reconstruct_flowline_seed_points reverse reconstructs it into. The right-hand half of
+		 * the flowline is however built up in the frame of the *right* plate, so the seed point
+		 * must be moved into that frame before it is used to seed the right-hand half.
+		 *
+		 * This is the rotation of the left plate relative to the right plate at
+		 * @a flowline_start_time (the youngest time in the flowline's list of times, which is when
+		 * both halves of the flowline start out together at the spreading centre), ie
+		 * R(0->flowline_start_time, right_plate->left_plate).
+		 *
+		 * It is the identity rotation whenever the two plates coincide at @a flowline_start_time -
+		 * which is the usual case, since the flowline's youngest time is usually present day and
+		 * rotations at present day are usually the identity rotation. It is *not* the identity when,
+		 * for example, a rotation file has been hand-edited so that present day is not the identity
+		 * rotation, or when the flowline's youngest time is not present day.
+		 */
+		GPlatesMaths::FiniteRotation
+		get_left_to_right_plate_frame_rotation(
+			const double &flowline_start_time,
+			const GPlatesModel::integer_plate_id_type &left_plate_id,
+			const GPlatesModel::integer_plate_id_type &right_plate_id,
+			const ReconstructionTreeCreator &reconstruction_tree_creator);
+
+		/**
 		 * Fills @a seed_point_rotations with half-stage rotations from earliest flowline
 		 * time to current time.
 		 */


### PR DESCRIPTION
Fixes #23.

## The problem

A flowline's seed point is stored in the frame of its **left** plate — that is the frame
`FlowlineUtils::reconstruct_flowline_seed_points()` reverse reconstructs it into, and the frame
`FlowlineGeometryPopulator` builds the left-hand half of the flowline in.

The right-hand half is built in the frame of the **right** plate, but the stored seed point was
being used to seed it as-is:

```cpp
const GPlatesMaths::PointOnSphere reconstructed_left_seed_point =
    FlowlineUtils::reconstruct_seed_point(present_day_seed_point, d_left_seed_point_rotations);

const GPlatesMaths::PointOnSphere reconstructed_right_seed_point =
    FlowlineUtils::reconstruct_seed_point(present_day_seed_point, d_right_seed_point_rotations);
```

That is only correct when the left and right plates coincide at the flowline's youngest time `t0`
(when both halves start out together at the spreading centre). Otherwise the two halves start from
different places and the flowline is broken, offset by exactly

    R(0->t0, right->left)

the rotation of the left plate relative to the right plate at `t0`.

The assumption normally holds because `t0` is usually present day and rotations at present day are
usually the identity rotation — so this has gone unnoticed. It breaks in two situations:

1. **A rotation file where present day is not the identity rotation.** This is what issue #23
   reports: plate motion was simulated *forwards* in time and the 0 Ma poles then hand-edited to
   match where the simulation had got to, rather than being left as identity.
2. **A flowline whose youngest time is not present day** — with a completely ordinary rotation
   file. The reporter suspected flowlines "might still break even with" their 1 Ma workaround;
   they do, for this reason.

This also explains the two other observations in the issue:

- **Mid-ocean ridges are unaffected** ("MOR also don't suffer from the same problem, despite the
  fact that the two should match"). A half-stage geometry is built in the left plate's frame only
  (`RotationUtils::get_half_stage_rotation()` ends with `compose(left_rotation, spreading_rotation)`),
  so there is no second frame to get wrong.
- For the same reason the flowline's **seed point** was always drawn in the right place; only the
  two halves around it were wrong.

## The fix

Move the seed point into the right plate's frame before it is used to seed the right-hand half.
The new `FlowlineUtils::get_left_to_right_plate_frame_rotation()` returns the identity rotation
whenever the two plates coincide at `t0`, so ordinary flowlines are bit-for-bit unchanged.

## Verification

A minimal two-plate spreading system (plate 201 left, 701 right, seed on the ridge at 0N/0E,
flowline times 0–40 Ma) with three rotation files: an ordinary one, one with a hand-edited "drift
correction" at 0 Ma (the issue), and one with the same correction at 1 Ma (the reporter's
workaround). Measuring the gap between the start points of the two halves of the flowline:

| rotation file | flowline youngest time | before | after |
|---|---|---|---|
| ordinary (identity at 0 Ma) | 0 Ma | 0.000° | 0.000° |
| drift correction at 0 Ma — **issue #23** | 0 Ma | **30.931°** | 0.000° |
| drift correction at 1 Ma — reporter's workaround | 0 Ma | 0.000° | 0.000° |
| ordinary (identity at 0 Ma) | 10 Ma | **8.000°** | 0.000° |

The gap is constant across reconstruction times and matches `R(0->t0, right->left)` applied to the
seed point in every case.

Checked in the GPlates GUI itself (built on Linux, Qt6, conda dependencies), loading the drift
correction at 0 Ma at 0 Ma reconstruction time. Reading the rendered flowline back off the globe:

| | unpatched | patched |
|---|---|---|
| left half, spreading-centre end | 4.45°S, 30.87°E | 4.45°S, 30.87°E |
| right half, spreading-centre end | 25.35°S, 7.67°E | 4.12°S, 31.62°E |
| separation | **30.53°** | 0.82° (≈3 px, they meet) |

Unpatched, the flowline is visibly torn into two disjoint halves; patched, the two halves meet at
the seed point. The left half is unchanged by the patch, as expected. On an ordinary rotation file
the two builds render identically.
