### PR TITLE
Make throw-from-destructor aborts diagnosable

### DIFF
--- a/cmake/modules/Version.cmake
+++ b/cmake/modules/Version.cmake
@@ -46,7 +46,7 @@ option(GPLATES_BUILD_GPLATES "True to build GPlates (false to build pyGPlates)."
 #   2.6.0
 #   2.6.1
 #
-set(GPLATES_SEMANTIC_VERSION 2.6.0-7)
+set(GPLATES_SEMANTIC_VERSION 2.6.0-8)
 
 
 #
@@ -77,7 +77,7 @@ set(GPLATES_SEMANTIC_VERSION 2.6.0-7)
 #   1.0.0
 #   1.0.1
 #
-set(PYGPLATES_PEP440_VERSION 1.1.0.dev7)
+set(PYGPLATES_PEP440_VERSION 1.1.0.dev8)
 
 
 ##################

--- a/src/gplates_main.cc
+++ b/src/gplates_main.cc
@@ -994,6 +994,17 @@ internal_main(int argc, char* argv[])
 int
 main(int argc, char* argv[])
 {
+	// Log any exception that reaches 'std::terminate' before the process aborts.
+	//
+	// This complements 'call_main()' below (and 'GPlatesQApplication::notify()'), which can only
+	// catch exceptions that actually unwind the stack. An exception thrown from a destructor, or
+	// from any 'noexcept' function, invokes 'std::terminate' directly - so no handler, including
+	// the one below, ever gets a chance to see it.
+	//
+	// We do this here (rather than in 'internal_main()') so that it also covers the non-GUI
+	// command-line paths and the period before QApplication exists.
+	GPlatesGui::GPlatesQApplication::install_terminate_handler();
+
 	// The first of two reasons to wrap 'main()' around 'internal_main()' is to
 	// handle any uncaught exceptions that occur in main() but outside the Qt event thread.
 	// Any uncaught exceptions occurring in the Qt event thread will get caught by the

--- a/src/gui/GPlatesQApplication.cc
+++ b/src/gui/GPlatesQApplication.cc
@@ -23,6 +23,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <cstdlib>
+#include <exception>
 #include <string>
 #include <sstream>
 #include <boost/bind/bind.hpp>
@@ -52,38 +54,31 @@
 namespace
 {
 	/**
-	 * Call function @a func and process any uncaught exceptions.
+	 * Report the exception that is *currently being handled*.
+	 *
+	 * NOTE: This must be called from inside a catch block (it uses a bare 'throw;' to re-dispatch on
+	 * the exception's dynamic type). That includes being called from a 'std::terminate' handler,
+	 * provided the in-flight exception has first been re-thrown into a catch block there.
+	 *
+	 * Pops up a dialog informing the user of the uncaught exception (only if @a qreceiver and
+	 * @a qevent are both non-NULL), records the exception's call stack trace from the location at
+	 * which it was thrown and logs this information with the currently installed Qt message handler.
+	 *
+	 * Does not return - ends by calling 'qFatal()'.
 	 */
-	template <typename ReturnType>
-	ReturnType
-	try_catch(
-			boost::function<ReturnType ()> func,
+	void
+	report_uncaught_exception(
 			QObject *qreceiver,
 			QEvent *qevent)
 	{
-#if !defined(GPLATES_DEBUG)
 		std::string error_message_std;
 		std::string call_stack_trace_std;
-#endif
 
 		try
 		{
-			return func();
+			// Re-throw the exception currently being handled so that we can determine its type.
+			throw;
 		}
-		catch (GPlatesGlobal::NeedExitException &ex)
-		{
-			std::ostringstream os;
-			os << ex;
-			qDebug() << os.str().c_str();
-			//use exception to exit gplates is better than call exit(0) directly.
-			return true;
-		}
-		// For debug builds we don't want to catch exceptions (except 'NeedExitException')
-		// because if we do then we lose the debugger call stack trace which is
-		// much more detailed than our own stack trace implementation that
-		// currently requires placing TRACK_CALL_STACK macros around the code.
-		// And, of course, debugging relies on the native debugger stack trace.
-#if !defined(GPLATES_DEBUG)
 		catch (GPlatesGlobal::Exception &exc)
 		{
 			// Get exception to write its message.
@@ -102,10 +97,6 @@ namespace
 		{
 			error_message_std = "unknown exception";
 		}
-
-		//
-		// If we get here then we caught an exception
-		//
 
 		QStringList error_message_stream;
 		if (qreceiver && qevent)
@@ -163,9 +154,45 @@ namespace
 		// This is where the core dump or debugger trigger happens on debug builds.
 		// On release builds this exits the application with a return value of 1.
 		qFatal("Exiting due to exception caught");
+	}
 
-		// Shouldn't get past qFatal - this just keeps compiler happy.
-		return false;
+
+	/**
+	 * Call function @a func and process any uncaught exceptions.
+	 */
+	template <typename ReturnType>
+	ReturnType
+	try_catch(
+			boost::function<ReturnType ()> func,
+			QObject *qreceiver,
+			QEvent *qevent)
+	{
+		try
+		{
+			return func();
+		}
+		catch (GPlatesGlobal::NeedExitException &ex)
+		{
+			std::ostringstream os;
+			os << ex;
+			qDebug() << os.str().c_str();
+			//use exception to exit gplates is better than call exit(0) directly.
+			return true;
+		}
+		// For debug builds we don't want to catch exceptions (except 'NeedExitException')
+		// because if we do then we lose the debugger call stack trace which is
+		// much more detailed than our own stack trace implementation that
+		// currently requires placing TRACK_CALL_STACK macros around the code.
+		// And, of course, debugging relies on the native debugger stack trace.
+#if !defined(GPLATES_DEBUG)
+		catch (...)
+		{
+			report_uncaught_exception(qreceiver, qevent);
+
+			// Shouldn't get past 'report_uncaught_exception' (it calls qFatal) - this just keeps
+			// the compiler happy.
+			return false;
+		}
 #endif // if !defined(GPLATES_DEBUG)
 	}
 
@@ -234,6 +261,46 @@ GPlatesGui::GPlatesQApplication::call_main(
 		boost::bind(main_function, argc, argv),
 		NULL/*qreceiver*/,
 		NULL/*qevent*/);
+}
+
+
+void
+GPlatesGui::GPlatesQApplication::install_terminate_handler()
+{
+	std::set_terminate(
+			[]()
+			{
+				// Guard against re-entering this handler (which would recurse indefinitely) if the
+				// reporting below happens to throw.
+				std::set_terminate(std::abort);
+
+				if (std::current_exception())
+				{
+					try
+					{
+						// Re-throw so that 'report_uncaught_exception()' has an exception to report on.
+						std::rethrow_exception(std::current_exception());
+					}
+					catch (...)
+					{
+						// Note: No dialog (ie, NULL qreceiver/qevent). Unlike the 'try_catch()' paths,
+						// no stack unwinding has taken place, the exception is still in flight and we
+						// may not even be on the Qt event thread - so popping up a modal QMessageBox
+						// here is not safe.
+						report_uncaught_exception(NULL/*qreceiver*/, NULL/*qevent*/);
+					}
+				}
+				else
+				{
+					// If we have an installed message handler then this will output to a log file.
+					qWarning() << "GPlates is terminating, with no active exception.";
+				}
+
+				// A terminate handler must not return to its caller.
+				// Note that 'qFatal()' (called by 'report_uncaught_exception()') is not marked
+				// '[[noreturn]]', so we cannot rely on it to end the process.
+				std::abort();
+			});
 }
 
 

--- a/src/gui/GPlatesQApplication.h
+++ b/src/gui/GPlatesQApplication.h
@@ -66,6 +66,27 @@ namespace GPlatesGui
 				int argc,
 				char* argv[]);
 
+		/**
+		 * Installs a @a std::terminate handler that logs the in-flight exception before aborting.
+		 *
+		 * This is the counterpart to @a call_main and @a notify for exceptions that those two
+		 * cannot catch. An exception thrown from a destructor, or from any function that is
+		 * (explicitly or implicitly) 'noexcept', invokes 'std::terminate' *immediately* - the stack
+		 * is never unwound and no handler is ever searched for. Without this, such a failure shows
+		 * up as a bare OS crash with an empty log, and adding a try/catch around the offending code
+		 * makes no difference at all.
+		 *
+		 * The handler logs the exception type, message and (for GPlatesGlobal::Exception) its call
+		 * stack trace with the currently installed Qt message handler, then aborts. It does not pop
+		 * up a dialog, since no unwinding has taken place and we may not be on the Qt event thread.
+		 *
+		 * Note: Install this as early as possible in 'main()'. Anything logged before the Qt message
+		 * handler adds its log file handler goes to stderr only.
+		 */
+		static
+		void
+		install_terminate_handler();
+
 	protected:
 
 		virtual

--- a/src/scribe/ScribeBool.cc
+++ b/src/scribe/ScribeBool.cc
@@ -17,15 +17,27 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <QDebug>
+
 #include "ScribeBool.h"
 
 #include "ScribeExceptions.h"
+#include "ScribeInternalUtils.h"
 
 #include "global/GPlatesAssert.h"
 
 
 namespace GPlatesScribe
 {
+	/**
+	 * Custom boost::shared_ptr deleter that carries the shared "has this result been checked?" state.
+	 *
+	 * NOTE: This deleter must not throw. It is called from
+	 * 'boost::detail::shared_count::~shared_count()' which, being a destructor declared without an
+	 * exception-specification, is implicitly 'noexcept(true)' (see [class.dtor]/3) - so any exception
+	 * thrown here would call 'std::terminate' without unwinding the stack (no handler could catch it
+	 * and nothing would be logged). The unchecked-result check is therefore done in '~Bool()' instead.
+	 */
 	struct Bool::CheckDeleter
 	{
 		explicit
@@ -41,43 +53,6 @@ namespace GPlatesScribe
 		operator()(
 				bool *bool_ptr)
 		{
-			if (require_check)
-			{
-				// Track the file/line of the call site for exception messages.
-				// This is the file/line at which a transcribe call was made which, in turn,
-				// returned a 'Bool'.
-				GPlatesUtils::CallStackTracker call_stack_tracker(transcribe_source);
-
-				// We shouldn't be throwing any exceptions in deleter, but this exception is to
-				// force programmer to correct the program to check validity.
-				//
-				// We can get double exceptions if an exception came from outside - then the program will
-				// just terminate with no exception information if we throw a second exception below.
-				// But this is unlikely because the programmer should be checking the return result
-				// straight after transcribing an object - and that should provide no window of
-				// opportunity for double exceptions to get thrown (outside exception and our
-				// has-been-checked exception).
-
-
-				// Throw exception if the boolean result 'Bool' returned by 'Scribe::transcribe()',
-				// or 'transcribe_base()', has not been checked by the caller (in the *load* path).
-				//
-				// If this assertion is triggered then it means:
-				//   * A Scribe client has called 'Scribe::transcribe()', or a similar call,
-				//     but has not checked the boolean result 'Bool'.
-				//
-				// To fix this do something like:
-				//
-				//	if (!scribe.transcribe(...))
-				//	{
-				//		return scribe.get_transcribe_result();
-				//	}
-				//
-				GPlatesGlobal::Assert<Exceptions::ScribeTranscribeResultNotChecked>(
-						has_been_checked,
-						GPLATES_ASSERTION_SOURCE);
-			}
-
 			boost::checked_delete(bool_ptr);
 		}
 
@@ -94,6 +69,60 @@ GPlatesScribe::Bool::Bool(
 		bool require_check) :
 	d_bool(new bool(result), CheckDeleter(transcribe_source, require_check))
 {
+}
+
+
+GPlatesScribe::Bool::~Bool() noexcept(false)
+{
+	CheckDeleter *const check_deleter = boost::get_deleter<CheckDeleter>(d_bool);
+
+	if (check_deleter == NULL ||
+		!check_deleter->require_check ||
+		check_deleter->has_been_checked)
+	{
+		return;
+	}
+
+	// Only the *last* 'Bool' referencing this result gets to complain. The result is allowed to be
+	// checked via any copy, so the verdict is only final once no other copy could still check it.
+	if (d_bool.use_count() > 1)
+	{
+		return;
+	}
+
+	// Track the file/line of the call site for exception messages.
+	// This is the file/line at which a transcribe call was made which, in turn, returned a 'Bool'.
+	GPlatesUtils::CallStackTracker call_stack_tracker(check_deleter->transcribe_source);
+
+	// If an exception is already propagating then throwing here would call 'std::terminate' and
+	// destroy the information carried by that (more interesting) exception. So just log instead.
+	//
+	// This should be rare, since the programmer should be checking the return result straight after
+	// transcribing an object - which leaves no real window for an outside exception to arrive first.
+	if (InternalUtils::is_unwinding())
+	{
+		qWarning() << "Incorrect Scribe usage: the return result of a transcribe call was not "
+				"checked (not throwing, since an exception is already propagating).";
+		return;
+	}
+
+	// Throw exception if the boolean result 'Bool' returned by 'Scribe::transcribe()',
+	// or 'transcribe_base()', has not been checked by the caller (in the *load* path).
+	//
+	// If this assertion is triggered then it means:
+	//   * A Scribe client has called 'Scribe::transcribe()', or a similar call,
+	//     but has not checked the boolean result 'Bool'.
+	//
+	// To fix this do something like:
+	//
+	//	if (!scribe.transcribe(...))
+	//	{
+	//		return scribe.get_transcribe_result();
+	//	}
+	//
+	GPlatesGlobal::Assert<Exceptions::ScribeTranscribeResultNotChecked>(
+			false,
+			GPLATES_ASSERTION_SOURCE);
 }
 
 

--- a/src/scribe/ScribeBool.h
+++ b/src/scribe/ScribeBool.h
@@ -65,6 +65,25 @@ namespace GPlatesScribe
 	public:
 
 		/**
+		 * Throws Exceptions::ScribeTranscribeResultNotChecked if the boolean result was never
+		 * checked by the client (and this is the last 'Bool' referencing that result).
+		 *
+		 * NOTE: This destructor is explicitly 'noexcept(false)' because, since C++11, destructors
+		 * are implicitly 'noexcept(true)' - and an exception escaping a 'noexcept' destructor calls
+		 * 'std::terminate' immediately, without unwinding the stack. That means no handler anywhere
+		 * can catch it and nothing gets logged, which would defeat the entire purpose of this check.
+		 *
+		 * This is also why the check is done here rather than in 'CheckDeleter' (where it used to be):
+		 * the deleter is called from 'boost::detail::shared_count::~shared_count()', which is declared
+		 * without an exception-specification and hence is *also* implicitly 'noexcept(true)'
+		 * (see [class.dtor]/3). So an exception thrown by the deleter terminates inside Boost, before
+		 * it ever reaches this class. Marking this destructor 'noexcept(false)' only helps if the
+		 * throw actually originates here.
+		 */
+		~Bool() noexcept(false);
+
+
+		/**
 		 * Boolean test - don't use directly.
 		 *
 		 * Instead use (for example):

--- a/src/scribe/ScribeInternalUtils.h
+++ b/src/scribe/ScribeInternalUtils.h
@@ -26,6 +26,7 @@
 #ifndef GPLATES_SCRIBE_SCRIBEINTERNALUTILS_H
 #define GPLATES_SCRIBE_SCRIBEINTERNALUTILS_H
 
+#include <exception>
 #include <functional>
 #include <typeinfo>
 #include <utility>
@@ -55,6 +56,30 @@ namespace GPlatesScribe
 	{
 		//! Typedef for an integer identifier for a transcribed object.
 		typedef TranscriptionScribeContext::object_id_type object_id_type;
+
+
+		/**
+		 * Returns true if an exception is currently propagating (ie, the stack is being unwound).
+		 *
+		 * This is used by the destructors that report an unchecked transcribe result (see
+		 * 'Bool' and 'LoadRef<>') to avoid throwing while another exception is already in flight.
+		 * Throwing a second exception during unwinding calls 'std::terminate' and would therefore
+		 * destroy the very diagnostic information those destructors exist to provide - and, worse,
+		 * would hide the original exception (which is the more interesting one).
+		 */
+		inline
+		bool
+		is_unwinding()
+		{
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411
+			return std::uncaught_exceptions() > 0;
+#else
+			// 'std::uncaught_exceptions()' is C++17 and GPlates currently targets C++14
+			// (see 'CXX_STANDARD 14' in 'src/CMakeLists.txt'), so fall back to the C++11
+			// singular form (which is deprecated in C++17 and removed in C++20).
+			return std::uncaught_exception();
+#endif
+		}
 
 
 		/**

--- a/src/scribe/ScribeLoadRef.h
+++ b/src/scribe/ScribeLoadRef.h
@@ -66,6 +66,25 @@ namespace GPlatesScribe
 
 
 		/**
+		 * Throws Exceptions::ScribeTranscribeResultNotChecked if @a is_valid was never called
+		 * (and this is the last 'LoadRef' referencing the object).
+		 *
+		 * NOTE: This destructor is explicitly 'noexcept(false)' because, since C++11, destructors
+		 * are implicitly 'noexcept(true)' - and an exception escaping a 'noexcept' destructor calls
+		 * 'std::terminate' immediately, without unwinding the stack. That means no handler anywhere
+		 * can catch it and nothing gets logged, which would defeat the entire purpose of this check.
+		 *
+		 * This is also why the check is done here rather than in 'TrackingDeleter' (where it used to
+		 * be): the deleter is called from 'boost::detail::shared_count::~shared_count()', which is
+		 * declared without an exception-specification and hence is *also* implicitly 'noexcept(true)'
+		 * (see [class.dtor]/3). So an exception thrown by the deleter terminates inside Boost, before
+		 * it ever reaches this class. Marking this destructor 'noexcept(false)' only helps if the
+		 * throw actually originates here.
+		 */
+		~LoadRef() noexcept(false);
+
+
+		/**
 		 * Return whether this reference is valid to be dereferenced, or whether it's a NULL reference.
 		 *
 		 * To use:

--- a/src/scribe/ScribeLoadRefImpl.h
+++ b/src/scribe/ScribeLoadRefImpl.h
@@ -27,6 +27,7 @@
 #define GPLATES_SCRIBE_SCRIBELOADREFIMPL_H
 
 #include <boost/checked_delete.hpp>
+#include <QDebug>
 
 #include "Scribe.h"
 #include "ScribeExceptions.h"
@@ -66,38 +67,12 @@ namespace GPlatesScribe
 			// This is the file/line at which a load call was made which, in turn, returned a 'LoadRef<>'.
 			GPlatesUtils::CallStackTracker call_stack_tracker(transcribe_source);
 
-			// If we've already thrown an exception then don't throw another one.
-			//
-			// We shouldn't be throwing any exceptions in deleter anyway, but this exception is to
-			// force programmer to correct the program to check validity.
-			//
-			// NOTE: We can only detect exceptions we've thrown (eg, in 'LoadRef<>::get()').
-			// So we can only prevent double exceptions in that case.
-			// If an exception came from outside then the program will terminate with no exception
-			// information if we throw a second exception below.
-			// But this is unlikely because the programmer should be calling 'LoadRef<>::is_valid()'
-			// straight after getting a 'LoadRef<>' instance - and that should provide no window of
-			// opportunity for double exceptions to get thrown (outside exception and our is-valid exception).
-			if (!exception_thrown)
-			{
-				// Throw exception if 'LoadRef<>::is_valid()' has not been checked by the caller.
-				//
-				// If this assertion is triggered then it means:
-				//   * A Scribe client has called 'Scribe::load()', or 'Scribe::load_reference()',
-				//     but has not checked 'LoadRef<>::is_valid()' on the returned LoadRef.
-				//
-				// To fix this do something like:
-				//
-				//	GPlatesScribe::LoadRef<X> x = scribe.load<X>(TRANSCRIBE_SOURCE, "x");
-				//	if (!x.is_valid())
-				//	{
-				//		return scribe.get_transcribe_result();
-				//	}
-				//
-				GPlatesGlobal::Assert<Exceptions::ScribeTranscribeResultNotChecked>(
-						is_valid_called,
-						GPLATES_ASSERTION_SOURCE);
-			}
+			// NOTE: The 'is_valid()-was-not-called' check is *not* done here - it's done in
+			// '~LoadRef()' instead. This deleter is called from
+			// 'boost::detail::shared_count::~shared_count()' which, being a destructor declared
+			// without an exception-specification, is implicitly 'noexcept(true)'
+			// (see [class.dtor]/3) - so any exception thrown here would call 'std::terminate'
+			// without unwinding the stack (no handler could catch it and nothing would be logged).
 
 			// Release the object if we are not referencing an existing object but instead own
 			// the object we are referencing.
@@ -140,6 +115,75 @@ namespace GPlatesScribe
 		bool release; //!< Whether to delete the object or not.
 		bool exception_thrown; //!< Avoid throwing exception in LoadRef<>::get() and subsequently in ~LoadRef<>().
 	};
+
+
+	template <typename ObjectType>
+	LoadRef<ObjectType>::~LoadRef() noexcept(false)
+	{
+		if (!d_object)
+		{
+			return;
+		}
+
+		TrackingDeleter *const tracking_deleter = boost::get_deleter<TrackingDeleter>(d_object);
+
+		if (tracking_deleter == NULL ||
+			tracking_deleter->is_valid_called)
+		{
+			return;
+		}
+
+		// If 'LoadRef<>::get()' has already thrown this same exception then don't throw another one.
+		// Note that this covers the case where that exception was *caught* (and hence we are no
+		// longer unwinding), which the 'is_unwinding()' test below would not detect.
+		if (tracking_deleter->exception_thrown)
+		{
+			return;
+		}
+
+		// Only the *last* 'LoadRef' referencing the object gets to complain. The object is allowed
+		// to be checked via any copy, so the verdict is only final once no other copy could still
+		// call 'is_valid()'.
+		if (d_object.use_count() > 1)
+		{
+			return;
+		}
+
+		// Track the file/line of the call site for exception messages.
+		// This is the file/line at which a load call was made which, in turn, returned a 'LoadRef<>'.
+		GPlatesUtils::CallStackTracker call_stack_tracker(tracking_deleter->transcribe_source);
+
+		// If an exception is already propagating then throwing here would call 'std::terminate' and
+		// destroy the information carried by that (more interesting) exception. So just log instead.
+		//
+		// This should be rare, since the programmer should be calling 'LoadRef<>::is_valid()' straight
+		// after getting a 'LoadRef<>' instance - which leaves no real window for an outside exception
+		// to arrive first.
+		if (InternalUtils::is_unwinding())
+		{
+			qWarning() << "Incorrect Scribe usage: 'LoadRef<>::is_valid()' was not called "
+					"(not throwing, since an exception is already propagating).";
+			return;
+		}
+
+		// Throw exception if 'LoadRef<>::is_valid()' has not been checked by the caller.
+		//
+		// If this assertion is triggered then it means:
+		//   * A Scribe client has called 'Scribe::load()', or 'Scribe::load_reference()',
+		//     but has not checked 'LoadRef<>::is_valid()' on the returned LoadRef.
+		//
+		// To fix this do something like:
+		//
+		//	GPlatesScribe::LoadRef<X> x = scribe.load<X>(TRANSCRIBE_SOURCE, "x");
+		//	if (!x.is_valid())
+		//	{
+		//		return scribe.get_transcribe_result();
+		//	}
+		//
+		GPlatesGlobal::Assert<Exceptions::ScribeTranscribeResultNotChecked>(
+				false,
+				GPLATES_ASSERTION_SOURCE);
+	}
 
 
 	template <typename ObjectType>
@@ -210,8 +254,8 @@ namespace GPlatesScribe
 			// This is the file/line at which a load call was made which, in turn, returned a 'LoadRef<>'.
 			GPlatesUtils::CallStackTracker call_stack_tracker(tracking_deleter->transcribe_source);
 
-			// Tell deleter not to also throw when the exception below unwinds the call stack
-			// and triggers deleter.
+			// Tell '~LoadRef()' not to also throw when the exception below unwinds the call stack
+			// (or, if it gets caught, when this 'LoadRef' is subsequently destroyed).
 			tracking_deleter->exception_thrown = true;
 
 			GPlatesGlobal::Assert<Exceptions::ScribeTranscribeResultNotChecked>(


### PR DESCRIPTION
Closes #41.

An exception thrown from a destructor, or from any explicitly or implicitly `noexcept` function, invokes `std::terminate` immediately — the stack is never unwound and no handler is ever searched for. The result is a bare OS crash and a log file that just stops.

Scribe's "transcribe result not checked" diagnostic hit this. `Exceptions::ScribeTranscribeResultNotChecked` was thrown from inside a `boost::shared_ptr` deleter (`Bool::CheckDeleter` and `LoadRef<>::TrackingDeleter`), and those deleters are called from `boost::detail::shared_count::~shared_count()` — a destructor declared without an exception-specification, and hence implicitly `noexcept(true)` per [class.dtor]/3. So the exception terminated inside Boost, before it could reach any GPlates code.

Both checks move out of the deleters and into user-declared destructors marked `noexcept(false)`. The deleters keep the shared "has this been checked?" state and their cleanup work; only the throw moves. Since the result may be checked via any copy, only the last owner performs the check, and the check is skipped while another exception is already propagating. The exception now unwinds normally, so it reaches the existing `GPlatesScribe::Exceptions::BaseException` handler in `FileIOFeedback` (error dialog plus full message and call stack trace in the log), and in pyGPlates it is translated to a Python exception instead of killing the interpreter.

Separately, `GPlatesQApplication::install_terminate_handler()` is added as the counterpart to `call_main()` and called from `main()`, as the general backstop for any other throw that cannot unwind. It re-throws `std::current_exception()` into a catch block so the existing reporting can identify it, then aborts. That reporting is factored out of the anonymous-namespace `try_catch<>()` into `report_uncaught_exception()` so the two paths share one implementation.

## Verification

Checked with **temporary scratch code** driving four cases from `internal_main()`, run against a Release build before and after the change. The scratch code was removed and is not part of this PR — nothing was added to `gplates-unit-test`.

| case | before | after |
|---|---|---|
| unchecked `Bool` result | `0xC0000409` abort, log stops, nothing on stderr, no dialog | exception type, message, call-site file/line and version all reported |
| unchecked `LoadRef` (`is_valid()` never called) | same silent abort | same, reported |
| `LoadRef<>::get()` throws and the caller catches it | — | exactly one exception, no spurious second throw from the destructor; exit 0 |
| throw from a genuinely `noexcept` destructor | silent abort | reported by the terminate handler, and it reaches `GPlates_log.txt` |

Regression checks: 439/439 pyGPlates tests pass; `gplates-unit-test` results are identical to a baseline build with these changes stashed (12 failed assertions of 1496 across the same 3 test cases — all pre-existing, from missing `unit-test-data/*.gpml.gz`); GPlates starts up clean with no new log warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)