### PR TITLE
Use QFile instead of std::ifstream so non-ASCII paths work

### DIFF
--- a/src/data-mining/DataMiningUtils.cc
+++ b/src/data-mining/DataMiningUtils.cc
@@ -22,10 +22,11 @@
  * with this program; if not, write to Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-#include <fstream>
 #include <utility>
 #include <boost/foreach.hpp>
+#include <QFile>
 #include <QtGlobal>
+#include <QTextStream>
 
 #include "app-logic/ReconstructionLayerProxy.h"
 #include "app-logic/ReconstructedFeatureGeometry.h"
@@ -237,25 +238,37 @@ GPlatesDataMining::DataMiningUtils::load_cfg(
 		const QString& cfg_filename,
 		const QString& section_name)
 {
-	std::string str;
 	std::vector<QString> ret;
-	// FIXME: We should replace usage of std::ifstream with the appropriate Qt class.
-	std::ifstream ifs ( cfg_filename.toStdString().c_str() , std::ifstream::in );
 
-	while (ifs.good()) // go to the line starting with section_name.
+	// Read the file through QFile rather than std::ifstream so that paths containing
+	// non-ASCII characters work. QString::toStdString() encodes as UTF-8, but the narrow
+	// std::ifstream constructor interprets its path using the process' ANSI code page on
+	// Windows, so any path outside that code page silently failed to open.
+	QFile cfg_file(cfg_filename);
+	if (!cfg_file.open(QIODevice::ReadOnly | QIODevice::Text))
 	{
-		std::getline(ifs,str);
-		QString s(str.c_str());
-		s = s.trimmed().simplified();
+		return ret;
+	}
+
+	QTextStream cfg_stream(&cfg_file);
+	// The replaced code decoded each line as UTF-8 via QString(const char *), so ask for
+	// UTF-8 explicitly rather than inheriting the locale codec under Qt5.
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+	cfg_stream.setEncoding(QStringConverter::Utf8);
+#else
+	cfg_stream.setCodec("UTF-8");
+#endif
+
+	while (!cfg_stream.atEnd()) // go to the line starting with section_name.
+	{
+		const QString s = cfg_stream.readLine().trimmed().simplified();
 		if(s.startsWith(section_name))
 			break;
 	}
 
-	while (ifs.good())
+	while (!cfg_stream.atEnd())
 	{
-		std::getline(ifs,str);
-		QString s(str.c_str());
-		s = s.trimmed().simplified();
+		const QString s = cfg_stream.readLine().trimmed().simplified();
 
 		if(s.startsWith("#"))//skip comments
 			continue;

--- a/src/file-io/PlatesRotationFileProxy.cc
+++ b/src/file-io/PlatesRotationFileProxy.cc
@@ -27,11 +27,11 @@
 #include <limits>
 #include <boost/foreach.hpp>
 
-#include <fstream>
 #include <sstream>
 #include <string>
 #include <QBuffer>
 #include <QFile>
+#include <QTextStream>
 
 #include "PlatesRotationFileProxy.h"
 
@@ -1025,13 +1025,26 @@ GPlatesFileIO::GrotWriterWithoutCfg::visit_gpml_metadata(
 	gpml_metadata.get_data().serialize(buf);
 	d_output_stream->seek(0);
 	
-	// FIXME: We should replace usage of std::ifstream with the appropriate Qt class.
-	std::ifstream ifs(d_file_ref.get_file_info().get_qfileinfo().filePath().toStdString().c_str());
-	std::string str(
-			(std::istreambuf_iterator<char>(ifs)),
-			std::istreambuf_iterator<char>());
+	// Read the file through QFile rather than std::ifstream so that paths containing
+	// non-ASCII characters work. QString::toStdString() encodes as UTF-8, but the narrow
+	// std::ifstream constructor interprets its path using the process' ANSI code page on
+	// Windows, so any path outside that code page silently failed to open and the existing
+	// file contents were dropped from the output.
+	QString existing_contents;
+	QFile existing_file(d_file_ref.get_file_info().get_qfileinfo().filePath());
+	if (existing_file.open(QIODevice::ReadOnly | QIODevice::Text))
+	{
+		QTextStream existing_stream(&existing_file);
+		// Match the UTF-8 encoding that the output stream is written with.
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+		existing_stream.setEncoding(QStringConverter::Utf8);
+#else
+		existing_stream.setCodec("UTF-8");
+#endif
+		existing_contents = existing_stream.readAll();
+	}
 	(*d_output_stream) << buf;
-	(*d_output_stream) << str.c_str();
+	(*d_output_stream) << existing_contents;
 }
 
 


### PR DESCRIPTION
QString::toStdString() encodes as UTF-8, but the narrow std::ifstream constructor interprets its path using the process' ANSI code page on Windows. Any path containing characters outside that code page therefore failed to open, silently and with no error reported. This is why feature collections and rotation files stored under paths with non-Latin characters do not load or save reliably.

Two places were affected:

- GrotWriterWithoutCfg::visit_gpml_metadata(), which reads the rotation file back while writing out the metadata block.
- DataMiningUtils::load_cfg(), which returned an empty configuration.

Both now read through QFile/QTextStream with UTF-8 requested explicitly. That matches the encoding PlatesRotationFormatWriter writes with, and the UTF-8 decoding the replaced code got implicitly from QString(const char *)
- a QTextStream would otherwise default to the locale codec under Qt5. Behaviour on ASCII paths is unchanged.

This resolves both occurrences of the "FIXME: We should replace usage of std::ifstream with the appropriate Qt class." comment; those were the only two instances in the tree.

Note: visit_gpml_metadata() reads back the same file that the base class constructor has already opened with QIODevice::WriteOnly, so what it reads is whatever has been flushed rather than the file's prior contents. That pre-existing behaviour is deliberately left unchanged here.