### PR TITLE
Make non-ASCII paths work for CSV export and the command-line

### DIFF
--- a/src/file-io/PlatesRotationFileProxy.cc
+++ b/src/file-io/PlatesRotationFileProxy.cc
@@ -1043,6 +1043,13 @@ GPlatesFileIO::GrotWriterWithoutCfg::visit_gpml_metadata(
 #endif
 		existing_contents = existing_stream.readAll();
 	}
+	else
+	{
+		// Not fatal, but the existing contents are about to be dropped from the output, so
+		// don't let that happen silently.
+		qWarning() << "Failed to open file for reading -- "
+				+ d_file_ref.get_file_info().get_qfileinfo().absoluteFilePath();
+	}
 	(*d_output_stream) << buf;
 	(*d_output_stream) << existing_contents;
 }

--- a/src/gplates_main.cc
+++ b/src/gplates_main.cc
@@ -613,9 +613,15 @@ namespace
 			if (!first_arg.empty())
 			{
 				// See if the first argument looks like an option.
-				if (first_arg[0] == '-')
+				//
+				// Note: A leading '@' names a response file. The command-line parser turns
+				// "@filename" into the "--response-file" option wherever it appears, so it is
+				// an option here too (otherwise "gplates @filename" was rejected as an
+				// unrecognised command, unlike "gplates --file x @filename").
+				if (first_arg[0] == '-' ||
+					first_arg[0] == '@')
 				{
-					// It looks like an option since it starts with the '-' character.
+					// It looks like an option since it starts with the '-' or '@' character.
 					return FIRST_ARG_IS_OPTION;
 				}
 

--- a/src/gplates_main.cc
+++ b/src/gplates_main.cc
@@ -265,8 +265,7 @@ namespace
 
 	GuiCommandLineOptions
 	parse_gui_command_line_options(
-			int argc, 
-			char *argv[])
+			const QStringList &command_line_arguments)
 	{
 		GPlatesUtils::CommandLineParser::InputOptions input_options;
 
@@ -331,7 +330,7 @@ namespace
 		try
 		{
 			GPlatesUtils::CommandLineParser::parse_command_line_options(
-				vm, argc, argv, input_options);
+				vm, command_line_arguments, input_options);
 		}
 		catch (std::exception &exc)
 		{
@@ -378,7 +377,8 @@ namespace
 					vm[POSITIONAL_FILENAMES_OPTION_NAME].as<std::vector<std::string> >();
 			for (unsigned int i=0; i<filenames.size(); i++)
 			{
-				const QString filename = QString(filenames[i].c_str());
+				// Note: The option values are UTF-8 encoded.
+				const QString filename = QString::fromStdString(filenames[i]);
 
 				// If the filename does not belong to a project file then consider it a feature collection.
 				if (filename.endsWith(GPlatesGui::FileIOFeedback::PROJECT_FILENAME_EXTENSION, Qt::CaseInsensitive))
@@ -423,13 +423,14 @@ namespace
 			for (unsigned int i=0; i<feature_collection_filenames.size(); i++)
 			{
 				command_line_options.feature_collection_filenames.push_back(
-						feature_collection_filenames[i].c_str());
+						QString::fromStdString(feature_collection_filenames[i]));
 			}
 		}
 
 		if (vm.count(PROJECT_FILENAME_OPTION_NAME))
 		{
-			const QString project_filename = vm[PROJECT_FILENAME_OPTION_NAME].as<std::string>().c_str();
+			const QString project_filename =
+					QString::fromStdString(vm[PROJECT_FILENAME_OPTION_NAME].as<std::string>());
 
 			if (!project_filename.endsWith(
 					GPlatesGui::FileIOFeedback::PROJECT_FILENAME_EXTENSION,
@@ -511,7 +512,8 @@ namespace
 			const std::string &command,
 			GPlatesCli::CommandDispatcher &command_dispatcher,
 			int argc,
-			char* argv[])
+			char* argv[],
+			const QStringList &command_line_arguments)
 	{
 		// GPlatesQApplication is a QApplication that also handles uncaught exceptions in the Qt event thread.
 		// NOTE: This enables the console (command-line) version of GPlates to pop up error message
@@ -552,7 +554,7 @@ namespace
 		{
 			// Parse the command-line options.
 			GPlatesUtils::CommandLineParser::parse_command_line_options(
-					vm, argc, argv, input_options);
+					vm, command_line_arguments, input_options);
 		}
 		catch (std::exception &exc)
 		{
@@ -592,17 +594,17 @@ namespace
 	get_command(
 			std::string &command,
 			GPlatesCli::CommandDispatcher &command_dispatcher,
-			int argc,
-			char* argv[])
+			const QStringList &command_line_arguments)
 	{
-		if (argc < 2)
+		if (command_line_arguments.size() < 2)
 		{
 			command.clear();
 			// Is there a command-line argument to test even ?
 			return FIRST_ARG_IS_NONEXISTENT;
 		}
 
-		const std::string first_arg = argv[1];
+		const QString first_qarg = command_line_arguments[1];
+		const std::string first_arg = first_qarg.toStdString();
 		command = first_arg;
 
 		// See if the first command-line argument is a recognised command.
@@ -618,7 +620,7 @@ namespace
 				}
 
 				// See if the first argument is the filename of an existing file.
-				if (QFileInfo(QString(first_arg.c_str())).exists())
+				if (QFileInfo(first_qarg).exists())
 				{
 					return FIRST_ARG_IS_FILENAME;
 				}
@@ -653,11 +655,18 @@ namespace
 		 */
 		GPlatesCli::CommandDispatcher command_dispatcher;
 
+		// Get the command-line arguments.
+		//
+		// Note: These are used in place of 'argv' since, on Windows, 'argv' cannot represent
+		// characters outside the process' ANSI code page (such as in a non-ASCII filename).
+		const QStringList command_line_arguments =
+				GPlatesUtils::CommandLineParser::get_command_line_arguments(argc, argv);
+
 		// Get the user-specified command (this is the first positional argument on the
 		// command-line).
 		std::string command;
 		const FirstCommandLineArgumentType first_arg_type =
-				get_command(command, command_dispatcher, argc, argv);
+				get_command(command, command_dispatcher, command_line_arguments);
 
 		switch (first_arg_type)
 		{
@@ -669,7 +678,7 @@ namespace
 			// GUI options (or simple options such as help and version) were specified.
 			//
 			// NOTE: This is the only case where GPlates runs as the familiar GUI application.
-			return parse_gui_command_line_options(argc, argv);
+			return parse_gui_command_line_options(command_line_arguments);
 
 		case FIRST_ARG_IS_UNRECOGNISED_COMMAND:
 			// The first command-line argument was not a recognised command or existing filename
@@ -683,7 +692,7 @@ namespace
 
 		case FIRST_ARG_IS_COMMAND:
 			// Process the specified command.
-			parse_and_run_command(command, command_dispatcher, argc, argv);
+			parse_and_run_command(command, command_dispatcher, argc, argv, command_line_arguments);
 			// Notify the caller that the GPlates GUI should *not* be started since the user
 			// has requested GPlates process a command instead.
 			return boost::none;

--- a/src/gplates_main.cc
+++ b/src/gplates_main.cc
@@ -34,6 +34,7 @@
 #include <vector>
 #include <boost/optional.hpp>
 #include <QtGlobal>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
@@ -512,13 +513,21 @@ namespace
 			const std::string &command,
 			GPlatesCli::CommandDispatcher &command_dispatcher,
 			int argc,
-			char* argv[],
-			const QStringList &command_line_arguments)
+			char* argv[])
 	{
 		// GPlatesQApplication is a QApplication that also handles uncaught exceptions in the Qt event thread.
 		// NOTE: This enables the console (command-line) version of GPlates to pop up error message
 		// dialogs such as QMessageBox (which happens in some file I/O code, but really shouldn't).
 		GPlatesGui::GPlatesQApplication qapplication(argc, argv);
+
+		// Get the command-line arguments from QCoreApplication, now that there is one, rather
+		// than from CommandLineParser::get_command_line_arguments().
+		//
+		// QApplication removes the arguments it recognises (such as '-platform' and '-style')
+		// from 'argv', and QCoreApplication::arguments() removes them from the wide Windows
+		// command-line in the same way. Otherwise they would reach the option parser below,
+		// which does not know them.
+		const QStringList command_line_arguments = QCoreApplication::arguments();
 
 		// Add some simple options.
 		GPlatesUtils::CommandLineParser::InputOptions input_options;
@@ -698,7 +707,7 @@ namespace
 
 		case FIRST_ARG_IS_COMMAND:
 			// Process the specified command.
-			parse_and_run_command(command, command_dispatcher, argc, argv, command_line_arguments);
+			parse_and_run_command(command, command_dispatcher, argc, argv);
 			// Notify the caller that the GPlates GUI should *not* be started since the user
 			// has requested GPlates process a command instead.
 			return boost::none;

--- a/src/gui/ColourScaleGenerator.cc
+++ b/src/gui/ColourScaleGenerator.cc
@@ -26,7 +26,7 @@
 #include <cmath>
 #include <utility>
 #include <boost/foreach.hpp>
-#include <boost/numeric/conversion/converter.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/optional.hpp>
 #include <QPainter>
 #include <QBrush>
@@ -70,21 +70,38 @@ namespace
 		return r.dval();
 	}
 
