### PR TITLE
Retire the last pre-conda MacPorts text

### DIFF
--- a/cmake/modules/FindPROJ.cmake
+++ b/cmake/modules/FindPROJ.cmake
@@ -102,7 +102,7 @@ endif()
 
 #
 # Proj does not have a CONFIG package (at least not all platforms were installed as a CMake package) but more recent versions should.
-# Note that Proj 4.9 is still used by Ubuntu Bionic (18.04).
+# Note that our minimum supported Ubuntu release (Jammy 22.04) ships Proj via apt without a CMake CONFIG package.
 #
 
 if (PROJ_VERBOSE)
@@ -111,65 +111,17 @@ endif()
 
 # Find the PROJ header location.
 find_path(PROJ_INCLUDE_DIR
-  NAMES proj.h proj_api.h
-  PATHS
-    # Macports stores Proj in locations that are difficult for CMake to find without some help
-    # (even when the /opt/local/ prefix is used, eg, via CMAKE_PREFIX_PATH or via the PATH environment variable)...
-    /opt/local/lib/proj9/include
-    /opt/local/lib/proj8/include
-    /opt/local/lib/proj7/include
-    /opt/local/lib/proj6/include
-    /opt/local/lib/proj5/include
-    /opt/local/lib/proj49/include
-    # Homebrew...
-    /usr/local/opt/proj9/include
-    /usr/local/opt/proj8/include
-    /usr/local/opt/proj7/include
-    /usr/local/opt/proj6/include
-    /usr/local/opt/proj5/include
-    /usr/local/opt/proj49/include)
+  NAMES proj.h proj_api.h)
 
 # Find the PROJ library.
 find_library(PROJ_LIBRARY
   NAMES proj proj_i
-  NAMES_PER_DIR
-  PATHS
-    # Macports stores Proj in locations that are difficult for CMake to find without some help
-    # (even when the /opt/local/ prefix is used, eg, via CMAKE_PREFIX_PATH or via the PATH environment variable)...
-    /opt/local/lib/proj9/lib
-    /opt/local/lib/proj8/lib
-    /opt/local/lib/proj7/lib
-    /opt/local/lib/proj6/lib
-    /opt/local/lib/proj5/lib
-    /opt/local/lib/proj49/lib
-    # Homebrew...
-    /usr/local/opt/proj9/lib
-    /usr/local/opt/proj8/lib
-    /usr/local/opt/proj7/lib
-    /usr/local/opt/proj6/lib
-    /usr/local/opt/proj5/lib
-    /usr/local/opt/proj49/lib)
+  NAMES_PER_DIR)
 
 # Find the 'proj' executable.
 find_program(PROJ_EXE
     NAMES proj
-    NAMES_PER_DIR
-    PATHS
-        # Macports stores Proj in locations that are difficult for CMake to find without some help
-        # (even when the /opt/local/ prefix is used, eg, via CMAKE_PREFIX_PATH or via the PATH environment variable)...
-        /opt/local/lib/proj9/bin
-        /opt/local/lib/proj8/bin
-        /opt/local/lib/proj7/bin
-        /opt/local/lib/proj6/bin
-        /opt/local/lib/proj5/bin
-        /opt/local/lib/proj49/bin
-        # Homebrew...
-        /usr/local/opt/proj9/bin
-        /usr/local/opt/proj8/bin
-        /usr/local/opt/proj7/bin
-        /usr/local/opt/proj6/bin
-        /usr/local/opt/proj5/bin
-        /usr/local/opt/proj49/bin)
+    NAMES_PER_DIR)
 
 # Make sure we found the PROJ include header location and library.
 find_package_handle_standard_args(PROJ REQUIRED_VARS PROJ_LIBRARY PROJ_INCLUDE_DIR PROJ_EXE)

--- a/cmake/modules/FindQwt.cmake
+++ b/cmake/modules/FindQwt.cmake
@@ -21,18 +21,10 @@ find_path(QWT_INCLUDE_DIR
   PATHS
   /usr/include
   /usr/local/include
-  /opt/local/include
   /usr/local/opt/qwt/include
   /usr/local/opt/qwt/lib  # CMake can find 'A/b.h' as 'A.framework/Headers/b.h'
-  # With Macports, Qwt is typically installed into Qt5 (using "sudo port install qwt-qt5"):
-  # If there's a 'qwt' sym-link in this 'include' directory
-  /opt/local/libexec/qt5/include  # Macports (if 'qwt' sym-links to '/opt/local/libexec/qt5/lib/qwt.framework/Headers')
-  /usr/local/opt/qt5/include  # Do same for Homebrew although unlikely (if 'qwt' sym-links to '/usr/local/opt/qt5/lib/qwt.framework/Headers')
-  # ...else explicitly specify directory containing framework (noting that CMake can find 'A/b.h' as 'A.framework/Headers/b.h')...
-  /opt/local/libexec/qt5/lib  # Macports ('/opt/local/libexec/qt5/lib/qwt.framework')
-  /usr/local/opt/qt5/lib  # Do same for Homebrew although unlikely ('/usr/local/opt/qt5/lib/qwt.framework')
   "$ENV{QWT_INCLUDE_DIR}"
-  "$ENV{INCLUDE}" 
+  "$ENV{INCLUDE}"
   # The '-qt5' versions searched first (in case 'qwt' is a qt4 version)...
   PATH_SUFFIXES qwt-qt5 qwt6-qt5 qwt qwt6
 )
