### PR TITLE
Cache compiled objects in CI with sccache

### DIFF
--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -58,9 +58,10 @@ jobs:
       # Kept inside the workspace because the 'runner' context (and so 'runner.temp') is not available
       # in a job-level 'env' block, only from the step level onwards.
       SCCACHE_DIR: ${{ github.workspace }}/.sccache
-      # Bounded deliberately. The whole repository shares a 10 GB GitHub Actions cache budget with
-      # LRU eviction, so three unbounded caches of Boost.Python object files would evict the caches
-      # belonging to the wheel and installer workflows added later.
+      # A safety ceiling rather than an expected size: a full build measures 38 MiB on macOS, 67 MiB
+      # on Linux and 114 MiB on Windows, so this only binds if a build grows by an order of
+      # magnitude. It matters because the whole repository shares a 10 GB Actions cache budget with
+      # LRU eviction, and the wheel and installer workflows will want their share of it.
       SCCACHE_CACHE_SIZE: 2G
       # Never let the server time out mid-build.
       SCCACHE_IDLE_TIMEOUT: 0
@@ -136,9 +137,7 @@ jobs:
         # branch and every other pull request cannot see it. Later runs of that same pull request can,
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
-        # That small gain is not worth another 6 GB generation against a 10 GB LRU-evicted budget
-        # shared with the wheel and installer workflows to come. Pushes to 'pygplates' warm the cache;
-        # pull requests restore from it.
+        # Pushes to 'pygplates' warm the cache; pull requests restore from it.
         # 'always()' so that a failed build still saves the objects it did compile.
         if: always() && github.event_name == 'push'
         uses: actions/cache/save@v4

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -8,6 +8,10 @@
 # This uses the CMake build tree (rather than 'pip install .') because the tests are registered
 # with CTest there: 'pygplates-test' runs pygplates/test/test.py with PYTHONPATH pointing at the
 # build directory, and 'pygplates-stub-test' checks the generated .pyi stub is up to date.
+#
+# Compilation goes through 'sccache' so that a push only recompiles what actually changed. A full
+# build takes ~30-60 minutes depending on platform, and is essentially the entire cost of a run
+# (configure is seconds, the tests are seconds).
 name: pygplates build and test
 
 on:
@@ -50,6 +54,17 @@ jobs:
             # found" (see BUILD-Windows.md).
             shell: cmd /C call {0}
 
+    env:
+      # Kept inside the workspace because the 'runner' context (and so 'runner.temp') is not available
+      # in a job-level 'env' block, only from the step level onwards.
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      # Bounded deliberately. The whole repository shares a 10 GB GitHub Actions cache budget with
+      # LRU eviction, so three unbounded caches of Boost.Python object files would evict the caches
+      # belonging to the wheel and installer workflows added later.
+      SCCACHE_CACHE_SIZE: 2G
+      # Never let the server time out mid-build.
+      SCCACHE_IDLE_TIMEOUT: 0
+
     defaults:
       run:
         # Conda only activates in a login shell (bash) or an explicitly declared cmd shell.
@@ -60,6 +75,17 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Restore compiler cache
+        # 'restore-keys' is what makes this useful: the primary key includes the commit SHA and so
+        # never hits, and the prefix fallback restores the most recent cache for this platform.
+        # A pull request can read caches written on its base branch, so PRs start warm from the
+        # last push to 'pygplates'.
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: sccache-${{ matrix.name }}-
 
       - name: Install dependencies (conda)
         uses: conda-incubator/setup-miniconda@v3
@@ -73,14 +99,52 @@ jobs:
           # latest). Building every supported Python version belongs in the wheel-building
           # workflow, not here.
 
+      - name: Install sccache
+        # Deliberately not added to the env.*.yml files: those are the developer dependency manifest
+        # and this is a CI-only tool. sccache (rather than ccache) because it treats MSVC as a
+        # first-class target, so one configuration works unchanged on all three platforms.
+        run: conda install --yes sccache
+
       - name: Configure
         # No -DCMAKE_PREFIX_PATH or -DBoost_ROOT: the top-level CMakeLists.txt detects the active
         # conda environment from CONDA_PREFIX. The configure output should report
         # "Detected active conda environment ..." - if it does not, activation above has failed.
-        run: cmake -S . -B build-pygplates -G Ninja -DCMAKE_BUILD_TYPE=Release -DGPLATES_BUILD_GPLATES=FALSE
+        #
+        # The compiler launchers are honoured by the Ninja and Makefile generators (all our
+        # documented builds use Ninja). Note this relies on GPLATES_USE_PRECOMPILED_HEADERS staying
+        # at its default of FALSE - sccache cannot cache translation units that use a precompiled
+        # header, so enabling PCH here would quietly gut the hit rate.
+        run: >
+          cmake -S . -B build-pygplates -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DGPLATES_BUILD_GPLATES=FALSE
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: cmake --build build-pygplates
+
+      - name: Compiler cache statistics
+        # Always reported, so the hit rate is visible in the log rather than assumed - it is the only
+        # way to tell whether the cache is earning its keep. Stopping the server flushes it to disk
+        # before the save step below.
+        if: always()
+        run: sccache --show-stats && sccache --stop-server
+
+      - name: Save compiler cache
+        # Only on push. A cache written by a pull request run is scoped to that pull request: the base
+        # branch and every other pull request cannot see it. Later runs of that same pull request can,
+        # but they gain little, because the base-branch cache already covers everything the pull
+        # request did not change - a re-run only recompiles the PR's own modified files either way.
+        # That small gain is not worth another 6 GB generation against a 10 GB LRU-evicted budget
+        # shared with the wheel and installer workflows to come. Pushes to 'pygplates' warm the cache;
+        # pull requests restore from it.
+        # 'always()' so that a failed build still saves the objects it did compile.
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-${{ matrix.name }}-${{ github.sha }}
 
       - name: Test
         # '-C Release' is required: the tests are registered with 'CONFIGURATIONS Release MinSizeRel',


