### PR TITLE
Windows wheels: Ninja and a measured compiler cache

### DIFF
--- a/.github/workflows/build-wheel-images.yml
+++ b/.github/workflows/build-wheel-images.yml
@@ -63,6 +63,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Check the Python version lists agree
+        # The dockerfile builds a Boost.Python library for each version in 'versions.sh' - do
+        # not publish an image whose version list has drifted from the authoritative 'build'
+        # list in 'pyproject.toml' (Linux wheel builds against such an image fail much later,
+        # with a linker error naming Boost). This workflow runs on pushes that touch
+        # 'versions.sh', which the equivalent check in 'build-wheels.yml' never sees.
+        run: python3 pygplates/wheel/check_python_versions.py
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,8 +8,9 @@
 # (including how to build a wheel locally).
 #
 # Full runs (every Python version) happen on release tags and manual dispatch. A pull request
-# that touches the wheel machinery instead builds a single Python version per platform - enough
-# to prove the machinery works without spending six builds' worth of runner time.
+# that touches the wheel machinery instead builds two Python versions per platform - enough to
+# prove the machinery works, and to show the compiler cache carrying from the first version to
+# the second, without spending six builds' worth of runner time.
 #
 # The sdist is built here too: it's what PyPI users without a matching wheel fall back to,
 # and it's what the conda-forge feedstock pulls. A future publish workflow uploads these
@@ -29,8 +30,11 @@ on:
       # PROJ and GDAL data among it - and the wheels once shipped without that data because nothing
       # here ran when it changed. The whole directory rather than that one file, so the next thing
       # to move between these files does not quietly fall outside the list again; changes under
-      # 'cmake/' are rare enough that the occasional extra smoke run costs little.
+      # 'cmake/' are rare enough that the occasional extra smoke run costs little. The root
+      # CMakeLists.txt is in the same position: it carries wheel-affecting configuration (the
+      # conda detection, the sccache SYSTEM-include override).
       - cmake/**
+      - CMakeLists.txt
   workflow_dispatch:
 
 # Superseded runs are cancelled rather than left to finish (a full wheel matrix takes hours).
@@ -48,6 +52,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Check the Python version lists agree
+        # A mismatch means Linux wheel builds fail much later with a Boost linker error - the
+        # script's header has the full story. Checked here, in the job every run starts with
+        # (the wheel matrix 'needs' this job, so a mismatch stops it before the multi-hour
+        # builds start); 'build-wheel-images.yml' runs the same check before publishing images.
+        run: python3 pygplates/wheel/check_python_versions.py
+
       - name: Build sdist
         run: pipx run build --sdist
 
@@ -62,15 +73,47 @@ jobs:
 
   build-wheels:
     name: wheels ${{ matrix.id }}
+    # So a version-list mismatch (or an sdist that will not even build) is caught before hours
+    # of wheel builds start. The sdist job takes under a minute.
+    needs: build-sdist
     runs-on: ${{ matrix.os }}
-    # A full run is six Python versions: the first compiles pyGPlates from scratch (~40
-    # minutes) and the rest mostly hit the sccache populated by the first.
-    timeout-minutes: 360
+    # A full run is six Python versions: the first compiles pyGPlates from scratch and the rest
+    # reuse about 90% of its object files from the compiler cache (measured - only the ~100
+    # sources that include Python's own headers really differ between versions).
+    #
+    # The worst case is a fully cold run on the slowest platform (Windows): ~64 minutes building
+    # the dependencies, ~63 minutes compiling the first wheel from scratch, then ~23 minutes per
+    # remaining wheel - about 4.5 hours in all (measured, 2026-08). So this limit is not expected
+    # to trip; hitting it means something is broken (a hung build, or compile times have
+    # genuinely grown). It sits deliberately below GitHub's hard 6-hour kill so that on a timeout
+    # the 'always()' steps below still get a window to salvage the run's work: the dependency
+    # cache is saved (the retry then starts warm) and the wheels already built are uploaded.
+    #
+    # If the arithmetic ever creeps toward the ceiling (eg, many more sources come to include
+    # Python.h, eroding the ~90% compiler-cache reuse), the fallback is to build the dependencies
+    # in an explicit step with the cache saved immediately after, before the cibuildwheel step
+    # ('before-all' then no-ops on the prefix's stamps) - that guarantees the dependencies
+    # survive any mid-wheels death without relying on the post-timeout grace window.
+    timeout-minutes: 330
+
+    defaults:
+      run:
+        # bash on every platform - including Windows, whose default is pwsh. In pwsh,
+        # "$GITHUB_ENV" and "$GITHUB_OUTPUT" name (undefined) pwsh variables rather than the
+        # environment variables, so 'echo ... >> "$GITHUB_ENV"' appends to nowhere and reports
+        # success - a silent trap for any cross-platform step added later. One shell also keeps
+        # every step below to one syntax on all five runners.
+        shell: bash
 
     strategy:
       # Run every platform to completion, so one platform failing still reports the others.
       fail-fast: false
       matrix:
+        # 'deps-path' is where the dependency libraries are built and cached, spelled once here
+        # for every step that names it (a second spelling that drifted would fail silently - eg,
+        # the completeness check below never finding its stamp and every run re-saving the
+        # multi-gigabyte cache). The Linux entries have none: their dependencies live in the
+        # GHCR images, and every deps step is gated on runner.os != 'Linux'.
         include:
           - id: linux-x86_64
             os: ubuntu-24.04
@@ -81,8 +124,16 @@ jobs:
           # wheels target the macOS 11 of MACOSX_DEPLOYMENT_TARGET in pyproject.toml.
           - id: macos-x86_64
             os: macos-15-intel
+            deps-path: ~/pygplates-wheel-deps
           - id: macos-arm64
             os: macos-14
+            deps-path: ~/pygplates-wheel-deps
+          # Visual Studio 2022 (windows-latest has moved on to VS 2026, which nothing here has
+          # been built against). The deps path is the 'C:/' form: git-bash and actions/cache
+          # both accept it, so one spelling serves every step.
+          - id: windows-x64
+            os: windows-2022
+            deps-path: C:/pygplates-wheel-deps
 
     steps:
       - name: Check out repository
@@ -100,48 +151,62 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute the dependency-libraries cache key
-        # The macOS dependency libraries are built by cibuildwheel's 'before-all' hook
-        # ('pygplates/wheel/build_macos_deps.sh') straight onto the runner - caching its
-        # output directory reduces that to about a minute on later runs. The key hashes the
-        # version pins and the dependency-building scripts (so bumping a dependency rebuilds
-        # the cache) and includes the deployment target from 'pyproject.toml' (the
-        # dependencies are compiled against it, so changing it must not reuse dylibs compiled
-        # for the old target). (The Linux dependencies live in the GHCR images instead, at no
-        # cache cost.)
-        if: runner.os == 'macOS'
+        # The macOS and Windows dependency libraries are built by cibuildwheel's 'before-all'
+        # hook ('pygplates/wheel/build_macos_deps.sh', 'build_windows_deps.sh') straight onto the
+        # runner - caching its output directory reduces that to about a minute on later runs. The
+        # key hashes the version pins and the dependency-building scripts, so bumping a dependency
+        # rebuilds the cache. macOS adds the deployment target from 'pyproject.toml' (the
+        # dependencies are compiled against it, so changing it must not reuse dylibs built for the
+        # old target); Windows adds 'vcpkg.json', which pins the vcpkg baseline that fixes the
+        # versions of the libraries vcpkg supplies. (The Linux dependencies live in the GHCR
+        # images instead, at no cache cost.)
+        if: runner.os != 'Linux'
         id: deps-cache-key
         run: |
-          target=$(sed -n 's/^MACOSX_DEPLOYMENT_TARGET *= *"\([^"]*\)".*/\1/p' pyproject.toml)
-          [ -n "${target}" ] # fail here if the pyproject.toml line was reformatted
-          echo "key=pygplates-wheel-deps-${{ matrix.id }}-target${target}-${{ hashFiles('pygplates/wheel/versions.sh', 'pygplates/wheel/build_macos_deps.sh', 'pygplates/wheel/build_boost_python.sh') }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ runner.os }}" = macOS ]; then
+              target=$(sed -n 's/^MACOSX_DEPLOYMENT_TARGET *= *"\([^"]*\)".*/\1/p' pyproject.toml)
+              [ -n "${target}" ] # fail here if the pyproject.toml line was reformatted
+              key=pygplates-wheel-deps-${{ matrix.id }}-target${target}-${{ hashFiles('pygplates/wheel/versions.sh', 'pygplates/wheel/build_macos_deps.sh', 'pygplates/wheel/build_boost_python.sh') }}
+          else
+              key=pygplates-wheel-deps-${{ matrix.id }}-${{ hashFiles('pygplates/wheel/versions.sh', 'pygplates/wheel/vcpkg.json', 'pygplates/wheel/build_windows_deps.sh', 'pygplates/wheel/build_boost_python.sh', 'pygplates/wheel/msvc_env.sh') }}
+          fi
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Restore the dependency-libraries cache
         # The primary key never hits (it ends in this run's unique id) - the 'restore-keys'
         # prefix restores the most recent cache for the computed key instead. That is what
         # lets an incomplete cache saved by a failed run be *completed*: saved cache keys are
         # immutable, so finishing the prefix off needs a fresh save under a fresh key.