@@ -46,11 +38,7 @@ find_library(QWT_LIBRARY
   PATHS
     /usr/lib
     /usr/local/lib
-    /opt/local/lib
     /usr/local/opt/qwt/lib
-    # On Macports Qwt is installed into Qt5 (using "sudo port install qwt-qt5")...
-    /opt/local/libexec/qt5/lib
-    /usr/local/opt/qt5/lib  # Do same for Homebrew although unlikely ('/usr/local/opt/qt5/lib/qwt.framework')
     "$ENV{QWT_LIB_DIR}"
 )
 

--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -106,16 +106,12 @@ elseif (APPLE)
     # This is done by setting the CMAKE_OSX_DEPLOYMENT_TARGET cache variable
     # (eg, using 'cmake -D CMAKE_OSX_DEPLOYMENT_TARGET:STRING="10.13", or setting manually inside 'ccmake' or 'cmake-gui').
     #
-    # Currently the minimum macOS version we support is macOS 10.13 because Qt5 currently supports 10.13+.
+    # Currently the minimum macOS version we support is macOS 11.0 (since Qt6 requires 11.0+, and
+    # M1/arm64 wasn't introduced until macOS 11.0 anyway).
     # Also, as of 10.9, Apple has removed support for libstdc++ (the default prior to 10.9) in favour of libc++ (C++11).
     #
-    # Note that if you do this then you'll also need the same deployment target set in your dependency libraries.
-    # For example, with Macports you can specify the following in your "/opt/local/etc/macports/macports.conf" file:
-    #   buildfromsource            always
-    #   macosx_deployment_target   10.13
-    # ...prior to installing the ports.
-    # This will also force all ports to have their source code compiled (not downloaded as binaries) which can be quite slow.
-    # For Apple M1 you can instead target 11.0 (since M1/arm64 wasn't introduced until macOS 11.0).
+    # Note that if you do this then you'll also need the same deployment target set in your dependency
+    # libraries (eg, Qt, Boost, PROJ, GDAL, CGAL).
     #
     # By default (when CMAKE_OSX_DEPLOYMENT_TARGET is not explicitly set) you are deploying to the macOS version of your build system (and above).
     # In this case you don't need to build your dependency libraries with a lower deployment target.

--- a/cmake/modules/TestPythonEmbedding.cmake
+++ b/cmake/modules/TestPythonEmbedding.cmake
@@ -19,8 +19,8 @@
 # interpreter. This example code is known to fail if the Python library that we
 # link against is different to the Python library used to build Boost.Python.
 # This problem manifests itself especially on macOS, where there is the
-# system version of Python and the version of Python installed by Macports, if
-# Boost is installed via Macports.
+# system version of Python and the version of Python installed by a package
+# manager (eg, conda), if Boost is installed by that same package manager.
 
 FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test_python_embedding.cc
 	"#include <boost/python.hpp>\n"
@@ -130,9 +130,8 @@ if (NOT CMAKE_CROSSCOMPILING)
 			"Check that the Python and Boost.Python libraries are in your system path."
 			"If you have multiple Python installations, make sure that the version of "
 			"Python that GPlates is being linked against is the same version of Python "
-			"that Boost.Python was built against. In particular, on macOS, if "
-			"Boost.Python was installed using MacPorts, provide the following CMake flag: "
-			"-DCMAKE_FRAMEWORK_PATH=/opt/local/Library/Frameworks")
+			"that Boost.Python was built against. In particular, make sure you have "
+			"activated the correct conda environment before configuring (see BUILD-macOS.md).")
 	ENDIF(PYTHON_EMBEDDING_RUNS EQUAL 1 OR PYTHON_EMBEDDING_RUNS STREQUAL FAILED_TO_RUN)
 endif()
 