### PR DESCRIPTION
Follow-up to #44. Compilation is essentially the entire cost of a CI run, so this routes it through `sccache` and carries the cache between runs.

Measured from run 31260191626 (the #44 PR run), all three green:

| Platform | conda env | Configure | Build | Test | Job total |
|---|---|---|---|---|---|
| Linux | 44 s | 3 s | **56 min** | 4.7 s | 57 min |
| macOS | 64 s | 10 s | **28 min** | 6.9 s | 30 min |
| Windows | 4 min | 25 s | **63 min** | 7.0 s | 69 min |

## Choices

**sccache rather than ccache** — it treats MSVC as a first-class target, so one configuration works unchanged on all three platforms instead of needing a Windows-specific branch in the matrix.

**Installed via conda, but not in `env.*.yml`** — those files are the developer dependency manifest documented in `BUILD-*.md`, and this is a CI-only tool.

**Saved only on `push`** — a cache written by a pull request run is scoped to that pull request; the base branch and other pull requests cannot see it. Later runs of the same pull request can, but gain little, since the base-branch cache already covers everything the pull request did not change — a re-run recompiles the pull request's own modified files either way. Pushes to `pygplates` warm the cache; pull requests restore from it.

**`SCCACHE_CACHE_SIZE` capped at 2G** — a safety ceiling, not an expected size (see measurements below). It matters only because the repository shares a 10 GB Actions cache budget with LRU eviction, which the wheel and installer workflows will also want.

**`restore-keys` prefix fallback** — the primary key contains the commit SHA and so never hits; the fallback is what actually restores.

## Results from this PR's run (31264002838)

Green on all three platforms, 2/2 CTest tests passing everywhere.

| Platform | Compile requests | Cache errors | Non-cacheable | Cache written | Avg compile |
|---|---|---|---|---|---|
| macOS | 971 | 0 | 0 | 38 MiB | 6.9 s |
| Linux | 971 | 0 | 0 | 67 MiB | 15.1 s |
| Windows | 971 | 0 | 0 | 114 MiB | 20.4 s |

The hit rate is 0%, by design rather than by failure: no cache existed yet, and this run does not write one because saving is push-only.

The columns that matter are the two zeros. **0 cache errors** shows the cache directory, server and save path all work under the real runner environment, including the Windows `cmd` shell. **0 non-cacheable compilations**, with 971 of 971 requests intercepted, confirms empirically that no translation unit bypassed sccache — had `GPLATES_USE_PRECOMPILED_HEADERS` been on, this would read 971 non-cacheable and the feature would be inert while still reporting success.

Real hit-rate evidence arrives from the first two pushes to `pygplates` after this merges: the first warms the cache, the second should show a much shorter Build step.

### Correction: cache sizes are far smaller than estimated

The comments in the first commit justified the 2G cap and the push-only policy partly by an estimated **~6 GB** per generation across three platforms. The measured total is **~219 MiB** — smaller by a factor of about 28 (a Release build carries no debug info, and object files compress well).

The final commit here is comment-only and corrects that: the budget-exhaustion argument is removed from the save step, which now rests solely on the marginal-benefit argument above, and the 2G cap is described as the safety ceiling it actually is. Practical consequences: the cap sits ~18x above what a full build produces and will never bind, and the 10 GB budget comfortably holds tens of push-generations plus the wheel and installer caches to come.

**Left open deliberately:** with the budget objection gone, whether pull requests should save too is worth revisiting. A pull request touching a widely-included header currently recompiles hundreds of files on *every* push to it; against that, CI-only pull requests like #44 and this one would gain nothing. Better decided on evidence from a real source-touching pull request than guessed at up front.

## Verified locally

On Windows (MSVC 19.44, Ninja, conda `gplates` env), against the real project flags:

- `LAUNCHER = sccache` is present in the generated `build.ninja`.
- Compiling two objects cold: 2 requests, **2 misses**.
- Deleting those objects and recompiling: **2 hits**, 0 non-cacheable compilations, 0 cache errors.
- `GPLATES_USE_PRECOMPILED_HEADERS` defaults to `FALSE` and is not enabled here, so there is no PCH/sccache conflict — noted in a comment, since turning PCH on would quietly gut the hit rate.
- `<prefix>\bin`, where conda places `sccache.exe`, is on `PATH` after activation on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