-        if: runner.os == 'macOS'
+        if: runner.os != 'Linux'
         id: restore-deps-cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/pygplates-wheel-deps
+          path: ${{ matrix.deps-path }}
           key: ${{ steps.deps-cache-key.outputs.key }}-${{ github.run_id }}
           restore-keys: ${{ steps.deps-cache-key.outputs.key }}-
 
       - name: Check whether the restored dependencies are complete
-        # 'build_macos_deps.sh' stamps the prefix once everything is built and checked. If the
+        # The dependency scripts stamp the prefix once everything is built and checked. If the
         # stamp was already present when restored, this run has nothing to add and the save
         # step below is skipped - re-saving an identical multi-gigabyte cache every run would
         # evict more useful caches from the repository's 10 GB budget.
-        if: runner.os == 'macOS'
+        if: runner.os != 'Linux'
         id: deps-complete
-        run: echo "complete=$([ -f ~/pygplates-wheel-deps/stamps/complete ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        # The assignment is unquoted so the '~' in the macOS path still tilde-expands.
+        run: |
+          deps=${{ matrix.deps-path }}
+          echo "complete=$([ -f "${deps}/stamps/complete" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
-      - name: Limit pull request runs to a single Python version
+      - name: Limit pull request runs to two Python versions
         # A smoke test of the wheel machinery, not a release build. Setting CIBW_BUILD here
         # overrides the 'build' list in pyproject.toml for this run only.
+        #
+        # Two versions rather than one because everything a full run relies on to stay inside
+        # its time limit happens on the *second*: the first compiles pyGPlates from scratch and
+        # the rest are meant to come mostly from the compiler cache. One version never exercises
+        # that, so the 'before-test' cache report in pyproject.toml would have nothing to show.
         if: github.event_name == 'pull_request'
-        run: echo "CIBW_BUILD=cp313-*" >> "$GITHUB_ENV"
+        run: echo "CIBW_BUILD=cp312-* cp313-*" >> "$GITHUB_ENV"
 
       - name: Enable crash reporting
         # The runner images ship with the ReportCrash agent unloaded - reload it so a crashing
@@ -150,6 +215,41 @@ jobs:
         run: |
           launchctl load -w /System/Library/LaunchAgents/com.apple.ReportCrash.plist 2>/dev/null || true
           sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.ReportCrash.Root.plist 2>/dev/null || true