-	typedef boost::numeric::converter<
-		int,
-		double,
-		boost::numeric::conversion_traits<int, double>,
-		boost::numeric::def_overflow_handler,
-		boost::numeric::Ceil< boost::numeric::conversion_traits<int, double>::source_type >
-	> round_up;
+	/**
+	 * Round a double up (or down) to the nearest int, throwing if it will not fit in an int.
+	 *
+	 * These were 'boost::numeric::converter' instantiations with 'Ceil' and 'Floor' rounding
+	 * policies. That is a compile error from Clang 21 on, and only for 'Floor': a policy carries
+	 * its rounding style as a 'std::float_round_style', Boost.MPL's 'integral_c' unconditionally
+	 * computes a 'next_value' one greater than the value it holds, and 'Floor' names
+	 * 'round_toward_neg_infinity' - the *last* enumerator - so that 'next_value' lands outside the
+	 * enumeration's range. Clang used to warn about the resulting cast and now rejects it as not a
+	 * constant expression. ('Ceil' escaped only because its enumerator is not the last one.)
+	 *
+	 * Rounding first and converting afterwards avoids naming a rounding policy at all.
+	 * 'boost::numeric_cast' keeps the range check that 'def_overflow_handler' was here for, and its
+	 * own (truncating) rounding does nothing to a value that is already integral. It throws
+	 * 'bad_numeric_cast' where the converter threw 'positive_overflow'/'negative_overflow', which
+	 * the only caller that catches anything here catches all the same.
+	 */
+	inline
+	int
+	round_up(
+			double d)
+	{
+		return boost::numeric_cast<int>(std::ceil(d));
+	}
 
