### PR TITLE
Fix pole adjustment silently not being committed to the model

### DIFF
--- a/pygplates/MERGE-EXECUTION-DETAILS.md
+++ b/pygplates/MERGE-EXECUTION-DETAILS.md
@@ -174,6 +174,13 @@ commits.
 - `src/qt-widgets/MetadataDialog.cc` `save_fc_meta()` / `save_mprs_meta()` (added `is_still_valid()` guards matching the old proxy's silent-skip)
 - `src/file-io/GpmlUpgradeReaderUtils.cc` crustal-thinning-factor upgrade (**also affects pygplates**: loading pre-GPlates-1.6.338 files silently kept unconverted values)
 - `src/qt-widgets/CreateFeatureDialog.cc` `reverse_reconstruct_geometry_property()` (also removed a stray duplicated `clone()` statement that predates the merge on both branches)
+- `src/qt-widgets/TotalReconstructionSequencesDialog.cc` `update_current_sequence()` (3 sites — TRS
+  dialog → Edit sequence → Apply) and `set_seq_disabled()` (1 site — enable/disable a sequence).
+  **Found later**, while investigating issue #38 (see §9): these are spelled `**opt_iter = x` /
+  `(**opt_iter) = x`, dereferencing a `boost::optional<FeatureHandle::iterator>` returned **by value**
+  from `TRSUtils::TRSFinder`, which the original audit's `*iter = ` grep did not match. Same bug class,
+  same fix (`feature_ref->set(iter, x)` with `is_still_valid()` guards). Independent of §9's fix:
+  `TRSFinder` is read-only (it only records iterators) and the mutation happens *after* the visit.
 
 **Not fixed / known residual:**
 - `BubbleUpRevisionHandler::commit()` has `// TODO: Emit model events.` — **in-place** property-value
@@ -182,6 +189,9 @@ commits.
   flag. Same gap existed for in-place edits on the old branch (old GUI always used clone + commit).
   Console `feature.add/remove/set` paths DO notify. Full fix is the deferred
   `feature/pygplates-model-revisions` work.
+  **Update:** this gap turned out to be live for the desktop app too, via the non-const `FeatureVisitor`
+  mutation path — see §9 for the symptom (issue #38) and the interim fix. The TODO itself remains
+  unimplementable until `FeatureHandle` is a `RevisionContext`.
 - New `FeatureHandle::set()` lacks the old instance-id equality skip, so a commit of an unchanged
   clone now still dirties the file (rare; e.g. a no-op geometry-builder update).
 - Disabled (`#if 0`) code still containing the dead pattern, left as-is: `SplitFeatureUndoCommand.cc`,
@@ -292,3 +302,97 @@ workaround can be deleted. No shared helper was introduced since it would just b
 un-hardened (option 2 skipped, per above) — every current `set()`/`add()` call site is disciplined today,
 and the full model migration (option 3) is expected to close this properly rather than layering a second
 temporary workaround on top of `set()`/`add()`.
+
+## 9. Post-merge regression (GPlates issue #38): non-const `FeatureVisitor` edits never reach the feature
+
+**Symptom (reported, GPlates 2.6.0-dev):** with the **Modify Reconstruction Pole** tool the plate follows
+the mouse while dragging, but **Apply** has no visible effect — the plate snaps back to its original
+position, and "Save All Changes" writes a byte-identical `.rot` file.
+
+**Root cause:** two consequences of the merge combine.
+
+1. *The write-back disappeared.* Pre-merge, `src/model/FeatureVisitor.cc` specialised the non-const
+   visitor to *clone → visit → commit*:
+   ```cpp
+   TopLevelProperty::non_null_ptr_type prop_clone = (*iter)->deep_clone();
+   prop_clone->accept_visitor(*this);
+   *iter = prop_clone;    // TopLevelPropertyRef proxy -> FeatureHandle::set() -> notifies the model
+   ```
+   The merge deleted that file (its `FeatureVisitorThatGuaranteesNotToModify` opt-out no longer exists
+   either), leaving only the generic template in `src/model/FeatureVisitor.h`:
+   `(*feature_iterator)->accept_visitor(*this);` — which mutates the live property in place.
+2. *Bubble-up does not reach the feature.* `GpmlFiniteRotation::set_finite_rotation()` commits via
+   `BubbleUpRevisionHandler`, and the chain terminates at `TopLevelPropertyInline` because
+   `FeatureHandle`/`BasicHandle` are **not** `RevisionContext`s — i.e. §7's residual `// TODO: Emit model
+   events.` (`src/model/BubbleUpRevisionHandler.cc`). That TODO cannot be implemented today: `d_model` is
+   always `boost::none` for an in-feature property value, so the handler has no feature to notify.
+
+So the pole data **is** updated in memory, but `BasicHandle::notify_listeners_of_modification()` never
+runs — and that one function does both jobs:
+
+- `set_unsaved_changes()` on the `FeatureCollectionHandle`. Without it, "Save All Changes" **skips the
+  file entirely** (`src/gui/FileIOFeedback.cc`), hence the unchanged `.rot`. (The per-row Save button
+  passes `only_unsaved_changes = false` and *would* write the new poles, since
+  `PlatesRotationFormatWriter` reads live property values — a useful confirmation that the model data
+  itself was correct all along.)
+- fires `publisher_modified` → `ApplicationState::reconstruct()` and `ReconstructGraph::modified_input_file()`
+  → `ReconstructionLayerProxy::invalidate()`, the only thing that discards the cached reconstruction
+  trees. Without it the view redraws from stale trees while
+  `ModifyReconstructionPoleWidget::reset_adjustment()` clears the drag orientation — so the plate
+  visibly snaps back.
+
+`AdjustmentApplicator::apply_adjustment()` (`src/qt-widgets/ApplyReconstructionPoleAdjustmentDialog.cc`)
+already wraps the visit in a `NotificationGuard` and releases it *expecting* a reconstruction; there was
+simply nothing pending to flush.
+
+**Interim fix applied** (two hunks, both marked `INTERIM (GPlates issue #38)`):
+- `src/model/TopLevelProperty.h` — new `accept_visitor_and_detect_modification(FeatureVisitor &)`
+  returning whether the visit created a new revision. The comparison lives inside `TopLevelProperty` so
+  `Revision` stays out of the public API (`Revisionable::get_current_revision()` is protected). Note the
+  `GPlatesModel::Revision` qualification — unqualified `Revision` would find the nested
+  `TopLevelProperty::Revision`.
+- `src/model/FeatureVisitor.h` — an `inline template<>` specialisation of
+  `FeatureVisitorBase<FeatureHandle>::visit_feature_property()` that, **only when the visit actually
+  created a new revision**, re-sets the property via `feature_ref->set(iter, property)` to notify model
+  listeners. A top-level property acquires a new revision iff something nested in it was modified, since
+  it is currently the root of the bubble-up chain — so this is an exact change detector, not a heuristic.
+
+Deliberately *not* a restoration of the pre-merge behaviour: there is **no deep clone** of every visited
+property, so the read-only visitors on the hot reconstruction path pay only a pointer copy and compare.
+`set()` with the same pointer is safe — `BasicRevision::set` is a copy-and-swap on the intrusive pointer
+(no reallocation, no size change, no revision swap), and `RevisionAwareIterator` holds only
+`{weak_ref, index}` and re-reads the revision on each dereference, so the enclosing
+`visit_feature_properties()` loop iterator stays valid.
+
+**Blast radius audited.** Of the 23 classes deriving from non-const `GPlatesModel::FeatureVisitor`,
+exactly three mutate property values:
+
+| Visitor | Verdict |
+|---|---|
+| `TotalReconstructionSequenceRotationInserter` | the bug — *wants* the notification, and already runs under a `NotificationGuard` |
+| `MakeFilePathsAbsoluteVisitor` (`src/file-io/GpmlReader.cc`) | runs on a **detached** collection during load (no model, no observers); `FeatureCollectionFileIO` clears the flag after a clean load — no regression |
+| `GeometryRotator` (`src/feature-visitors/GeometryRotator.h`) | **zero callers** — dead code |
+
+The other 20 (all the `ReconstructMethod*`, `TopologyGeometryResolver`, `TopologyNetworkResolver`,
+`GeometryCookieCutter`, `TopologyInternalUtils`, `*GeometryPopulator`, `TRSUtils`, `PartitionFeatureUtils`,
+`EditWidgetChooser`, `PaleomagUtils`, `api/PyPropertyValueVisitor`) are non-const only to obtain non-const
+references; none calls a setter or a `RevisionedVector` mutator, so none can trip the detector
+(`PartitionFeatureUtils.cc` even carries a TODO saying exactly this). Nothing overrides
+`visit_feature_property`, so the specialisation cannot be bypassed. pyGPlates is unaffected:
+`FeatureVisitorWrap` exposes only property-value visiting and never goes through `visit_feature_property`.
+
+**Removal criterion:** delete **both** hunks once `FeatureHandle` is a `RevisionContext` — Stage 4 of
+`feature/pygplates-model-revisions` (`src/model/FeatureBase.h`) — and the model emits these events itself
+via the now-implementable `BubbleUpRevisionHandler::commit()` TODO. That branch deliberately leaves
+`visit_feature_property()` as the plain in-place call, which is the correct end state; this interim
+specialisation exists only to bridge the gap.
+
+**Also fixed alongside** (drive-by, pre-existing on both branches — not caused by the merge):
+`TotalReconstructionSequenceRotationInserter::update_finite_rotation()` built its `old_pole` from
+`gpml_finite_rotation.get_finite_rotation()` *after* calling `set_finite_rotation()`, so
+`old_pole == new_pole`. Benign today (only the `.grot` proxy consumes it, and
+`PlatesRotationFileProxy::update_pole` matches on moving-plate-id + time), but it would break `.grot`
+editing the moment that match becomes value-sensitive. Now captures the original rotation first.
+
+**Explicitly out of scope** (recorded, not attempted): making the handles `RevisionContext`s;
+implementing the `BubbleUpRevisionHandler::commit()` TODO; making Python property-value edits notify.

--- a/src/feature-visitors/TotalReconstructionSequenceRotationInserter.cc
+++ b/src/feature-visitors/TotalReconstructionSequenceRotationInserter.cc
@@ -419,8 +419,12 @@ void
 GPlatesFeatureVisitors::TotalReconstructionSequenceRotationInserter::update_finite_rotation(
 		GPlatesPropertyValues::GpmlFiniteRotation &gpml_finite_rotation)
 {
+	// Note: Must be captured *before* the finite rotation is updated below.
+	const GPlatesMaths::FiniteRotation original_finite_rotation =
+			gpml_finite_rotation.get_finite_rotation();
+
 	const GPlatesMaths::FiniteRotation updated_finite_rotation =
-			GPlatesMaths::compose(d_rotation_to_apply, gpml_finite_rotation.get_finite_rotation());
+			GPlatesMaths::compose(d_rotation_to_apply, original_finite_rotation);
 	gpml_finite_rotation.set_finite_rotation(updated_finite_rotation);
 
 	if (d_grot_proxy)
@@ -431,7 +435,7 @@ GPlatesFeatureVisitors::TotalReconstructionSequenceRotationInserter::update_fini
 				d_fixed_plate_id,
 				d_recon_time.value());
 		const GPlatesFileIO::RotationPoleData old_pole(
-				gpml_finite_rotation.get_finite_rotation(),
+				original_finite_rotation,
 				d_moving_plate_id,
 				d_fixed_plate_id,
 				d_recon_time.value());

--- a/src/model/FeatureVisitor.h
+++ b/src/model/FeatureVisitor.h
@@ -803,6 +803,43 @@ namespace GPlatesModel
 	}
 
 
+	/**
+	 * INTERIM (GPlates issue #38) - remove this specialisation, together with
+	 * TopLevelProperty::accept_visitor_and_detect_modification(), once FeatureHandle is a
+	 * RevisionContext (see the 'feature/pygplates-model-revisions' branch) and the model emits
+	 * these events itself.
+	 *
+	 * A non-const feature visitor can modify a top-level property, but the bubble-up revisioning
+	 * chain currently terminates at the top-level property (FeatureHandle is not a RevisionContext),
+	 * so the feature - and hence the feature collection - is never notified of the modification.
+	 * Without that notification the feature collection is not flagged as having unsaved changes and
+	 * no reconstruction is triggered.
+	 *
+	 * Unlike the pre-pyGPlates-merge code (the deleted "FeatureVisitor.cc") this does *not* deep
+	 * clone every visited property - it only re-sets the property when the visit actually created a
+	 * new revision - so the read-only visitors on the reconstruction path are unaffected.
+	 */
+	template<>
+	inline
+	void
+	FeatureVisitorBase<FeatureHandle>::visit_feature_property(
+			const feature_iterator_type &feature_iterator)
+	{
+		const TopLevelProperty::non_null_ptr_type feature_property = *feature_iterator;
+
+		if (feature_property->accept_visitor_and_detect_modification(*this))
+		{
+			// Re-set the property on the feature in order to notify the model listeners
+			// (unsaved changes, reconstruction, etc).
+			const FeatureHandle::weak_ref feature_ref = feature_iterator.handle_weak_ref();
+			if (feature_ref.is_valid())
+			{
+				feature_ref->set(feature_iterator, feature_property);
+			}
+		}
+	}
+
+
 	template<class FeatureHandleType>
 	const boost::optional<typename FeatureVisitorBase<FeatureHandleType>::feature_iterator_type> &
 	FeatureVisitorBase<FeatureHandleType>::current_top_level_propiter() const

--- a/src/model/TopLevelProperty.h
+++ b/src/model/TopLevelProperty.h
@@ -144,6 +144,35 @@ namespace GPlatesModel
 				FeatureVisitor &visitor) = 0;
 
 		/**
+		 * Accept a FeatureVisitor instance and return whether the visitor modified this property.
+		 *
+		 * A top-level property acquires a new revision if and only if something nested within it
+		 * was modified, since it is currently the root of the bubble-up revisioning chain
+		 * (FeatureHandle is not yet a RevisionContext).
+		 *
+		 * INTERIM (GPlates issue #38) - remove this method once FeatureHandle is a RevisionContext
+		 * (see the 'feature/pygplates-model-revisions' branch) and the model emits these events itself.
+		 * See also the FeatureVisitorBase<FeatureHandle>::visit_feature_property() specialisation
+		 * in "FeatureVisitor.h" that is the sole caller.
+		 */
+		bool
+		accept_visitor_and_detect_modification(
+				FeatureVisitor &visitor)
+		{
+			// Hold a reference to the revision current before the visit, so that if the visitor
+			// creates more than one revision an intermediate one cannot be freed and its address reused.
+			//
+			// Note: 'GPlatesModel::Revision' must be qualified since the nested 'TopLevelProperty::Revision'
+			// (declared below) would otherwise be found instead.
+			const GPlatesModel::Revision::non_null_ptr_to_const_type revision_before_visit =
+					get_current_revision();
+
+			accept_visitor(visitor);
+
+			return get_current_revision() != revision_before_visit;
+		}
+
+		/**
 		 * Prints the contents of this TopLevelProperty to the stream @a os.
 		 *
 		 * Note: This function is not called operator<< because operator<< needs to

--- a/src/qt-widgets/TotalReconstructionSequencesDialog.cc
+++ b/src/qt-widgets/TotalReconstructionSequencesDialog.cc
@@ -1692,9 +1692,29 @@ GPlatesQtWidgets::TotalReconstructionSequencesDialog::update_current_sequence(
     trs_finder.visit_feature(feature_ref);
     if (trs_finder.can_process_trs())
     {
-        **trs_finder.irregular_sampling_property_iterator() = trs;	
-        **trs_finder.moving_ref_frame_property_iterator() = moving_plate_id;
-        **trs_finder.fixed_ref_frame_property_iterator() = fix_plate_id;
+        // Note: Cannot use '**trs_finder.<...>_property_iterator() = ...' since dereferencing a
+        // feature properties iterator returns a temporary pointer (so assigning to it does nothing) -
+        // instead set the property via the feature (which also notifies model listeners, eg, to
+        // flag unsaved changes).
+        const FeatureHandle::iterator irregular_sampling_iter =
+                *trs_finder.irregular_sampling_property_iterator();
+        const FeatureHandle::iterator moving_ref_frame_iter =
+                *trs_finder.moving_ref_frame_property_iterator();
+        const FeatureHandle::iterator fixed_ref_frame_iter =
+                *trs_finder.fixed_ref_frame_property_iterator();
+
+        if (irregular_sampling_iter.is_still_valid())
+        {
+            feature_ref->set(irregular_sampling_iter, trs);
+        }
+        if (moving_ref_frame_iter.is_still_valid())
+        {
+            feature_ref->set(moving_ref_frame_iter, moving_plate_id);
+        }
+        if (fixed_ref_frame_iter.is_still_valid())
+        {
+            feature_ref->set(fixed_ref_frame_iter, fix_plate_id);
+        }
     }
 
 	//Step 2: update the pole data in PlatesRotationFileProxy
@@ -1939,9 +1959,12 @@ GPlatesQtWidgets::TotalReconstructionSequencesDialog::set_seq_disabled(
 	trs_finder.visit_feature(feature_ref);
 	if (trs_finder.can_process_trs())
 	{
+		const FeatureHandle::iterator irregular_sampling_iter =
+			*trs_finder.irregular_sampling_property_iterator();
+
 		TopLevelProperty::non_null_ptr_type
-			trs = (**trs_finder.irregular_sampling_property_iterator())->clone();
-		boost::optional<PropertyValue::non_null_ptr_type> trs_value = 
+			trs = (*irregular_sampling_iter)->clone();
+		boost::optional<PropertyValue::non_null_ptr_type> trs_value =
 			ModelUtils::get_property_value(*trs);
 		if(trs_value)
 		{
@@ -1952,7 +1975,15 @@ GPlatesQtWidgets::TotalReconstructionSequencesDialog::set_seq_disabled(
 				irreg_sampling->set_disabled(flag);
 			}
 		}
-		(**trs_finder.irregular_sampling_property_iterator()) = trs;
+
+		// Note: Cannot use '(**trs_finder.irregular_sampling_property_iterator()) = trs' since
+		// dereferencing a feature properties iterator returns a temporary pointer (so assigning to
+		// it does nothing) - instead set the property via the feature (which also notifies model
+		// listeners, eg, to flag unsaved changes).
+		if (irregular_sampling_iter.is_still_valid())
+		{
+			feature_ref->set(irregular_sampling_iter, trs);
+		}
 	}
 	
 	//step 2: update the pole metadata in PlatesRotationFileProxy so that


### PR DESCRIPTION
Fixes #38.

## Symptom

With the **Modify Reconstruction Pole** tool the plate follows the mouse while dragging, but **Apply** has no visible effect: the feature snaps back, and "Save All Changes" writes the `.rot` file out unchanged.

## Cause

A regression from #28 (`3c5314737`), which replaced the old GPlates model with the pyGPlates copy-on-write revisioning model. Two changes combined:

1. **The write-back disappeared.** Pre-merge, `src/model/FeatureVisitor.cc` specialised the non-const visitor to *clone → visit → commit*, and that final `*iter = prop_clone` went through the (now removed) `TopLevelPropertyRef` proxy to `FeatureHandle::set()`, which notified the model. That file is gone; the generic template is now just `(*feature_iterator)->accept_visitor(*this)`, mutating the live property in place.

2. **Bubble-up doesn't reach the feature.** `GpmlFiniteRotation::set_finite_rotation()` commits via `BubbleUpRevisionHandler`, but the chain terminates at `TopLevelPropertyInline` because `FeatureHandle`/`BasicHandle` are not yet `RevisionContext`s.

So the pole data *is* updated in memory, but `BasicHandle::notify_listeners_of_modification()` never runs — and that one function does both jobs:

* `set_unsaved_changes()` on the `FeatureCollectionHandle`. Without it, "Save All Changes" skips the file entirely, which is why the `.rot` on disk is byte-identical.
* fires `publisher_modified` → `ApplicationState::reconstruct()` and `ReconstructionLayerProxy::invalidate()`, the only thing that discards the cached reconstruction trees. Without it the view redraws from stale trees while `ModifyReconstructionPoleWidget::reset_adjustment()` clears the drag orientation — so the plate visibly snaps back.

## Fix

The permanent fix is making `FeatureHandle` a `RevisionContext` (in progress on `feature/pygplates-model-revisions`). Until that lands, this restores the pre-merge behaviour with a small, clearly-marked, easily-removable interim change: re-set the property on the feature after a non-const visit, **but only when the visit actually changed something**.

A top-level property acquires a new revision if and only if something nested within it was modified, since it is currently the root of the bubble-up chain — so comparing the revision pointer across the visit is an exact change detector. Unlike the pre-merge code this does *not* deep clone every visited property, so the read-only visitors on the reconstruction path pay only a pointer copy and compare.

Both hunks are marked `INTERIM (GPlates issue #38)` with the removal criterion.

### Blast radius

Of the 23 classes deriving from non-const `GPlatesModel::FeatureVisitor`, exactly three mutate property values:

| Visitor | Verdict |
|---|---|
| `TotalReconstructionSequenceRotationInserter` | the bug — *wants* the notification, and already runs under a `NotificationGuard` |
| `MakeFilePathsAbsoluteVisitor` | runs on a **detached** collection during load (no observers); the flag is cleared after a clean load — no regression |
| `GeometryRotator` | zero callers — dead code |

The other 20 are non-const only to obtain non-const references; none calls a setter or a `RevisionedVector` mutator, so none can trip the detector. Nothing overrides `visit_feature_property`, so the specialisation cannot be bypassed. pyGPlates is unaffected — `FeatureVisitorWrap` exposes only property-value visiting and never goes through `visit_feature_property`.

## Commits

1. **Fix issue #38** — `TopLevelProperty::accept_visitor_and_detect_modification()` plus the `FeatureVisitorBase<FeatureHandle>::visit_feature_property()` specialisation, and a new §9 in `pygplates/MERGE-EXECUTION-DETAILS.md` documenting the regression and the removal criterion.
2. **Two more dead `*iter = x` model commits in the TRS dialog** — same bug class as `c27a33cf7`, but spelled `**opt_iter = x` (dereferencing a `boost::optional<FeatureHandle::iterator>` returned by value), which that sweep's grep missed. Affects *Total Reconstruction Sequences → Edit sequence* and *enable/disable a sequence*, both of which silently discarded their edits.
3. **Stale `old_pole`** in `TotalReconstructionSequenceRotationInserter::update_finite_rotation()` — it was built *after* the finite rotation was updated, so `old_pole == new_pole`. Pre-existing (also in `release-gplates`) and benign today, since `PlatesRotationFileProxy::update_pole` matches on moving-plate-id + time, but it would break `.grot` editing the moment that match becomes value-sensitive.

## Testing

* Full rebuild of GPlates and pyGPlates (Windows, Qt6, Ninja/Release).
* pyGPlates test suite: 439 tests, all pass.
* Manually verified with `sample-data/plates4-rotation-files/rotations_about_axes.rot` + `sample-data/plates4-line-files/front_polygon_rotates_about_x.dat` (plate 101 has poles at 0.0 and 300.0 Ma only, so 300 Ma exercises the exact-match branch and 100 Ma the interpolate branch):
  * the feature stays where it was dragged after **Apply**, and the position persists across scrubbing time away and back (proving the cached reconstruction tree was invalidated, not just a repaint);
  * the `.rot` row is flagged unsaved and **Save All Changes** writes the new pole;
  * no spurious dirtying — loading and then scrubbing time, toggling layers and focusing features leaves nothing flagged;
  * the TRS dialog edit/disable paths now stick;
  * vertex moves and Edit Feature Properties still work and are not double-notified.

## Follow-up

When `feature/pygplates-model-revisions` makes `FeatureHandle` a `RevisionContext`, delete the specialisation in `FeatureVisitor.h` and `TopLevelProperty::accept_visitor_and_detect_modification()`, and implement the `BubbleUpRevisionHandler::commit()` TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