--- a/doc-python-api/pygplates_getting_started.rst
+++ b/doc-python-api/pygplates_getting_started.rst
@@ -227,7 +227,7 @@ Now you can use pyGPlates. For example, to see the pyGPlates version:
   | The build scripts are more robust because they install the shared library dependencies into the wheel using ``auditwheel`` on Linux, ``delocate`` on macOS,
     and ``delvewheel`` on Windows. This generates *unique* shared library names to avoid potential conflicts with other installed Python packages that have
     the same dependencies as pyGPlates (eg, the GDAL dependency). This is in contrast to installing pyGPlates directly from source code (as described above), which does **not**
-    generate unique names because the dependency libraries (that you built above) are simply copied into the Python ``site-packages`` installation without renaming them.
+    generate unique names because the dependency libraries (that you installed above) are simply copied into the Python ``site-packages`` installation without renaming them.
 
 
 .. _pygplates_getting_started_troubleshooting:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,12 +161,9 @@ GPLATES_BUILD_GPLATES = "FALSE"
 # Note: The CMAKE_OSX_DEPLOYMENT_TARGET define is not actually used (by scikit-build-core) to determine the wheel tag.
 #       But CMake will use MACOSX_DEPLOYMENT_TARGET to set the default value for CMAKE_OSX_DEPLOYMENT_TARGET.
 #
-# Note: If you do this then you'll also need the same deployment target set in your dependency libraries.
-#       For example, with Macports you can specify the following in your "/opt/local/etc/macports/macports.conf" file:
-#           buildfromsource            always
-#           macosx_deployment_target   11.0
-#       ...prior to installing the ports.
-#       This will also force all ports to have their source code compiled (not downloaded as binaries) which can be quite slow.
+# Note: If you do this then you'll also need the same deployment target set in your dependency libraries
+#       (eg, Qt, Boost, PROJ, GDAL, CGAL). Building against binaries compiled for a newer macOS version
+#       than MACOSX_DEPLOYMENT_TARGET can result in linker warnings or runtime failures.
 #       For Apple Silicon, targeting 11.0 is sufficient (since M1/arm64 wasn't introduced until macOS 11.0).
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -302,8 +302,8 @@ find_package(Boost ${_GPLATES_MIN_BOOST_VERSION} REQUIRED
 			#         But for accessing the NumPy C API via Boost.Python.NumPy (which we don't do yet) it means
 			#         Boost.Python itself must be built against NumPy 2.0. And ensuring this is a bit more work.
 			#         For example, on Windows you'd need to make sure you install NumPy 2.0 into your Python versions
-			#         prior to building Boost from source code. And with MacPorts (on macOS) you'd need to ensure that
-			#         your 'py-numpy' port is updated (to 2.0).
+			#         prior to building Boost from source code. And on macOS/Linux you'd need to ensure that the
+			#         NumPy installed into your build environment (eg, conda) is updated (to 2.0).
 			#
 			#         So, since we're not yet using Boost.Python.NumPy we'll just disable it to avoid the possible runtime error:
 			#           "A module that was compiled using NumPy 1.x cannot be run in NumPy 2.0.0 as it may crash."


### PR DESCRIPTION
## Summary
- Removes the last stale MacPorts advice outside `pygplates/wheel/` (which the follow-up cibuildwheel PR will delete/rewrite): the `FATAL_ERROR` guidance in `TestPythonEmbedding.cmake`, the `macports.conf` recipes duplicated in `pyproject.toml` and `Package.cmake`, and the hardcoded MacPorts/Homebrew search paths in `FindQwt.cmake`/`FindPROJ.cmake`.
- Updates `Package.cmake`'s stale "macOS 10.13 because Qt5" rationale to macOS 11.0/Qt6 (matching the project's move to Qt6-only packages), and `FindPROJ.cmake`'s stale Ubuntu Bionic note (minimum is now Jammy 22.04).
- Fixes two smaller MacPorts references: the getting-started docs ("dependency libraries that you built above" → conda/apt install nothing to build) and a disabled Boost.Python.Numpy comment.

Remaining `MacPorts`/`Macports` hits after this PR are the deliberate framework-vs-non-framework-Python contrast comments (`Config_h.cmake`, `Install.cmake`, `PythonManager.cc`, `StandaloneBundle.*`, `InstallSharedLibraryDependencies.cmake`, `BUILD-macOS.md`) plus `pygplates/wheel/`, which is out of scope here.

## Test plan
- [x] `grep -rin macports --include=*.cmake --include=*.toml --include=*.rst` returns only the deliberate contrast comments
- [x] Configured pyGPlates against the `gplates` conda env (`cmake -G Ninja -DGPLATES_BUILD_GPLATES=FALSE`) — Qwt and PROJ are still found via the conda prefix after the Find-module path deletions
- [x] CI green on `build-test-pygplates.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)