-	typedef boost::numeric::converter<
-		int,
-		double,
-		boost::numeric::conversion_traits<int, double>,
-		boost::numeric::def_overflow_handler,
-		boost::numeric::Floor< boost::numeric::conversion_traits<int, double>::source_type >
-	> round_down;
+	inline
+	int
+	round_down(
+			double d)
+	{
+		return boost::numeric_cast<int>(std::floor(d));
+	}
 
 	/**
 	 * Calculates the number that the annotations should be a multiple of.
@@ -99,7 +116,7 @@ namespace
 		{
 			// First find the power of 10 that maximises the number of rows that we can
 			// display while staying under max_rows.
-			double pow_of_10 = std::pow(10.0, round_up::convert(std::log10(range / max_rows)));
+			double pow_of_10 = std::pow(10.0, round_up(std::log10(range / max_rows)));
 
 			// Try the largest multiple of 2 * 10^k smaller than pow_of_10.
 			double test = pow_of_10 / 5;
@@ -337,8 +354,8 @@ namespace
 							double multiplier = calculate_linear_annotation_multiplier(maximum_value - minimum_value, max_rows);
 							if (multiplier > 0)
 							{
-								int start = round_up::convert(interp.get_value_at(d_pixmap_height - 1) / multiplier);
-								int end = round_down::convert(interp.get_value_at(0) / multiplier) + 1;
+								int start = round_up(interp.get_value_at(d_pixmap_height - 1) / multiplier);
+								int end = round_down(interp.get_value_at(0) / multiplier) + 1;
 
 								for (int i = start; i != end; ++i)
 								{

--- a/src/gui/CsvExport.cc
+++ b/src/gui/CsvExport.cc
@@ -25,15 +25,72 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <stdexcept>
+#include <QFile>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QString>
 #include <QTableWidget>
+#include <QTextStream>
+#include <QtGlobal>
 
 #include "file-io/ErrorOpeningFileForWritingException.h"
 #include "CsvExport.h"
 
 namespace {
+
+	/**
+	 * Opens @a file for writing and attaches @a os to it as a UTF-8 text stream.
+	 *
+	 * The file is opened through QFile rather than std::ofstream so that paths containing
+	 * non-ASCII characters work. QString::toStdString() encodes as UTF-8, but the narrow
+	 * std::ofstream constructor interprets its path using the process' ANSI code page on
+	 * Windows, so any path outside that code page failed to open.
+	 */
+	void
+	open_csv_file(
+			QFile &file,
+			QTextStream &os)
+	{
+		if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+		{
+			throw GPlatesFileIO::ErrorOpeningFileForWritingException(
+					GPLATES_EXCEPTION_SOURCE,
+					file.fileName());
+		}
+
+		os.setDevice(&file);
+
+		// The replaced code wrote UTF-8 bytes (via QString::toStdString()), so ask for UTF-8
+		// explicitly rather than inheriting the locale codec under Qt5.
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+		os.setEncoding(QStringConverter::Utf8);
+#else
+		os.setCodec("UTF-8");
+#endif
+	}
+
+	/**
+	 * Flushes @a os and throws if anything went wrong while writing.
+	 *
+	 * The replaced std::ofstream had exceptions enabled for badbit/failbit; QTextStream
+	 * reports failures through its device instead, so they are checked explicitly.
+	 */
+	void
+	close_csv_file(
+			QFile &file,
+			QTextStream &os)
+	{
+		// Flush the stream into the file and the file to the OS: an error such as a full disk
+		// can surface at either point, and QFile::close() retains the error status.
+		os.flush();
+		file.close();
+
+		if (file.error() != QFile::NoError)
+		{
+			throw std::runtime_error(file.errorString().toStdString());
+		}
+	}
 
 	/**
 	 * Attempts to apply quoting/escaping rules to a single CSV field
@@ -70,7 +127,7 @@ namespace {
 	void
 	export_table_view_header(
 			const QTableView &table_view,
-			std::ofstream &os,
+			QTextStream &os,
 			const GPlatesGui::CsvExport::ExportOptions &options)
 	{
 		int num_columns = table_view.model()->columnCount();
@@ -80,14 +137,16 @@ namespace {
 			QVariant header = table_view.model()->headerData(column,Qt::Horizontal);
 
 			header_item_as_string = csv_quote_if_necessary(header.toString(), options);
-			os << header_item_as_string.toStdString().c_str();
+			os << header_item_as_string;
 
 			// Separate fields with a delimiter.
 			if (column < (num_columns - 1)) {
 				os << options.delimiter;
 			}
 		}
-		os << std::endl;
+		// The file is opened with QIODevice::Text, so this becomes the platform line ending
+		// just as the replaced std::ofstream's text mode did.
+		os << "\n";
 
 	}
 
@@ -103,11 +162,11 @@ namespace GPlatesGui
 			const QTableWidget &table)
 	{
 		QFileInfo file_info(filename);
+		QFile file(filename);
+		QTextStream os;
 		try{
 
-			std::ofstream os;
-			os.exceptions(std::ios::badbit | std::ios::failbit);
-			os.open(filename.toStdString().c_str());
+			open_csv_file(file, os);
 
 			int num_columns = table.columnCount();
 			int num_rows = table.rowCount();
@@ -126,7 +185,7 @@ namespace GPlatesGui
 					item = table.item(row, column);
 					if (item) {
 						item_as_str = csv_quote_if_necessary(item->text(), options);
-						os << item_as_str.toStdString().c_str();
+						os << item_as_str;
 					}
 
 					// Separate fields with a delimiter.
@@ -136,9 +195,18 @@ namespace GPlatesGui
 
 				}
 
-				os << std::endl;
+				os << "\n";
 
 			}
+
+			close_csv_file(file, os);
+		}
+		catch (GPlatesFileIO::ErrorOpeningFileForWritingException &)
+		{
+			QString message = QObject::tr("Error opening file '%1' for writing")
+					.arg(file_info.filePath());
+			QMessageBox::critical(0, QObject::tr("Error Saving File"), message,
+								  QMessageBox::Ok, QMessageBox::Ok);
 		}
 		catch (std::exception &exc)
 		{
@@ -166,12 +234,11 @@ namespace GPlatesGui
 			const QTableView &table)
 	{
 		QFileInfo file_info(filename);
+		QFile file(filename);
+		QTextStream os;
 		try{
 
-			std::ofstream os;
-			os.exceptions(std::ios::badbit | std::ios::failbit);
-			os.open(filename.toStdString().c_str());
-
+			open_csv_file(file, os);
 
 			QAbstractItemModel *model = table.model();
 
@@ -192,7 +259,7 @@ namespace GPlatesGui
 						// if no item has been set at the (row, column) position.
 						QVariant data = model->index(row,column).data();
 						item_as_str = csv_quote_if_necessary(data.toString(), options);
-						os << item_as_str.toStdString().c_str();
+						os << item_as_str;
 
 						// Separate fields with a delimiter.
 						if (column < (num_columns - 1)) {
@@ -201,10 +268,19 @@ namespace GPlatesGui
 
 					}
 
-					os << std::endl;
+					os << "\n";
 
 				}
 			}
+
+			close_csv_file(file, os);
+		}
+		catch (GPlatesFileIO::ErrorOpeningFileForWritingException &)
+		{
+			QString message = QObject::tr("Error opening file '%1' for writing")
+					.arg(file_info.filePath());
+			QMessageBox::critical(0, QObject::tr("Error Saving File"), message,
+								  QMessageBox::Ok, QMessageBox::Ok);
 		}
 		catch (std::exception &exc)
 		{
@@ -228,17 +304,17 @@ namespace GPlatesGui
 
 	void
 	CsvExport::export_line(
-			std::ofstream &os,
+			QTextStream &os,
 			const CsvExport::ExportOptions &options,
 			const LineDataType &line_data)
 	{
-		
+
 		std::vector<QString>::const_iterator it;
 
 		for(it=line_data.begin();it!=line_data.end();it++)
 		{
 			QString str = csv_quote_if_necessary(*it, options);
-			os << str.toStdString().c_str();
+			os << str;
 
 			if (it!=(line_data.end() - 1))
 			{
@@ -246,7 +322,7 @@ namespace GPlatesGui
 			}
 
 		}
-		os << std::endl;
+		os << "\n";
 		return;
 	}
 
@@ -256,35 +332,40 @@ namespace GPlatesGui
 			const CsvExport::ExportOptions &options,
 			const std::vector<CsvExport::LineDataType> &data)
 	{
-		std::ofstream os;
 		QFileInfo file_info(filename);
-		try{	
-			os.exceptions(std::ios::badbit | std::ios::failbit);
-			os.open(filename.toStdString().c_str());
+		QFile file(filename);
+		QTextStream os;
+		try{
+			open_csv_file(file, os);
 			std::vector<CsvExport::LineDataType>::const_iterator it;
 			for(it=data.begin();it!=data.end();it++)
 			{
 				export_line(os,options,*it);
 			}
 
+			close_csv_file(file, os);
+		}
+		catch (GPlatesFileIO::ErrorOpeningFileForWritingException &)
+		{
+			QString message = QObject::tr("Error opening file '%1' for writing")
+					.arg(file_info.filePath());
+			QMessageBox::critical(0, QObject::tr("Error Saving File"), message,
+					QMessageBox::Ok, QMessageBox::Ok);
 		}
 		catch (std::exception &exc)
 		{
-			os.close();
 			QString message = QObject::tr("Error writing to file '%1': %2")
 					.arg(file_info.filePath()).arg(exc.what());
 			QMessageBox::critical(0, QObject::tr("Error Saving File"), message,
-					QMessageBox::Ok, QMessageBox::Ok);					
+					QMessageBox::Ok, QMessageBox::Ok);
 		}
 		catch(...)
 		{
-			os.close();
 			QString message = QObject::tr("An error occurred while writing to file '%1'")
 				.arg(file_info.filePath());
 			QMessageBox::critical(0, QObject::tr("Error Saving File"), message,
-				QMessageBox::Ok, QMessageBox::Ok);					
+				QMessageBox::Ok, QMessageBox::Ok);
 		}
-		os.close();
 		return;
 	}
 

--- a/src/gui/CsvExport.cc
+++ b/src/gui/CsvExport.cc
@@ -81,14 +81,37 @@ namespace {
 			QFile &file,
 			QTextStream &os)
 	{
-		// Flush the stream into the file and the file to the OS: an error such as a full disk
-		// can surface at either point, and QFile::close() retains the error status.
+		// Flush the stream into the file: an error such as a full disk can surface here.
 		os.flush();
-		file.close();
 
+		// Note: The file's error is taken *before* it is closed. QFileDevice::close() clears the
+		// error status when its own final flush succeeds, and that flush can succeed after an
+		// earlier write has already failed, since the failed write left nothing behind to flush.
+		QString error_string;
 		if (file.error() != QFile::NoError)
 		{
-			throw std::runtime_error(file.errorString().toStdString());
+			error_string = file.errorString();
+		}
+
+		// Closing flushes the file to the operating system, which can fail in turn.
+		file.close();
+		if (error_string.isEmpty() &&
+			file.error() != QFile::NoError)
+		{
+			error_string = file.errorString();
+		}
+
+		// QTextStream records a failed write as well, and unlike QFile it does not forget one,
+		// so ask it too - it is what noticed if a write failed part-way through the table.
+		if (error_string.isEmpty() &&
+			os.status() != QTextStream::Ok)
+		{
+			error_string = QObject::tr("writing to the file failed");
+		}
+
+		if (!error_string.isEmpty())
+		{
+			throw std::runtime_error(error_string.toStdString());
 		}
 	}
 

--- a/src/gui/CsvExport.h
+++ b/src/gui/CsvExport.h
@@ -28,9 +28,9 @@
 #ifndef GPLATES_GUI_CSVEXPORT_H
 #define GPLATES_GUI_CSVEXPORT_H
 
-#include <iostream>
-#include <fstream>
+#include <vector>
 #include <QTableWidget>
+#include <QTextStream>
 namespace GPlatesGui {
 
 	/**
@@ -77,7 +77,7 @@ namespace GPlatesGui {
 		static
 		void
 		export_line(
-				std::ofstream &os,
+				QTextStream &os,
 				const ExportOptions &options,
 				const LineDataType &line_data);
 

--- a/src/unit-test/CMakeLists.txt
+++ b/src/unit-test/CMakeLists.txt
@@ -11,6 +11,7 @@
 set(srcs
     ApplicationStateTest.cc
     CptPaletteTest.cc
+    CsvExportTest.cc
     DataAssociationDataTableTest.cc
     GenerateVelocityDomainCitcomsTest.cc
     MipmapperTest.cc

--- a/src/unit-test/CMakeLists.txt
+++ b/src/unit-test/CMakeLists.txt
@@ -10,6 +10,7 @@
 #
 set(srcs
     ApplicationStateTest.cc
+    CommandLineParserTest.cc
     CptPaletteTest.cc
     CsvExportTest.cc
     DataAssociationDataTableTest.cc

--- a/src/unit-test/CommandLineParserTest.cc
+++ b/src/unit-test/CommandLineParserTest.cc
@@ -1,0 +1,246 @@
+/**
+ * Copyright (C) 2026 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <string>
+#include <vector>
+#include <boost/program_options.hpp>
+#include <gtest/gtest.h>
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+
+#include "utils/CommandLineParser.h"
+
+
+namespace
+{
+	const char *FILE_OPTION_NAME = "file";
+
+	/**
+	 * Non-ASCII text, as explicit UTF-8 bytes rather than as characters in this source file.
+	 *
+	 * The build does not tell MSVC that its sources are UTF-8 (there is no '/utf-8'), so a
+	 * character written literally here would be decoded using the compiler's own code page.
+	 *
+	 * These characters are outside code page 1252, so on Windows they cannot survive the
+	 * conversion of the command-line that the C runtime does before 'main()' - which is why
+	 * CommandLineParser works with a QStringList rather than with 'argv'.
+	 */
+	const QString
+	non_ascii_text()
+	{
+		// 测试-Ünïcode
+		// Note: The literal is split because a hex escape is greedy - "\xAFcode" would
+		//       otherwise continue into the 'c', which is also a hex digit.
+		return QString::fromUtf8("\xE6\xB5\x8B\xE8\xAF\x95-\xC3\x9Cn\xC3\xAF" "code");
+	}
+
+	/**
+	 * A filename (with no directory, so that it contains no spaces - a response file is
+	 * tokenized on whitespace and cannot quote a value).
+	 */
+	const QString
+	non_ascii_filename()
+	{
+		return non_ascii_text() + ".gpml";
+	}
+
+	/**
+	 * The options accepted by these tests: the simple options (which is where the
+	 * '--response-file' and '--config-file' options come from) and a '--file' option.
+	 *
+	 * Note: '--file' is a config option, so that it can be given on the command-line, in a
+	 * config file, or as a positional argument.
+	 */
+	void
+	add_options(
+			GPlatesUtils::CommandLineParser::InputOptions &input_options)
+	{
+		input_options.add_simple_options();
+
+		input_options.config_options.add_options()
+			(FILE_OPTION_NAME,
+			boost::program_options::value< std::vector<std::string> >(),
+			"files to load");
+
+		input_options.positional_options.add(FILE_OPTION_NAME, -1);
+	}
+
+	/**
+	 * Returns the values of the '--file' option as QStrings.
+	 *
+	 * Option values are UTF-8 encoded, which is what QString::fromStdString() decodes.
+	 */
+	QStringList
+	get_filenames(
+			const boost::program_options::variables_map &vm)
+	{
+		QStringList filenames;
+
+		if (vm.count(FILE_OPTION_NAME))
+		{
+			const std::vector<std::string> values =
+					vm[FILE_OPTION_NAME].as< std::vector<std::string> >();
+			for (unsigned int n = 0; n < values.size(); ++n)
+			{
+				filenames.append(QString::fromStdString(values[n]));
+			}
+		}
+
+		return filenames;
+	}
+
+	/**
+	 * Writes @a contents to a file named @a filename, which the caller names non-ASCII-ly.
+	 */
+	void
+	write_file(
+			const QString &filename,
+			const QString &contents)
+	{
+		QFile file(filename);
+		ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+		ASSERT_NE(-1, file.write(contents.toUtf8()));
+		file.close();
+	}
+}
+
+
+TEST(CommandLineParserTest, non_ascii_option_values_survive_the_parse)
+{
+	// The arguments as GPlates gets them from CommandLineParser::get_command_line_arguments(),
+	// the first of which is the program name.
+	QStringList command_line_arguments;
+	command_line_arguments
+			<< "gplates"
+			<< "--file" << non_ascii_filename()
+			<< non_ascii_text() + "-positional.gpml";
+
+	GPlatesUtils::CommandLineParser::InputOptions input_options;
+	add_options(input_options);
+
+	boost::program_options::variables_map vm;
+	GPlatesUtils::CommandLineParser::parse_command_line_options(vm, command_line_arguments, input_options);
+
+	// The values are encoded as UTF-8 for boost::program_options, which works with narrow
+	// strings, and decoded again on the way out - so they should be unchanged.
+	QStringList expected_filenames;
+	expected_filenames << non_ascii_filename() << non_ascii_text() + "-positional.gpml";
+
+	EXPECT_EQ(expected_filenames, get_filenames(vm));
+}
+
+
+TEST(CommandLineParserTest, reads_a_response_file_with_a_non_ascii_name)
+{
+	QTemporaryDir temp_dir;
+	ASSERT_TRUE(temp_dir.isValid());
+	const QString directory = temp_dir.filePath(non_ascii_text());
+	ASSERT_TRUE(QDir().mkpath(directory));
+	const QString response_filename = directory + "/" + non_ascii_text() + ".rsp";
+
+	write_file(response_filename, QString("--file ") + non_ascii_filename());
+
+	QStringList expected_filenames;
+	expected_filenames << non_ascii_filename();
+
+	// The response file is opened with QFile, so its name can contain anything a filename can.
+	{
+		QStringList command_line_arguments;
+		command_line_arguments << "gplates" << "--response-file" << response_filename;
+
+		GPlatesUtils::CommandLineParser::InputOptions input_options;
+		add_options(input_options);
+
+		boost::program_options::variables_map vm;
+		GPlatesUtils::CommandLineParser::parse_command_line_options(vm, command_line_arguments, input_options);
+
+		EXPECT_EQ(expected_filenames, get_filenames(vm));
+	}
+
+	// "@filename" names a response file too.
+	{
+		QStringList command_line_arguments;
+		command_line_arguments << "gplates" << "@" + response_filename;
+
+		GPlatesUtils::CommandLineParser::InputOptions input_options;
+		add_options(input_options);
+
+		boost::program_options::variables_map vm;
+		GPlatesUtils::CommandLineParser::parse_command_line_options(vm, command_line_arguments, input_options);
+
+		EXPECT_EQ(expected_filenames, get_filenames(vm));
+	}
+}
+
+
+TEST(CommandLineParserTest, reads_a_config_file_with_a_non_ascii_name)
+{
+	QTemporaryDir temp_dir;
+	ASSERT_TRUE(temp_dir.isValid());
+	const QString directory = temp_dir.filePath(non_ascii_text());
+	ASSERT_TRUE(QDir().mkpath(directory));
+	const QString config_filename = directory + "/" + non_ascii_text() + ".cfg";
+
+	write_file(config_filename, QString(FILE_OPTION_NAME) + "=" + non_ascii_filename() + "\n");
+
+	QStringList command_line_arguments;
+	command_line_arguments << "gplates" << "--config-file" << config_filename;
+
+	GPlatesUtils::CommandLineParser::InputOptions input_options;
+	add_options(input_options);
+
+	boost::program_options::variables_map vm;
+	GPlatesUtils::CommandLineParser::parse_command_line_options(vm, command_line_arguments, input_options);
+
+	QStringList expected_filenames;
+	expected_filenames << non_ascii_filename();
+
+	EXPECT_EQ(expected_filenames, get_filenames(vm));
+}
+
+
+TEST(CommandLineParserTest, does_not_parse_the_program_name_as_an_option)
+{
+	// The program name is whatever the program was invoked as, which is not necessarily a name
+	// that looks like a filename.
+	//
+	// Note: The arguments are parsed by the std::vector<std::string> overload of
+	// boost::program_options::command_line_parser, which - unlike the (argc, argv) overload -
+	// does not skip a leading program name, so parse_command_line_options() drops it itself.
+	QStringList command_line_arguments;
+	command_line_arguments << "--help" << "--file" << non_ascii_filename();
+
+	GPlatesUtils::CommandLineParser::InputOptions input_options;
+	add_options(input_options);
+
+	boost::program_options::variables_map vm;
+	GPlatesUtils::CommandLineParser::parse_command_line_options(vm, command_line_arguments, input_options);
+
+	EXPECT_FALSE(GPlatesUtils::CommandLineParser::is_help_requested(vm));
+
+	QStringList expected_filenames;
+	expected_filenames << non_ascii_filename();
+
+	EXPECT_EQ(expected_filenames, get_filenames(vm));
+}