+
+      - name: Set up the MSVC environment
+        # The Windows wheels are built with Ninja (see CMAKE_GENERATOR in 'pyproject.toml'), which
+        # compiles with whatever 'cl' the environment provides - and cibuildwheel builds each
+        # wheel's environment from this job's. 'msvc_env.sh' is the same importer the dependency
+        # scripts use; here its results are handed back to the job, so the step below inherits
+        # them. (Locally the equivalent is starting from an "x64 Native Tools Command Prompt".)
+        if: runner.os == 'Windows'
+        run: |
+          path_before=${PATH}
+          . pygplates/wheel/msvc_env.sh
+          # The variables the compiler and the linker read - named by MSVC_ENV_VARS so that
+          # 'msvc_env.sh' and this step always hand over the same set. Already Windows paths.
+          for name in ${MSVC_ENV_VARS}; do
+              value=${!name:-}
+              if [ -n "${value}" ]; then
+                  echo "${name}=${value}" >> "$GITHUB_ENV"
+              fi
+          done
+          # PATH is this shell's, in Unix form - so hand back only what vcvarsall added to it,
+          # converted to the Windows form the rest of the job needs. Written back in *reverse*:
+          # the runner prepends each GITHUB_PATH line in turn, so the last line written ends up
+          # first on PATH - reversing here preserves vcvarsall's own ordering.
+          added=()
+          IFS=:
+          for entry in ${PATH}; do
+              case ":${path_before}:" in
+                  *":${entry}:"*) ;;
+                  *) added+=("${entry}") ;;
+              esac
+          done
+          unset IFS
+          for ((i = ${#added[@]} - 1; i >= 0; i--)); do
+              cygpath --windows "${added[i]}" >> "$GITHUB_PATH"
+          done
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0
@@ -189,151 +289,21 @@ jobs:
         # idempotent, so a partially-built cache is picked up where it left off) and, because
         # its own save key is fresh, can save the completed prefix. Skipped only when this
         # run restored an already-complete prefix and so has nothing new to save.
-        if: always() && runner.os == 'macOS' && steps.deps-complete.outputs.complete != 'true'
+        if: always() && runner.os != 'Linux' && steps.deps-complete.outputs.complete != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ~/pygplates-wheel-deps
+          path: ${{ matrix.deps-path }}
           key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}
 
       - name: Upload wheels
+        # 'always()' so the wheels already built and repaired survive a later version failing
+        # (or the job timing out) - a full run is six sequential builds, and losing five good
+        # wheels to a test flake on the sixth would force the whole job to run again.
+        # 'if-no-files-found: ignore' keeps the step green when the failure came before any
+        # wheel finished.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.id }}
           path: wheelhouse/*.whl
-
-  # Windows is built by its own pair of jobs rather than as another entry in the matrix above.
-  #
-  # The reason is that Windows has no compiler cache: pyGPlates is built with the Visual Studio
-  # generator (see 'pyproject.toml' for why), which ignores the sccache launchers that make the
-  # second and later Python versions cheap on Linux and macOS. A cold pyGPlates build takes about
-  # an hour here, so building six of them in one job would run past the six-hour ceiling GitHub
-  # puts on a job. Each Python version therefore gets a job of its own, and they run in parallel.
-  #
-  # That in turn is why the dependency libraries are built by a separate job first: six wheel jobs
-  # starting at once would otherwise each build the same dependencies, and then race to save the
-  # same cache.
-  build-windows-deps:
-    name: windows deps
-    runs-on: windows-2022
-    timeout-minutes: 180
-
-    outputs:
-      # The dependency cache key, so the wheel jobs restore what this job saved without having to
-      # repeat the recipe for computing it.
-      cache-key: ${{ steps.deps-cache-key.outputs.key }}
-      # The Python versions to build wheels for, as cibuildwheel build selectors.
-      builds: ${{ steps.builds.outputs.builds }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Compute the dependency-libraries cache key
-        # As on macOS: the key hashes the version pins and the dependency-building scripts, so
-        # bumping a dependency rebuilds the cache. There is no deployment target to include here,
-        # but there is 'vcpkg.json' - it pins the vcpkg baseline, which is what fixes the versions
-        # of the libraries vcpkg supplies.
-        id: deps-cache-key
-        shell: bash
-        run: echo "key=pygplates-wheel-deps-windows-x64-${{ hashFiles('pygplates/wheel/versions.sh', 'pygplates/wheel/vcpkg.json', 'pygplates/wheel/build_windows_deps.sh', 'pygplates/wheel/build_boost_python.sh', 'pygplates/wheel/msvc_env.sh') }}" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the dependency-libraries cache
-        # The primary key never hits (it ends in this run's unique id) - the 'restore-keys' prefix
-        # restores the most recent cache for the computed key instead. That is what lets an
-        # incomplete cache saved by a failed run be *completed*: saved cache keys are immutable,
-        # so finishing the prefix off needs a fresh save under a fresh key.
-        id: restore-deps-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: C:/pygplates-wheel-deps
-          key: ${{ steps.deps-cache-key.outputs.key }}-${{ github.run_id }}
-          restore-keys: ${{ steps.deps-cache-key.outputs.key }}-
-
-      - name: Check whether the restored dependencies are complete
-        # 'build_windows_deps.sh' stamps the prefix once everything is built and checked. If the
-        # stamp was already present when restored, this run has nothing to add and the save step
-        # below is skipped - re-saving an identical multi-gigabyte cache every run would evict
-        # more useful caches from the repository's 10 GB budget.
-        id: deps-complete
-        shell: bash
-        run: echo "complete=$([ -f /c/pygplates-wheel-deps/stamps/complete ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-
-      - name: Build the dependency libraries
-        # Normally cibuildwheel's 'before-all' hook runs this, and still does in the wheel jobs
-        # below - where it finds everything stamped and only re-runs its sanity checks. Running it
-        # here as well is what gets the dependencies built once rather than once per wheel job.
-        if: steps.deps-complete.outputs.complete != 'true'
-        shell: bash
-        run: bash pygplates/wheel/build_windows_deps.sh
-        env:
-          PYGPLATES_DEPS: C:/pygplates-wheel-deps
-
-      - name: Save the dependency-libraries cache
-        # Saved explicitly (rather than by actions/cache's success-only post step) so that
-        # dependencies built by a *failed* run are still cached - the next attempt then resumes
-        # from them instead of rebuilding ('build_windows_deps.sh' is idempotent, so a partially
-        # built prefix is picked up where it left off) and, because its own save key is fresh, can
-        # save the completed prefix.
-        if: always() && steps.deps-complete.outputs.complete != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: C:/pygplates-wheel-deps
-          key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}
-
-      - name: List the Python versions to build
-        # A pull request builds a single Python version - a smoke test of the wheel machinery,
-        # not a release build. Everything else builds the versions in 'versions.sh' (which the
-        # 'build' list in 'pyproject.toml' is kept in step with).
-        id: builds
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = pull_request ]; then
-            python_versions=3.13
-          else
-            . pygplates/wheel/versions.sh
-            python_versions=${PYTHON_VERSIONS}
-          fi
-          builds=
-          for python_version in ${python_versions}; do
-            builds="${builds}${builds:+,}\"cp${python_version/./}\""
-          done
-          echo "builds=[${builds}]" >> "$GITHUB_OUTPUT"
-
-  build-windows-wheels:
-    name: wheels windows-x64 ${{ matrix.build }}
-    needs: build-windows-deps
-    runs-on: windows-2022
-    # A single Python version, from a cold compiler: about an hour, with room for a dependency
-    # build if the cache went missing between the job above and this one.
-    timeout-minutes: 240
-
-    strategy:
-      # Run every Python version to completion, so one failing still reports the others.
-      fail-fast: false
-      matrix:
-        build: ${{ fromJSON(needs.build-windows-deps.outputs.builds) }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Restore the dependency-libraries cache
-        # Read-only: the job above is what builds and saves this cache. (If it is missing anyway,
-        # cibuildwheel's 'before-all' hook builds the dependencies in this job instead.)
-        uses: actions/cache/restore@v4
-        with:
-          path: C:/pygplates-wheel-deps
-          key: ${{ needs.build-windows-deps.outputs.cache-key }}-${{ github.run_id }}
-          restore-keys: ${{ needs.build-windows-deps.outputs.cache-key }}-
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v4.2.0
-        env:
-          # This job's Python version. Overrides the 'build' list in 'pyproject.toml'.
-          CIBW_BUILD: ${{ matrix.build }}-*
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-x64-${{ matrix.build }}
-          path: wheelhouse/*.whl
+          if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,31 @@ else()
             LANGUAGES C CXX)
 endif()
 
+# When compiling MSVC through sccache, pass SYSTEM include directories as plain '-I' rather than
+# letting CMake use '-external:I' (which it does for MSVC >= 19.29, see Modules/Compiler/MSVC.cmake).
+#
+# The difference matters only to the cache. sccache hashes a compilation as its preprocessed
+# output plus the flags that affect code generation; '-I' is neither (its effect is already in the
+# preprocessed output), but '-external:I <dir>' is hashed as an opaque flag - so when a SYSTEM
+# include directory's *path* varies while its *contents* do not, every object misses for no
+# reason. That is exactly what the wheel builds do: cibuildwheel installs each Python version
+# (and its NumPy) under a path of its own, so with '-external:I' the second Python version reused
+# nothing, and with '-I' it reuses ~90% (matching Linux and macOS, whose '-isystem' sccache
+# likewise resolves through the preprocessed output).
+#
+# The cost is that MSVC warnings from dependency headers (Qt, Boost, CGAL...) reappear at /W3 in
+# sccache builds, since nothing is marked external any more ('-external:W0' suppressed them).
+#
+# A normal 'set()' deliberately shadowing the value from CMake's compiler module - which runs at
+# 'project()' above, so this must come after it. Scoped to wheel builds (SKBUILD is defined by
+# scikit-build-core) using sccache: the conda CI also compiles MSVC through sccache, but its
+# include paths never move between runs, so it loses nothing to '-external:I' and keeps the
+# quieter logs - as do plain developer builds.
+if (SKBUILD AND MSVC AND CMAKE_CXX_COMPILER_LAUNCHER MATCHES "sccache")
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-I")
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-I")
+endif()
+
 # Enable testing of GPlates (the 'gplates-unit-test' executable) or pyGPlates (the Python test suite),
 # either via running 'ctest', or 'make test', or building 'RUN_TESTS' in Visual Studio.
 enable_testing()

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -16,7 +16,7 @@ The pieces fit together like this:
 | `build_macos_deps.sh` (this directory) | Builds the pyGPlates dependency libraries on macOS (run automatically by cibuildwheel, once per machine; cached in CI). |
 | `build_windows_deps.sh` (this directory) | The same on Windows. |
 | `vcpkg.json` (this directory) | The subset of the Windows dependency libraries that vcpkg supplies, and the vcpkg baseline that pins their versions. |
-| `msvc_env.sh` (this directory) | Puts the MSVC toolchain into the environment of the two Windows scripts above (they build with `b2` and `nmake`, which cannot find Visual Studio for themselves). |
+| `msvc_env.sh` (this directory) | Puts the MSVC toolchain into the environment: the two Windows scripts above source it (they build with `b2` and `nmake`, which cannot find Visual Studio for themselves), and the CI job runs it to set up the environment Ninja compiles in. |
 | `build_boost_python.sh` (this directory) | Builds Boost.Python against each wheel's Python version, on macOS and Windows (run automatically by cibuildwheel before each wheel build). |
 | `check_wheel_contents.py` (this directory) | Checks each repaired wheel carries the data PROJ and GDAL read at run time (run automatically by cibuildwheel, after the test suite). |
 | `.github/workflows/build-wheel-images.yml` | Builds the Docker images (natively, per architecture) and pushes them to GHCR. |
@@ -46,7 +46,9 @@ an hour - later runs reuse them; see the macOS section below). Xcode command lin
 On Windows, the first run builds them into `C:\pygplates-wheel-deps` (see the Windows section
 below), and Visual Studio 2022 - or its Build Tools - with the C++ x64 toolset, Git for Windows
 (which provides the `bash` those scripts are written for), Python and CMake must be installed.
-No developer command prompt is needed: an ordinary one will do.
+Start it from an **"x64 Native Tools Command Prompt for VS 2022"**: the wheels are built with
+Ninja, which compiles with whatever `cl` the environment provides, and neither cibuildwheel nor
+scikit-build-core sets that environment up (see "Ninja and the compiler cache" below).
 
 ## The Linux dependency image
 
@@ -148,8 +150,9 @@ Studio for itself. Both scripts therefore source `msvc_env.sh`, which runs `vcva
 cmd shell and imports the environment it produces. That is what lets them run under cibuildwheel,
 whose hooks run in a plain cmd shell, instead of requiring an "x64 Native Tools Command Prompt".
 
-In CI the prefix is cached the same way as on macOS, but it is built by a job of its own - see
-the Windows part of "Why the wheels are configured the way they are" below for why.
+In CI the prefix is cached exactly as on macOS. The CI job does not run from a developer command
+prompt either - it imports the same environment with `msvc_env.sh` before running cibuildwheel,
+which is the one thing a local build has to arrange for itself.
 
 ## Why the wheels are configured the way they are
 
@@ -267,22 +270,39 @@ wheels are covered either way.
 That much covers the causes the build can see. `check_wheel_contents.py` covers the rest of the
 path, since the data still has to survive installation and the repair step to reach the user.
 
-### The Visual Studio generator, and a job per Python version (Windows)
+### Ninja and the compiler cache (Windows)
 
-pyGPlates is built with the `Visual Studio 17 2022` generator (`CMAKE_GENERATOR` in
-`[tool.cibuildwheel.windows.environment]`), because that generator locates the compiler itself.
-The Ninja generator scikit-build-core would otherwise use needs the MSVC environment to be set up
-*before* cibuildwheel starts, which neither cibuildwheel nor scikit-build-core does - so every
-local wheel build would have to be started from a developer command prompt.
+pyGPlates is built with Ninja on every platform, Windows included (`CMAKE_GENERATOR` in
+`[tool.cibuildwheel.windows.environment]`). The Visual Studio generator would locate the compiler
+by itself, which is convenient, but it ignores `CMAKE_<LANG>_COMPILER_LAUNCHER` - so there would
+be no compiler cache, and each of the six Python versions would pay a full compile of about an
+hour.
 
-The price is that Windows gets no compiler cache. `CMAKE_<LANG>_COMPILER_LAUNCHER` - what points
-the Linux and macOS builds at sccache, and what makes the second and later Python versions there
-cheap - is ignored by the Visual Studio generator. A cold pyGPlates build takes about an hour on
-a runner, so building six of them in one job would run past the six-hour ceiling GitHub puts on a
-job. `.github/workflows/build-wheels.yml` therefore gives each Python version a job of its own
-(they run in parallel), and builds the dependency libraries in a separate job before them - since
-six wheel jobs would otherwise each build the same dependencies and then race to save the same
-cache.
+What Ninja costs is that it compiles with whatever `cl` the environment provides, and neither
+cibuildwheel nor scikit-build-core arranges one (scikit-build-core sets the MSVC environment up
+only for "Visual Studio" generators). So a local wheel build must be started from an "x64 Native
+Tools Command Prompt for VS 2022", and the CI job imports the same environment with `msvc_env.sh`
+before running cibuildwheel. The dependency scripts are unaffected either way - they source
+`msvc_env.sh` themselves, because as cibuildwheel hooks they cannot set up the environment of the
+process that runs them.
+
+Ninja also means CMake has to *find* a compiler, rather than being told one by the generator - and
+what it finds on a machine with Visual Studio installed is the LLVM that Visual Studio bundles, in
+`VC/Tools/Llvm`. So the wheel would be built with clang against a Qt, Boost and vcpkg stack built
+with MSVC. `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` in the `config-settings` therefore name `cl`.
+
+The cache earns it. Only about a hundred of the thousand-odd sources include Python's own
+headers, so the second and later Python versions reuse around 90% of the first's object files -
+measured on Linux and macOS, where the same arrangement cut the second wheel from 33 to 14
+minutes. Windows is therefore one job per platform like everything else, rather than a
+dependency job followed by one wheel job per Python version.
+
+For that reuse to happen at all, every Python version must build in the *same* directory: sccache
+keys on preprocessor output, which names the path of every header included, so a per-version
+build directory makes each source that includes a generated header (`config.h`, Qt's moc and ui
+output) hash differently for no reason. Hence `build-dir` in the cibuildwheel `config-settings`,
+together with the `before-build` that empties it - the emptying is what keeps a shared directory
+from also being an incremental build across Python versions.
 
 ### `delvewheel --add-path` (Windows)
 
@@ -305,7 +325,7 @@ NumPy wheels is not usable anyway). To add or remove a version:
 1. Update the `build` list in `[tool.cibuildwheel]` in `pyproject.toml`
    (and `requires-python`/classifiers in `[project]` if the floor changed).
 2. Update `PYTHON_VERSIONS` in `versions.sh` to match, and rebuild the Linux images
-   (a push of the change rebuilds them automatically). `PYTHON_VERSIONS` is also what the
-   per-version Windows wheel jobs are generated from.
-   (macOS needs no equivalent step: `build_boost_python.sh` builds Boost.Python for whatever
-   Python version each wheel build brings.)
+   (a push of the change rebuilds them automatically). The `sdist` job fails if the two lists
+   disagree, so this cannot be forgotten quietly.
+   (macOS and Windows need no equivalent step: `build_boost_python.sh` builds Boost.Python for
+   whatever Python version each wheel build brings.)

--- a/pygplates/wheel/build_windows_deps.sh
+++ b/pygplates/wheel/build_windows_deps.sh
@@ -37,9 +37,13 @@
 # invokes it as 'bash ...'), and python and cmake on PATH. All are present on the GitHub Windows
 # runners.
 #
-# Note: there is no sccache here, unlike the Linux and macOS builds. The Visual Studio generator
-#       ignores CMAKE_<LANG>_COMPILER_LAUNCHER, so the wheel builds cannot use a compiler cache;
-#       the CI workflow builds each Python version in its own parallel job instead.
+# The wheel builds compile through sccache, as on Linux and macOS - which is why they are built
+# with Ninja rather than the Visual Studio generator (that one ignores
+# CMAKE_<LANG>_COMPILER_LAUNCHER). Ninja needs the MSVC environment set up before CMake runs, and
+# cibuildwheel cannot do that from 'pyproject.toml', so a *local* wheel build has to be started
+# from an "x64 Native Tools Command Prompt for VS 2022". This script does not: it sets its own
+# environment up (see 'msvc_env.sh') so it runs from any shell - the CI workflow imports that
+# same file's results into its job, which is what its wheel builds compile with.
 
 set -e -u
 
@@ -95,6 +99,21 @@ cd "${PYGPLATES_DEPS}/src"
 # Each source-building step below removes any leftover source tree before starting: CI saves the
 # deps cache even when a build fails (see 'build-wheels.yml'), so a later run can find the
 # half-built tree of the step that failed - it restarts that step from a clean extraction.
+
+# sccache.
+#
+# Not used by this script - it is for the wheel builds: cibuildwheel builds pyGPlates once per
+# Python version, and the versions share all but the hundred or so sources that include Python's
+# own headers, so the later builds mostly reuse the objects of the first (measured at 90%).
+# Installed into the deps prefix, which 'pyproject.toml' puts on PATH.
+if [ ! -f "${PYGPLATES_DEPS}/stamps/sccache-${SCCACHE_VERSION}" ]; then
+    sccache_dir=sccache-v${SCCACHE_VERSION}-x86_64-pc-windows-msvc
+    rm -rf "${sccache_dir}"
+    curl -sSL https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${sccache_dir}.tar.gz | tar xz
+    install -m 755 "${sccache_dir}/sccache.exe" "${PYGPLATES_DEPS}/bin/sccache.exe"
+    rm -rf "${sccache_dir}"
+    touch "${PYGPLATES_DEPS}/stamps/sccache-${SCCACHE_VERSION}"
+fi
 
 # Qt (the official binaries, downloaded with aqtinstall - the same binaries the Qt online
 # installer provides, and the same ones the macOS deps script uses).
@@ -296,6 +315,31 @@ fi
 
 # Sanity-check the installs (fails the run if anything is missing).
 #
+# Through these three, rather than a bare 'test -f': that aborts the script under 'set -e' having
+# printed nothing at all, in the one section whose whole purpose is to fail where the cause is
+# visible.
+require_file() {
+    if [ ! -f "$1" ]; then
+        echo "error: $2 is missing from the dependency prefix ($1) - the build that installs it" >&2
+        echo "       either failed or installed it somewhere else." >&2
+        exit 1
+    fi
+}
+require_exe() {
+    if [ ! -x "$1" ]; then
+        echo "error: $2 is missing from the dependency prefix ($1) - the build that installs it" >&2
+        echo "       either failed or installed it somewhere else." >&2
+        exit 1
+    fi
+}
+require_dir() {
+    if [ ! -d "$1" ]; then
+        echo "error: $2 is missing from the dependency prefix ($1) - the build that installs it" >&2
+        echo "       either failed or installed it somewhere else." >&2
+        exit 1
+    fi
+}
+#
 # The vcpkg libraries are checked by their headers rather than their import libraries: a port
 # decides for itself what to call the library it installs (glew32.lib, proj_9.lib, ...), whereas
 # the header a dependent compiles against is the port's contract. The library directories are
@@ -307,20 +351,21 @@ ls "${QT_DIR}/bin/Qt6Core.dll" "${QT_DIR}/bin/Qt6Gui.dll" "${QT_DIR}/bin/Qt6Widg
     "${QT_DIR}/bin/Qt6Core5Compat.dll"
 ls "${PYGPLATES_DEPS}/lib/qwt.lib"
 ls "${PYGPLATES_DEPS}/lib/boost_program_options.lib" "${PYGPLATES_DEPS}/lib/boost_thread.lib"
-test -f "${VCPKG_PREFIX}/include/GL/glew.h"
-test -f "${VCPKG_PREFIX}/include/zlib.h"
-test -f "${VCPKG_PREFIX}/include/proj.h"
-test -f "${VCPKG_PREFIX}/include/gdal.h"
-test -f "${VCPKG_PREFIX}/include/gmp.h"
-test -f "${VCPKG_PREFIX}/include/mpfr.h"
+require_file "${VCPKG_PREFIX}/include/GL/glew.h" "GLEW"
+require_file "${VCPKG_PREFIX}/include/zlib.h" "zlib"
+require_file "${VCPKG_PREFIX}/include/proj.h" "PROJ"
+require_file "${VCPKG_PREFIX}/include/gdal.h" "GDAL"
+require_file "${VCPKG_PREFIX}/include/gmp.h" "GMP"
+require_file "${VCPKG_PREFIX}/include/mpfr.h" "MPFR"
 # PROJ and GDAL read these data directories at run time, and the wheel build copies both into
 # the wheel ('pyproject.toml' names them; cmake/modules/Install.cmake does the copying), so a
 # missing one has to fail here rather than produce a wheel that cannot resolve a coordinate
 # reference system. 'projinfo' is how the build asks PROJ where its data is.
-test -f "${VCPKG_PREFIX}/share/proj/proj.db"
-test -f "${VCPKG_PREFIX}/share/gdal/gdalvrt.xsd"
-test -x "${VCPKG_PREFIX}/tools/proj/projinfo.exe"
-test -d "${PYGPLATES_DEPS}/include/CGAL"
+require_file "${VCPKG_PREFIX}/share/proj/proj.db" "PROJ's data, which the wheel carries a copy of"
+require_file "${VCPKG_PREFIX}/share/gdal/gdalvrt.xsd" "GDAL's data, which the wheel carries a copy of"
+require_exe "${VCPKG_PREFIX}/tools/proj/projinfo.exe" "projinfo (the proj port's 'tools' feature), which the wheel build runs to find PROJ's data"
+require_dir "${PYGPLATES_DEPS}/include/CGAL" "CGAL"
+"${PYGPLATES_DEPS}/bin/sccache.exe" --version
 ls "${PYGPLATES_DEPS}/lib" "${VCPKG_PREFIX}/lib" "${VCPKG_PREFIX}/bin"
 
 # Mark the whole prefix built and checked. The CI cache-save step skips re-saving a prefix that

--- a/pygplates/wheel/check_python_versions.py
+++ b/pygplates/wheel/check_python_versions.py
@@ -1,0 +1,32 @@
+# Checks that the two lists of wheel Python versions agree:
+#
+#  - the 'build' list in '[tool.cibuildwheel]' in 'pyproject.toml' - the authoritative list,
+#    what cibuildwheel builds wheels for;
+#  - PYTHON_VERSIONS in 'pygplates/wheel/versions.sh', which repeats it for the Linux image
+#    ('manylinux_2_28.dockerfile' builds a Boost.Python library per version).
+#
+# Nothing else keeps the two in step, and a mismatch is quiet in the worst way: the image simply
+# lacks the library for a version, and the wheel build fails much later with a linker error
+# naming Boost. So the check runs everywhere a stale list could do damage: in
+# '.github/workflows/build-wheel-images.yml' before an image is built and published, and in
+# '.github/workflows/build-wheels.yml' (the sdist job, which gates the wheel matrix).
+#
+# Run from the repository root; exits non-zero on a mismatch. Needs Python >= 3.11 (tomllib).
+
+import pathlib
+import sys
+import tomllib
+
+build = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["tool"]["cibuildwheel"]["build"]
+wheels = [b[2] + "." + b[3:].split("-")[0] for b in build]   # "cp313-*" -> "3.13"
+
+line = next(l for l in pathlib.Path("pygplates/wheel/versions.sh").read_text().splitlines()
+            if l.startswith("PYTHON_VERSIONS="))
+image = line.split("=", 1)[1].strip().strip('"').split()
+
+if wheels != image:
+    print("error: the Python version lists disagree:", file=sys.stderr)
+    print("  pyproject.toml [tool.cibuildwheel] build:", " ".join(wheels), file=sys.stderr)
+    print("  versions.sh    PYTHON_VERSIONS         :", " ".join(image), file=sys.stderr)
+    sys.exit(1)
+print("Python versions:", " ".join(wheels))

--- a/pygplates/wheel/msvc_env.sh
+++ b/pygplates/wheel/msvc_env.sh
@@ -5,9 +5,12 @@
 #   . "$(dirname "$0")/msvc_env.sh"
 #
 # The Windows dependency builds need it because they are not CMake builds: Boost's b2 and Qwt's
-# qmake/nmake compile with whatever 'cl' the environment provides. (The pyGPlates wheel build
-# itself needs nothing from here - it is a CMake build with the Visual Studio generator, which
-# locates Visual Studio by itself.)
+# qmake/nmake compile with whatever 'cl' the environment provides. The pyGPlates wheel build
+# needs it too, since it moved from the Visual Studio generator (which locates Visual Studio by
+# itself) to Ninja (which does not) - but a cibuildwheel hook cannot set the environment for the
+# CMake build that follows it, so that comes from the shell cibuildwheel is started from: in CI
+# the workflow imports this file's results into the whole job (see 'build-wheels.yml'), and a
+# local wheel build starts from an "x64 Native Tools Command Prompt" instead.
 #
 # Visual Studio provides the environment as a batch file, 'vcvarsall.bat', which is only usable
 # from a cmd shell - so it is run in one, and the environment it produces is imported back into
@@ -16,8 +19,16 @@
 # hooks run in a plain cmd shell.
 #
 # Skipped when the environment is already set up (eg, when the scripts *are* run from a
-# developer command prompt, or when a wheel build's 'before-build' hook follows 'before-all'
-# in one already-configured shell).
+# developer command prompt, when the CI workflow set one up for Ninja before starting
+# cibuildwheel, or when a wheel build's 'before-build' hook follows 'before-all' in one
+# already-configured shell). Either way the environment is checked before this file returns.
+
+# The variables vcvarsall.bat sets that the builds actually read (besides PATH, which needs
+# per-shell translation and so is handled on its own below). One list, exported, so the CI
+# workflow's environment step hands the job exactly the set imported here - a second copy of
+# this list would drift silently (the workflow's export of VCINSTALLDIR makes this file's
+# import a no-op there, so its copy would be the one CI builds actually got).
+export MSVC_ENV_VARS="INCLUDE LIB LIBPATH UCRTVersion VCToolsVersion VSINSTALLDIR WindowsSdkDir WindowsSDKVersion VCINSTALLDIR VSCMD_ARG_TGT_ARCH"
 
 # ...but only if that environment targets x64, which is what everything built here is. An "x86
 # Native Tools Command Prompt" also sets VCINSTALLDIR, and taking it would build Boost and Qwt
@@ -76,17 +87,25 @@ if [ -z "${VCINSTALLDIR:-}" ]; then
         case "${_name}" in
             PATH)
                 export PATH="$(cygpath --unix --path "${_value}")" ;;
-            INCLUDE|LIB|LIBPATH|UCRTVersion|VCToolsVersion|VSINSTALLDIR|WindowsSdkDir|WindowsSDKVersion|VCINSTALLDIR|VSCMD_ARG_TGT_ARCH)
-                export "${_name}=${_value}" ;;
+            *)
+                # The space-padded 'case' is a containment test: import _name only if it is
+                # one of the MSVC_ENV_VARS words.
+                case " ${MSVC_ENV_VARS} " in
+                    *" ${_name} "*) export "${_name}=${_value}" ;;
+                esac ;;
         esac
     done < <(cd "${_vcvars_dir}" && cmd //c vcvars.bat | tr -d '\r')
 
     rm -rf "${_vcvars_dir}"
 
-    if ! command -v cl > /dev/null; then
-        echo "error: the MSVC environment was imported but 'cl' is still not on PATH" >&2
-        return 1
-    fi
-
     unset _vswhere _vs_install _vcvarsall _vcvars_dir _name _value
+fi
+
+# Outside the block above, so it checks the environment that was already there as well as the one
+# just imported. The CI workflow sets one up before running cibuildwheel (Ninja compiles with
+# whatever 'cl' it finds), and that path used to go entirely unverified - VCINSTALLDIR alone was
+# taken as proof of a working toolchain.
+if ! command -v cl > /dev/null; then
+    echo "error: the MSVC environment names a Visual Studio installation but 'cl' is not on PATH" >&2
+    return 1
 fi

--- a/pygplates/wheel/versions.sh
+++ b/pygplates/wheel/versions.sh
@@ -12,12 +12,12 @@
 # Keep this file to plain NAME=VALUE assignments and comments - it is sourced by /bin/sh in
 # the Docker build steps.
 
-# The Python versions to build Boost.Python for. Must match the 'build' list in
-# '[tool.cibuildwheel]' in 'pyproject.toml' (the authoritative list of wheel Python versions).
-# The Linux image builds a Boost.Python library for each of them, and the Windows wheel jobs
-# in '.github/workflows/build-wheels.yml' are generated from this list (one job per version).
-# macOS needs neither: 'build_boost_python.sh' builds Boost.Python for whatever Python version
-# each wheel build brings.
+# The Python versions to build Boost.Python for, in the Linux image - which is the only thing
+# that reads this. Must match the 'build' list in '[tool.cibuildwheel]' in 'pyproject.toml' (the
+# authoritative list of wheel Python versions); the sdist job in
+# '.github/workflows/build-wheels.yml' fails if the two ever disagree. macOS and Windows need no
+# such list: 'build_boost_python.sh' builds Boost.Python for whatever Python version each wheel
+# build brings.
 PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13 3.14"
 
 QT_VERSION=6.7.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,17 @@ Discussions = "https://discourse.gplates.org/"
 # Scikit-build-core minimum version required.
 minimum-version = "build-system.requires"
 
-# Optionally specify a build directory (uses temp dir by default).
-# This can give rebuild speedups (eg, during development).
+# Where CMake builds. Left at scikit-build-core's default, a fresh temporary directory each time,
+# so that a 'pip install .' from this source tree - the install route BUILD-Linux.md,
+# BUILD-macOS.md and BUILD-Windows.md all document - can never reuse a build tree left behind by
+# another Python version.
+#
+# Uncomment for rebuild speedups while developing, keeping the '{wheel_tag}' so that different
+# Python versions still get a tree each.
 #build-dir = "dist/build/{wheel_tag}"
+#
+# The wheel builds do share one directory across Python versions, deliberately and together with
+# the wipe that makes it safe - see [tool.cibuildwheel.config-settings] below.
 
 # Build target is 'pygplates'.
 build.targets = ["pygplates"]
@@ -224,6 +232,22 @@ test-command = [
 #       it entirely, so each platform table repeats this define.
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
 
+# Build every Python version in the one directory, overriding the temporary directory that
+# [tool.scikit-build] leaves everything else with.
+#
+# The compiler cache depends on it. sccache keys on the *preprocessor output*, which carries a
+# '# line "<path>"' marker for every header the translation unit includes - so when the generated
+# headers (config.h, and Qt's moc and ui output) sit in a different directory each time, every
+# source that includes one hashes differently and cannot be reused. Measured before this was
+# pinned: the second Python version reused 435 of 971 objects, on Linux and macOS alike.
+#
+# 'before-build' empties it, so this is not an incremental build across Python versions: the
+# objects are reused through the cache, which validates them by hashing what went into them,
+# rather than by leaving a build tree in place that CMake and Ninja must reason about after the
+# Python version underneath it changed. That pairing is why this is set here, with the wheel
+# builds that do the wiping, rather than as the default for every build of this project.
+"build-dir" = "build/wheel"
+
 [tool.cibuildwheel.linux]
 # Custom manylinux_2_28 images with the pyGPlates dependencies pre-installed - built and
 # pushed to GHCR by '.github/workflows/build-wheel-images.yml' from
@@ -231,9 +255,27 @@ test-command = [
 manylinux-x86_64-image = "ghcr.io/gplates/pygplates-manylinux_2_28_x86_64:latest"
 manylinux-aarch64-image = "ghcr.io/gplates/pygplates-manylinux_2_28_aarch64:latest"
 
+# Empty the build directory before each wheel build. The 'build-dir' in the config-settings below
+# points every Python version at one path, so the compiler cache can reuse objects across them;
+# wiping it keeps that from also being an incremental build, in which a stale object compiled
+# against another version's Python headers would be linked into a released wheel if CMake or Ninja
+# ever failed to notice.
+before-build = "rm -rf {project}/build/wheel"
+
+# Report the compiler cache after each wheel is built - cibuildwheel says nothing about it
+# otherwise, so the sccache defines below have never been shown to do anything.
+#
+# 'before-test' runs once per Python version, after that version's wheel is built and repaired.
+# The figures are cumulative over the cibuildwheel run, so what each version added is the
+# difference between successive reports - which is the measurement that matters here, since the
+# cache exists to make the *second and later* versions cheap. (Run inside the container, where
+# the compiling happens; the image installs sccache on the default PATH.)
+before-test = "sccache --show-stats"
+
 [tool.cibuildwheel.linux.config-settings]
-# See the note in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
+# See the notes in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
+"build-dir" = "build/wheel"
 # Link the LEGACY 'libGL' rather than the GLVND 'libOpenGL': auditwheel whitelists 'libGL'
 # (leaves it to come from the end user's system) but vendors 'libOpenGL' along with its
 # 'libGLdispatch' dependency into the wheel - and since Qt uses 'libGL' (which loads the
@@ -253,7 +295,15 @@ manylinux-aarch64-image = "ghcr.io/gplates/pygplates-manylinux_2_28_aarch64:late
 # dependency, so it's built by 'before-build' instead (which runs with each wheel build's
 # Python on PATH), into the same prefix.
 before-all = "bash {project}/pygplates/wheel/build_macos_deps.sh"
-before-build = "bash {project}/pygplates/wheel/build_boost_python.sh"
+# The wipe is for the same reason as on Linux (see the note there); the commands run in order.
+before-build = [
+    "rm -rf {project}/build/wheel",
+    "bash {project}/pygplates/wheel/build_boost_python.sh",
+]
+
+# Report the compiler cache after each wheel is built, as on Linux (see the note there). sccache
+# is on PATH from the dependency prefix, which the environment below puts there.
+before-test = "sccache --show-stats"
 
 [tool.cibuildwheel.macos.environment]
 # The oldest macOS the wheels support (it also determines the wheel tag, eg, macosx_11_0_arm64).
@@ -281,8 +331,9 @@ CMAKE_ARGS = "-DCMAKE_INSTALL_RPATH=$HOME/pygplates-wheel-deps/lib;$HOME/pygplat
 PATH = "$HOME/pygplates-wheel-deps/bin:$PATH"
 
 [tool.cibuildwheel.macos.config-settings]
-# See the note in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
+# See the notes in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
+"build-dir" = "build/wheel"
 # Prefer dylibs/headers over Apple frameworks when CMake searches - otherwise dependencies
 # like Python and zlib can resolve to a framework rather than the intended library. (The root
 # CMakeLists.txt only sets this for conda builds - a -D define beats its cache default.)
@@ -298,16 +349,26 @@ PATH = "$HOME/pygplates-wheel-deps/bin:$PATH"
 archs = ["AMD64"]
 
 # The dependency libraries are built once per machine into C:/pygplates-wheel-deps ('before-all'
-# runs once, before any wheel builds; in CI a separate job builds them and the wheel builds
-# restore them from a cache - see '.github/workflows/build-wheels.yml'). Boost.Python is the one
-# per-Python-version dependency, so it's built by 'before-build' instead (which runs with each
-# wheel build's Python on PATH), into the same prefix.
+# runs once, before any wheel builds; in CI the workflow caches that directory, so later runs
+# restore it in minutes and 'before-all' finds everything already stamped - see
+# '.github/workflows/build-wheels.yml'). Boost.Python is the one per-Python-version dependency,
+# so it's built by 'before-build' instead (which runs with each wheel build's Python on PATH),
+# into the same prefix.
 #
 # They are bash scripts (as on macOS) run through 'bash': cibuildwheel runs these hooks in a cmd
 # shell, and Git for Windows - which provides bash - is installed on any machine that cloned this
 # repository, and on the GitHub Windows runners.
 before-all = "bash {project}/pygplates/wheel/build_windows_deps.sh"
-before-build = "bash {project}/pygplates/wheel/build_boost_python.sh"
+# The wipe is for the same reason as on Linux (see the note there). Run through bash because these
+# hooks run in a cmd shell, which has no 'rm'.
+before-build = [
+    "bash -c \"rm -rf {project}/build/wheel\"",
+    "bash {project}/pygplates/wheel/build_boost_python.sh",
+]
+
+# Report the compiler cache after each wheel is built, as on Linux (see the note there). sccache
+# is on PATH from the dependency prefix, which the environment below puts there.
+before-test = "sccache --show-stats"
 
 # Windows has no rpath: a DLL records only its name, and is looked for in a list of directories.
 # So delvewheel is told where the dependency DLLs are - the deps prefix (Boost, which b2 installs
@@ -328,13 +389,21 @@ PYGPLATES_DEPS = "C:/pygplates-wheel-deps"
 # intact: cibuildwheel builds the assignment as NAME="value" itself, and quoting it here would
 # only nest one pair of quotes inside another - which it rejects as a malformed option.
 CMAKE_PREFIX_PATH = "C:/pygplates-wheel-deps;C:/pygplates-wheel-deps/qt;C:/pygplates-wheel-deps/vcpkg/x64-windows"
-# Build with the Visual Studio generator rather than Ninja. The VS generator locates the compiler
-# itself; Ninja needs the MSVC environment to be already set up, which neither cibuildwheel nor
-# scikit-build-core does - so a local wheel build would have to be started from a developer
-# command prompt. (The cost is that the wheel builds cannot use a compiler cache: the VS generator
-# ignores CMAKE_<LANG>_COMPILER_LAUNCHER, which is what the Linux and macOS builds set to sccache.
-# The CI workflow builds each Python version in its own job instead.)
-CMAKE_GENERATOR = "Visual Studio 17 2022"
+# Build with Ninja rather than the Visual Studio generator, so that the compiler cache below is
+# used at all: the VS generator ignores CMAKE_<LANG>_COMPILER_LAUNCHER, and without a cache every
+# Python version pays a full compile of about an hour.
+#
+# What it costs: Ninja compiles with whatever 'cl' the environment provides, and neither
+# cibuildwheel nor scikit-build-core sets the MSVC environment up (scikit-build-core does that
+# only for "Visual Studio" generators). So a local wheel build has to be started from an "x64
+# Native Tools Command Prompt for VS 2022" - see 'pygplates/wheel/README.md'. In CI the workflow
+# imports that environment with 'msvc_env.sh' before running cibuildwheel. The dependency scripts
+# are unaffected either way: they set their own environment up, since they run as hooks *inside*
+# cibuildwheel and cannot reach back out to it.
+CMAKE_GENERATOR = "Ninja"
+# So the wheel builds find sccache, which 'build_windows_deps.sh' installs into the deps prefix.
+# (Forward slashes are fine in a PATH entry - Windows accepts them as separators.)
+PATH = "C:/pygplates-wheel-deps/bin;$PATH"
 # Where PROJ and GDAL keep the data files they read at run time (the coordinate reference
 # system database, and GDAL's driver data). The build copies both into the wheel, so that an
 # installed pyGPlates carries its own - it points the two libraries at them when it is
@@ -349,5 +418,15 @@ GDAL_DATA = "C:/pygplates-wheel-deps/vcpkg/x64-windows/share/gdal"
 CMAKE_PROGRAM_PATH = "C:/pygplates-wheel-deps/vcpkg/x64-windows/tools/proj"
 
 [tool.cibuildwheel.windows.config-settings]
-# See the note in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
+# See the notes in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
+"build-dir" = "build/wheel"
+# Compile with MSVC. The Visual Studio generator would imply it; Ninja instead has CMake search
+# PATH, which on a machine with Visual Studio finds the LLVM it bundles ('VC/Tools/Llvm') and
+# builds the wheel with clang - against Qt, Boost and the vcpkg libraries that were all built
+# with MSVC. Named rather than pathed, so CMake takes the one the environment set up.
+"cmake.define.CMAKE_C_COMPILER" = "cl"
+"cmake.define.CMAKE_CXX_COMPILER" = "cl"
+# Compile through sccache, as on Linux and macOS - which is what CMAKE_GENERATOR above is for.
+"cmake.define.CMAKE_C_COMPILER_LAUNCHER" = "sccache"
+"cmake.define.CMAKE_CXX_COMPILER_LAUNCHER" = "sccache"


### PR DESCRIPTION
Follow-up work left undone by the cibuildwheel migration (#49, #50, #52). Three things, landing in
order, because the first decides whether the second is possible:

1. **Measure the compiler cache** across Python versions. It has never been observed working.
2. **Windows: Ninja + sccache**, and collapse the Windows jobs into the same shape as macOS.
3. Two small review findings that fall out of the above.

### Why the measurement comes first

The Linux and macOS builds set `CMAKE_<LANG>_COMPILER_LAUNCHER=sccache`, and the comments claim the
second and later Python versions build many times faster because of it. Nothing has ever shown that.
cibuildwheel prints nothing about the cache, and every wheel run to date is a pull request smoke test
building a single Python version - the one case where a cross-version cache can show nothing.

Two things rest on that unmeasured premise: a full run puts six Python versions in one job against a
six-hour ceiling, and the Windows jobs are split one-per-version *because* the Visual Studio
generator ignores the sccache launchers. If the cache turns out not to carry across versions, then
collapsing Windows into a single job is not merely unhelpful, it would run past the ceiling.

There is a specific reason to doubt it: `build-dir` is commented out in `pyproject.toml`, so
scikit-build-core builds each Python version in a fresh temporary directory, and generated headers
(`config.h`, moc, ui) then sit at different absolute paths each time.

So the first commit adds a `before-test` hook printing `sccache --show-stats` after each wheel is
built (cumulative, so each version's contribution is the difference between successive reports), and
widens the pull request limiter from one Python version to two. This run answers the question on
Linux and macOS at once.

Windows deliberately stays at one version for now - it has no compiler cache to report yet.