--- a/src/unit-test/CsvExportTest.cc
+++ b/src/unit-test/CsvExportTest.cc
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2026 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <vector>
+#include <gtest/gtest.h>
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QString>
+#include <QTemporaryDir>
+#include <QTextStream>
+
+#include "gui/CsvExport.h"
+
+
+namespace
+{
+	/**
+	 * Non-ASCII text, as explicit UTF-8 bytes rather than as characters in this source file.
+	 *
+	 * The build does not tell MSVC that its sources are UTF-8 (there is no '/utf-8'), so a
+	 * character written literally here would be decoded using the compiler's own code page.
+	 */
+	const QString
+	non_ascii_text()
+	{
+		// 测试-Ünïcode
+		// Note: The literal is split because a hex escape is greedy - "\xAFcode" would
+		//       otherwise continue into the 'c', which is also a hex digit.
+		return QString::fromUtf8("\xE6\xB5\x8B\xE8\xAF\x95-\xC3\x9Cn\xC3\xAF" "code");
+	}
+
+	/**
+	 * The line ending that QIODevice::Text writes, which is what the std::ofstream text mode
+	 * that CsvExport used to open its files with wrote.
+	 */
+	const QByteArray
+	native_line_ending()
+	{
+#if defined(Q_OS_WIN)
+		return QByteArray("\r\n");
+#else
+		return QByteArray("\n");
+#endif
+	}
+
+	/**
+	 * Returns the contents of @a filename as the bytes it actually contains.
+	 *
+	 * Note: The file is *not* opened with QIODevice::Text, so that the line endings written
+	 * are visible to the caller rather than translated back.
+	 */
+	QByteArray
+	read_file(
+			const QString &filename)
+	{
+		QFile file(filename);
+		EXPECT_TRUE(file.open(QIODevice::ReadOnly));
+		return file.readAll();
+	}
+}
+
+
+TEST(CsvExportTest, exports_to_a_non_ascii_path)
+{
+	// A directory and a filename that both contain characters outside any single-byte code page.
+	//
+	// Note: The non-ASCII names are created here rather than committed to the repository, since
+	// a filename is not stored identically by every filesystem (macOS decomposes it, for one).
+	QTemporaryDir temp_dir;
+	ASSERT_TRUE(temp_dir.isValid());
+	const QString directory = temp_dir.filePath(non_ascii_text());
+	ASSERT_TRUE(QDir().mkpath(directory));
+	const QString filename = directory + "/" + non_ascii_text() + ".csv";
+
+	GPlatesGui::CsvExport::ExportOptions options;
+	options.delimiter = ',';
+
+	std::vector<GPlatesGui::CsvExport::LineDataType> data;
+
+	GPlatesGui::CsvExport::LineDataType header;
+	header.push_back("plate id");
+	header.push_back(non_ascii_text());
+	data.push_back(header);
+
+	GPlatesGui::CsvExport::LineDataType row;
+	row.push_back("801");
+	row.push_back(non_ascii_text());
+	data.push_back(row);
+
+	// Note: export_data() reports a failure to the user with a message box rather than by
+	// throwing, since it is called from the GUI. So if this ever regresses on a platform where
+	// the path cannot be opened, the test blocks in that modal dialog and fails by exceeding the
+	// timeout that 'gtest_discover_tests' sets, rather than failing on the checks below.
+	GPlatesGui::CsvExport::export_data(filename, options, data);
+
+	// The file is named by the path asked for...
+	ASSERT_TRUE(QFile::exists(filename));
+
+	// ...and contains the data encoded as UTF-8, with the platform line ending.
+	//
+	// Note: This is compared as bytes because the encoding is part of what is being tested: a
+	// QTextStream writes the locale encoding unless told otherwise, so exporting the same data
+	// on two machines would otherwise not produce the same file.
+	QByteArray expected;
+	expected += QByteArray("plate id,") + non_ascii_text().toUtf8() + native_line_ending();
+	expected += QByteArray("801,") + non_ascii_text().toUtf8() + native_line_ending();
+
+	EXPECT_EQ(expected, read_file(filename));
+}
+
+
+TEST(CsvExportTest, quotes_only_the_fields_that_need_quoting)
+{
+	// CsvExport::export_line() writes to a QTextStream, which need not be a file.
+	QString line;
+	QTextStream os(&line);
+
+	GPlatesGui::CsvExport::ExportOptions options;
+	options.delimiter = ',';
+
+	GPlatesGui::CsvExport::LineDataType line_data;
+	line_data.push_back("801");						// Nothing to quote.
+	line_data.push_back(non_ascii_text());			// Non-ASCII is not a reason to quote.
+	line_data.push_back("a,b");						// Contains the delimiter.
+	line_data.push_back("say \"hello\"");			// Contains quotes, which are doubled.
+	line_data.push_back(" leading space");			// Would otherwise be trimmed by a reader.
+
+	GPlatesGui::CsvExport::export_line(os, options, line_data);
+
+	const QString expected =
+			"801," +
+			non_ascii_text() + "," +
+			"\"a,b\"," +
+			"\"say \"\"hello\"\"\"," +
+			"\" leading space\"\n";
+
+	EXPECT_EQ(expected, line);
+}

--- a/src/utils/CommandLineParser.cc
+++ b/src/utils/CommandLineParser.cc
@@ -24,11 +24,27 @@
  */
 
 #include <iostream>
-#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
 #include <boost/bind/bind.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/token_functions.hpp>
+#include <QByteArray>
+#include <QFile>
+#include <QIODevice>
+#include <QString>
 #include <QtGlobal>
+
+#if defined(Q_OS_WIN)
+// Note: Prevent windows.h from defining min/max macros since these interfere with
+//       things like 'std::numeric_limits<int>::max()'.
+#ifndef NOMINMAX
+#	define NOMINMAX
+#endif
+#include <windows.h>
+#include <shellapi.h>
+#endif
 
 #include "CommandLineParser.h"
 
@@ -90,19 +106,21 @@ namespace
 
 
 	/**
-	* Parse the command-line arguments defined by @a argc and @a argv.
+	* Parse the command-line arguments in @a args (which excludes the program name).
 	*/
 	void
 	parse_command_line(
 			boost::program_options::variables_map &vm,
-			int argc,
-			char* argv[],
+			const std::vector<std::string> &args,
 			const boost::program_options::options_description &cmdline_options,
 			const boost::program_options::positional_options_description &positional_options,
 			int command_line_style)
 	{
 		// Setup the parser for the command-line.
-		boost::program_options::command_line_parser command_line_parser(argc, argv);
+		//
+		// Note: This overload of 'command_line_parser', unlike the (argc, argv) overload, does
+		// not skip a leading program name, so @a args must not contain one.
+		boost::program_options::command_line_parser command_line_parser(args);
 		command_line_parser.extra_parser(at_option_parser);
 
 		// Set the command-line style of processing.
@@ -156,7 +174,7 @@ namespace
 	/**
 	* Parses a file containing configuration options.
 	*
-	* @param config_filename the name of config file to parse
+	* @param config_filename the name of config file to parse (UTF-8 encoded)
 	* @param config_file_options the options to looks for in the config file
 	* @param vm the place to store configuration values found
 	*/
@@ -166,14 +184,21 @@ namespace
 			const boost::program_options::options_description &config_file_options,
 			boost::program_options::variables_map &vm)
 	{
-		// Load the file and tokenize it.
-		std::ifstream config_file(config_filename.c_str());
-		if (!config_file)
+		// Open the file with QFile rather than std::ifstream: the narrow std::ifstream
+		// constructor interprets its path using the process' ANSI code page on Windows, so any
+		// path outside that code page failed to open.
+		const QString config_qfilename = QString::fromStdString(config_filename);
+
+		QFile config_qfile(config_qfilename);
+		if (!config_qfile.open(QIODevice::ReadOnly | QIODevice::Text))
 		{
 			throw GPlatesFileIO::ErrorOpeningFileForReadingException(
 				GPLATES_EXCEPTION_SOURCE,
-				config_filename.c_str());
+				config_qfilename);
 		}
+
+		// Load the file and tokenize it (boost::program_options parses from a std::istream).
+		std::istringstream config_file(config_qfile.readAll().toStdString());
 
 		// Parse the file and store the options.
 		boost::program_options::store(
@@ -220,9 +245,11 @@ namespace
 			// The main exception handler will print an error message but
 			// it's not so easy to read so print it here also to make it obvious
 			// to the program user.
+			// Note: Encode the filename for the console rather than as UTF-8, otherwise a
+			// non-ASCII filename is printed as mojibake.
 			std::cerr
 				<< "Error opening config file '"
-				<< exc.filename().toStdString().c_str()
+				<< exc.filename().toLocal8Bit().constData()
 				<< "' for reading."
 				<< std::endl;
 
@@ -246,23 +273,23 @@ namespace
 			return std::vector<std::string>();
 		}
 
-		// Get the response filename.
-		const std::string &response_filename =
-			vm[RESPONSE_FILE_OPTION_NAME].as<std::string>();
+		// Get the response filename (UTF-8 encoded).
+		const QString response_qfilename =
+			QString::fromStdString(vm[RESPONSE_FILE_OPTION_NAME].as<std::string>());
 
-		// Load the file and tokenize it.
-		std::ifstream response_file(response_filename.c_str());
-		if (!response_file)
+		// Open the file with QFile rather than std::ifstream: the narrow std::ifstream
+		// constructor interprets its path using the process' ANSI code page on Windows, so any
+		// path outside that code page failed to open.
+		QFile response_qfile(response_qfilename);
+		if (!response_qfile.open(QIODevice::ReadOnly | QIODevice::Text))
 		{
 			throw GPlatesFileIO::ErrorOpeningFileForReadingException(
 				GPLATES_EXCEPTION_SOURCE,
-				response_filename.c_str());
+				response_qfilename);
 		}
 
 		// Read the whole file into a string.
-		std::ostringstream ostr_stream;
-		ostr_stream << response_file.rdbuf();
-		const std::string response_file_content = ostr_stream.str();
+		const std::string response_file_content = response_qfile.readAll().toStdString();
 
 		// Split the file content
 		boost::char_separator<char> sep(" \n\r");
@@ -306,11 +333,46 @@ namespace
 	}
 }
 
+QStringList
+GPlatesUtils::CommandLineParser::get_command_line_arguments(
+		int argc,
+		char* argv[])
+{
+	QStringList command_line_arguments;
+
+#if defined(Q_OS_WIN)
+	// Ask Windows for the wide command-line, since 'argv' has already lost any character that
+	// the process' ANSI code page cannot represent.
+	int num_wide_arguments = 0;
+	wchar_t **wide_argv = ::CommandLineToArgvW(::GetCommandLineW(), &num_wide_arguments);
+	if (wide_argv)
+	{
+		for (int n = 0; n < num_wide_arguments; ++n)
+		{
+			command_line_arguments.append(QString::fromWCharArray(wide_argv[n]));
+		}
+
+		::LocalFree(wide_argv);
+
+		return command_line_arguments;
+	}
+
+	// Fall through to 'argv' in the unlikely event that Windows would not parse its own
+	// command-line (in which case non-ASCII arguments are no worse off than they were).
+#endif
+
+	for (int n = 0; n < argc; ++n)
+	{
+		command_line_arguments.append(QString::fromLocal8Bit(argv[n]));
+	}
+
+	return command_line_arguments;
+}
+
 void
 GPlatesUtils::CommandLineParser::parse_command_line_options(
 		boost::program_options::variables_map &vm,
-		int argc,
-		char* argv[],
+		const QStringList &command_line_arguments,
 		const GPlatesUtils::CommandLineParser::InputOptions &input_options,
 		int command_line_style)
 {
@@ -336,11 +398,23 @@ GPlatesUtils::CommandLineParser::parse_command_line_options(
 	//   from both sources are merged together.
 	//
 
+	// Convert the arguments for boost::program_options, which works with narrow strings.
+	//
+	// UTF-8 is used so that non-ASCII option values (in particular filenames) survive - they
+	// are converted back to QString with QString::fromStdString() by the caller.
+	//
+	// Note: The first argument is the program name, which is not an option.
+	std::vector<std::string> args;
+	args.reserve(command_line_arguments.size());
+	for (int n = 1; n < command_line_arguments.size(); ++n)
+	{
+		args.push_back(command_line_arguments[n].toStdString());
+	}
+
 	// Parse the command-line.
 	parse_command_line(
 		vm,
-		argc,
-		argv,
+		args,
 		cmdline_options,
 		input_options.positional_options,
 		command_line_style);

--- a/src/utils/CommandLineParser.cc
+++ b/src/utils/CommandLineParser.cc
@@ -363,7 +363,28 @@ GPlatesUtils::CommandLineParser::get_command_line_arguments(
 
 	for (int n = 0; n < argc; ++n)
 	{
-		command_line_arguments.append(QString::fromLocal8Bit(argv[n]));
+		const QString argument = QString::fromLocal8Bit(argv[n]);
+
+		// Warn if the argument did not survive being decoded, rather than leave the user to
+		// wonder why a file that exists cannot be opened.
+		//
+		// A filename is a byte string that need not be text in the local encoding (UTF-8 on
+		// Unix), but a QString cannot represent such bytes - each becomes a replacement
+		// character - and GPlates works with QString filenames throughout.
+		//
+		// Note: Encode the argument for the console rather than as UTF-8, otherwise a
+		// non-ASCII argument is printed as mojibake.
+		if (argument.toLocal8Bit() != QByteArray(argv[n]))
+		{
+			std::cerr
+				<< "Warning: command-line argument " << n
+				<< " is not valid in the local encoding and was read as '"
+				<< argument.toLocal8Bit().constData()
+				<< "'."
+				<< std::endl;
+		}
+
+		command_line_arguments.append(argument);
 	}
 
 	return command_line_arguments;

--- a/src/utils/CommandLineParser.h
+++ b/src/utils/CommandLineParser.h
@@ -29,6 +29,7 @@
 #define GPLATES_UTILS_COMMAND_LINE_PARSER_H
 
 #include <boost/program_options.hpp>
+#include <QStringList>
 
 namespace GPlatesUtils
 {
@@ -85,8 +86,28 @@ namespace GPlatesUtils
 				const GPlatesUtils::CommandLineParser::InputOptions &input_options);
 
 		/**
+		* Returns the command-line arguments, the first of which is the program name.
+		*
+		* On Windows the narrow @a argv passed to 'main()' has already been converted to the
+		* process' ANSI code page by the C runtime, so any character outside that code page is
+		* lost before 'main()' is even entered. In that case the original wide command-line is
+		* obtained from Windows instead. This is what QCoreApplication::arguments() does, but
+		* the arguments are needed before there is a QCoreApplication to ask.
+		*/
+		QStringList
+		get_command_line_arguments(
+				int argc,
+				char* argv[]);
+
+		/**
 		* Parse the command-line options and also parse any response file and config files
 		* that are specified and store parsed results in @a vm.
+		*
+		* @a command_line_arguments should come from @a get_command_line_arguments - in particular
+		* its first element is the program name, which is not parsed as an option.
+		*
+		* Option values are stored in @a vm as UTF-8 encoded std::string, so a filename retrieved
+		* from @a vm should be converted back to a QString with QString::fromStdString().
 		*
 		* @a command_line_style contains options for how boost::program_options processes the command-line.
 		*
@@ -95,8 +116,7 @@ namespace GPlatesUtils
 		void
 		parse_command_line_options(
 				boost::program_options::variables_map &vm,
-				int argc,
-				char* argv[],
+				const QStringList &command_line_arguments,
 				const InputOptions &input_options,
 				int command_line_style = boost::program_options::command_line_style::default_style);
 


### PR DESCRIPTION
Follow-up to #37, which fixed two `std::ifstream` cases but left the rest of the non-ASCII path handling alone. Two independent bugs, both on Windows, both about paths whose characters fall outside the process' ANSI code page.

### CSV export (`src/gui/CsvExport.{h,cc}`)

`QString::toStdString()` encodes as UTF-8, but the narrow `std::ofstream` constructor interprets its path using the ANSI code page, so any path outside that code page failed to open. Every CSV export went through that path.

All three entry points — `export_table_widget()`, `export_table_view()` and `export_data()` — now write through `QFile`/`QTextStream`:

- **Encoding is unchanged on purpose.** UTF-8 is requested explicitly, which preserves the UTF-8 bytes the replaced code emitted via `QString::toStdString()`; a `QTextStream` would otherwise default to the locale codec under Qt5 and silently change the encoding of every exported file.
- **Line endings are unchanged.** The file is opened with `QIODevice::Text`, so a newline still becomes the platform line ending, exactly as `std::ofstream`'s text mode did.
- **Error reporting is preserved.** The replaced `std::ofstream` had exceptions enabled for `badbit`/`failbit`; `QTextStream` reports failures through its device instead, so the stream is flushed, the file closed, and `QFile::error()` checked explicitly. The error is taken *before* the file is closed, because `QFileDevice::close()` clears it when its own final flush succeeds - which it can do after an earlier write has already failed, that write having left nothing behind to flush. `QTextStream::status()` is checked as well, since it is what notices a write failing part-way through the table and it does not forget one. Failing to open throws `ErrorOpeningFileForWritingException`, matching `PlatesRotationFormatWriter`. It is caught separately from the existing `std::exception` handler because `GPlatesGlobal::Exception::what()` appends a call stack trace, which does not belong in a message box.

`CsvExport::export_line()` now takes a `QTextStream &` instead of a `std::ofstream &`. Its only caller is inside `CsvExport.cc`.

### Command-line file paths (`src/gplates_main.cc`, `src/utils/CommandLineParser.{h,cc}`)

The `std::ifstream` calls in `CommandLineParser` look like the same bug, but fixing them alone would have achieved nothing: the damage happens earlier. `main(int argc, char *argv[])` receives arguments already converted to the ANSI code page by the C runtime, and there is no UTF-8 application manifest, so a character that code page cannot represent is gone before `main()` is even entered. No filename given on the command line — positional, `--file`, `--project`, `--config-file`, or a response file — could name a path containing one.

- `CommandLineParser::get_command_line_arguments()` returns the arguments as a `QStringList`, asking Windows for the wide command line instead of using `argv`. This is what `QCoreApplication::arguments()` does, but the arguments are needed before there is a `QCoreApplication` to ask — the command line is deliberately parsed first, in case GPlates is being used only to process a command and then exit. Everywhere else falls back to `argv` via `QString::fromLocal8Bit()`, which is also what Qt does.
- `parse_command_line_options()` takes that `QStringList` and encodes it as UTF-8 for boost::program_options, which works with narrow strings. Option values are therefore UTF-8 and are converted back with `QString::fromStdString()`. `gplates_main.cc` was already relying on `QString(const char *)`, which decodes as UTF-8 — so it was assuming what only now holds.
- The config and response files are opened with `QFile` rather than `std::ifstream`, whose narrow constructor interprets its path using the ANSI code page as well.
- The message printed when a config file cannot be opened is encoded for the console rather than as UTF-8, otherwise a non-ASCII filename prints as mojibake.
- A leading `@` names a response file, and `at_option_parser()` turns `@filename` into `--response-file` wherever it appears — but the first argument is classified by `get_command()` before that parse happens, and only `-` marked an argument as an option there. `gplates @filename` was therefore rejected as an unrecognised command, while the same response file worked as `gplates --file x @filename`. A leading `@` is now an option there too. A file whose name really does begin with `@` can no longer be loaded by naming it as the first argument, since it is read as a response file — that was already true of every later argument, and such a file can still be named with a path (`./@filename`).
- A filename on Unix is a byte string that need not be text in any encoding, so bytes that are not valid UTF-8 (a filename typed on a Latin-1 system, say) cannot be represented by a `QString` at all: each becomes U+FFFD, and the replacement characters then name a file that does not exist. GPlates works with `QString` filenames throughout, so decoding the command line differently would only move the loss to the first `QString`; `get_command_line_arguments()` now says so, instead of failing later with an `Error opening file` naming a path the user can see is the file they asked for.

- `QApplication` removes the arguments it recognises (`-platform`, `-style`, `-stylesheet`, `-widgetcount`, …) from `argv` as it starts up, and `parse_and_run_command()` constructs one before parsing - so those arguments never used to reach the option parser. The command path therefore takes its arguments from `QCoreApplication::arguments()`, which removes the same ones from the wide Windows command-line that it recovers. Without that, `gplates reconstruct -platform offscreen …` (a normal way to run the non-GUI commands on a headless machine) fails with `unrecognised option`. The GUI path is unaffected, having always parsed before `QApplication` exists.

`argc`/`argv` are still passed through where `QApplication` needs them.

### Rotation file proxy (`src/file-io/PlatesRotationFileProxy.cc`)

`GrotWriterWithoutCfg::visit_gpml_metadata()` re-reads the file it is writing so it can append the existing contents after the metadata block. #37 made the failed-read case explicit; this logs a warning instead of silently dropping those contents.

### Also here: a Clang 21 build fix (`src/gui/ColourScaleGenerator.cc`)

Unrelated to the above, but needed to get the macOS CI green on this branch. Cherry-picked from `fcce948f` on the `pygplates` branch.

`ColourScaleGenerator.cc` rounded with two `boost::numeric::converter` instantiations, and the one carrying the `Floor` policy stopped compiling when conda-forge moved its toolchain from Clang 19 to Clang 21 — a rounding policy carries its style as a `std::float_round_style`, Boost.MPL's `integral_c` unconditionally computes a `next_value` one greater than the value it holds, and `Floor` names the last enumerator, so `next_value` falls outside the enumeration. Rounding with `std::ceil`/`std::floor` and converting with `boost::numeric_cast` afterwards names no policy at all, and keeps the range check.

### Testing

Built and run on Windows (MSVC 2022) against both Qt6 and Qt5, with the ANSI code page set to 1252 so that the CJK characters below cannot be represented in `argv`. Against a directory named `测试-Ünïcode`, both builds behave identically:

| Invocation | Before | After |
| --- | --- | --- |
| `gplates --config-file "…\测试-Ünïcode\配置.cfg" --version` | error opening config file | version printed, exit 0 |
| `gplates --config-file … "@…\测试-Ünïcode\応答.rsp"` (response file contains `--version`) | error opening response file | version printed, exit 0 |
| `gplates "@…\测试-Ünïcode\応答.rsp"` (as the *first* argument) | rejected as an unrecognised command | version printed, exit 0 |
| `gplates "…\测试-Ünïcode\地形.gpml" --version` | first argument not recognised as an existing file | recognised, exit 0 |
| `gplates "…\测试-Ünïcode\@地形.gpml" --version` (a `@`-named file, path-qualified) | first argument not recognised as an existing file | recognised, exit 0 |
| a config file that genuinely does not exist | — | still reports the error, exit 1, path readable on the console |

The non-Windows branch of `get_command_line_arguments()` has since been run as well, on Linux (Qt6, `C.UTF-8` locale), against a directory named `Ωディレクトリ-café` holding files named `rotátions-日本語-Ωμέγα.rot`, `volcánoes-火山.gpml` and so on — non-ASCII in both the directory and the filename. Every kind of filename argument was exercised:

| Invocation | Result |
| --- | --- |
| `equivalent-total-rotation -r <non-ASCII .rot>`, absolute and relative | same pole as the same file named by an ASCII path |
| `convert-file-format` writing `出力-rotátions-日本語-Ωμέγα-suffixé.rot` and `変換-volcánoes-火山.xy` | both written; the rotation file read back gives the same pole, which also exercises the `PlatesRotationFileProxy` re-read above — it stayed silent |
| non-ASCII positional `.gpml`, `--file` and `--project`, GUI (offscreen) | `strace` shows `openat` succeeding on the exact path bytes |
| non-ASCII `--response-file`, and `@filename`, whose contents name a non-ASCII path | both the response file and the file it names are opened |
| non-ASCII `--config-file` naming a non-ASCII rotation file | pole printed |
| any of the above naming a file that does not exist | the error reports the path intact, no mojibake |

That run is what turned up the `@filename` and local-encoding bullets above; both are fixed here, and the table was re-run afterwards.

`equivalent-total-rotation -r <non-ASCII .rot> -p 801 -t 100` prints the same pole as the same file named by an ASCII path, with and without a `-style fusion` argument, on both Qt6 and Qt5 - which also confirms that `QCoreApplication::arguments()` on Windows returns the wide command-line rather than the mangled `argv`.

ASCII behaviour is unchanged: `--help`, `--version`, `reconstruct --bogus` and `--bogus` (unrecognised option errors), and `equivalent-total-rotation` with a missing required option all behave as before. In particular the program name is not parsed as an option — the `std::vector<std::string>` overload of `command_line_parser`, unlike the `(argc, argv)` overload, does not skip it.

Compiled clean and linked under both Qt6 and Qt5 (no warnings): the changed files plus all seven translation units that include `CsvExport.h`, since that header no longer pulls in `<iostream>`/`<fstream>`. Both arms of the `QT_VERSION_CHECK` guard in `CsvExport.cc` are therefore compiled.

CSV export was then exercised through the GUI on Windows, on both the Qt6 and the Qt5 build, via `TotalReconstructionPolesDialog` — the only caller of `export_table_widget()`. With the Müller et al. (2022) rotation file loaded and the reconstruction time set to 100 Ma, *Reconstruction → View Total Reconstruction Poles → Equivalent Rotations → Export…* wrote `輸出.csv` into the `测试-Ünïcode` directory. Before this change that failed with an error dialog reading *"Error writing to file '…': ios_base::failbit set"*, since `std::ofstream::open()` could not open the ANSI-mangled path and the `badbit`/`failbit` exception mask turned that into an exception.

Exporting to a path that cannot be written (`C:\Windows\System32\test.csv`) reports *"Error opening file '…' for writing"*, with no call stack trace in the dialog — that is the separate `ErrorOpeningFileForWritingException` catch clause; letting it reach the `std::exception` handler would have put `Exception::what()`, trace and all, into the message box.

Both halves are now covered by unit tests as well, which CTest runs on all three platforms — including Windows, where the paths in question are the ones that were broken:

- `CsvExportTest` — `export_data()` needs no dialog, so the test can call it directly. It exports to a filename that is non-ASCII in both the directory and the file component, and compares the file byte for byte: the encoding is as much a part of the contract as the path is, and `QIODevice::Text` is what keeps the platform line ending. A second test pins the quoting rules, since `export_line()` changed signature to `QTextStream`.
- `CommandLineParserTest` — `parse_command_line_options()` takes a `QStringList`, so it can be handed any arguments on any platform. Non-ASCII values survive the UTF-8 round trip (as an option value and as a positional one), a response file and a config file are read when their own *name* is non-ASCII, and the program name is not parsed as an option.

Both were checked against mutations rather than merely run: setting the CSV encoding to Latin-1 fails `exports_to_a_non_ascii_path`, and parsing the arguments from index 0 instead of 1 fails all four parser tests. The non-ASCII names are created at run time in a `QTemporaryDir` rather than committed, since a filename is not stored identically by every filesystem, and the non-ASCII literals are written as explicit UTF-8 bytes because the build passes no `/utf-8` to MSVC.

`get_command_line_arguments()` itself is not unit-tested: on Windows it deliberately ignores `argv` and asks the OS for the real command-line, so a test that passed it synthetic arguments would be handed the test runner's own.

Not exercised: the UTF-8 codec half of the `CsvExport` change. Every cell in these tables is a plate ID or a number, and ASCII bytes are identical under UTF-8 and the locale codec, so the guard is unobservable there — it only matters where the *cell contents* are non-ASCII, which in practice means the co-registration data table. It is there to keep Qt5 from silently changing the encoding of exported files, so "the exported bytes are unchanged" is all it has to achieve. `CsvExportTest` does put non-ASCII text in the cells and compares the exported bytes, so dropping the explicit encoding is caught there — switching it to Latin-1 fails that test. CI builds Qt6, whose `QTextStream` already defaults to UTF-8, so it is a Qt5 build that the guard itself is for.


