### PR TITLE
Converge the geospatial library versions across platforms

### DIFF
--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -137,7 +137,11 @@ path limit):
   GMP and MPFR are the reason vcpkg is here at all: they have no MSVC build system. PROJ and GDAL
   come along with them because they are a deep stack that vcpkg already knows how to build on
   Windows. These versions are pinned by the vcpkg baseline commit in `vcpkg.json` rather than by
-  `versions.sh`, so they can differ from the versions the Linux and macOS wheels use.
+  `versions.sh` - but the `versions.sh` pins for GLEW, PROJ and GDAL are kept equal to what the
+  baseline supplies, so every platform's wheels ship the same versions of the libraries a user
+  can feel (CRS handling, datum grids, driver behaviour). Bump the baseline and those three pins
+  together, as one act, with vcpkg setting the cadence; `build_windows_deps.sh` compares what
+  vcpkg installed against `versions.sh` and fails if they have drifted apart.
 - Qwt, Boost and CGAL are built from source against the `versions.sh` pins, as on the other
   platforms. Qwt is built as a *static* library, because a Qwt DLL would require everything that
   includes its headers to be compiled with `-DQWT_DLL`.

--- a/pygplates/wheel/build_macos_deps.sh
+++ b/pygplates/wheel/build_macos_deps.sh
@@ -205,11 +205,6 @@ fi
 if [ ! -f "${PYGPLATES_DEPS}/stamps/gdal-${GDAL_VERSION}" ]; then
     rm -rf gdal && mkdir gdal && cd gdal
     curl -sSL https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz | tar xz --strip-components=1
-    # GDAL's bundled libpng predates libpng commit 893b811: recent Apple clang predefines
-    # TARGET_OS_MAC, which sends pngpriv.h down a classic-Mac-OS branch that includes the
-    # long-gone <fp.h>. Mirror the upstream fix (plain <math.h>) by dropping that macro from
-    # the guard. (A no-op once a GDAL release bundles the fixed libpng.)
-    sed -i '' 's/ || defined(TARGET_OS_MAC)//' frmts/png/libpng/pngpriv.h
     mkdir build && cd build
     cmake \
         -DCMAKE_BUILD_TYPE=Release \

--- a/pygplates/wheel/build_windows_deps.sh
+++ b/pygplates/wheel/build_windows_deps.sh
@@ -339,6 +339,25 @@ require_dir() {
         exit 1
     fi
 }
+# The libraries pinned both by the vcpkg baseline (for this build) and by 'versions.sh' (for the
+# Linux and macOS builds) must be pinned to the same versions - that agreement is the only thing
+# keeping the wheels' geospatial behaviour identical across platforms, and nothing else notices
+# when a baseline bump quietly moves one side. What vcpkg installed is read from its status file,
+# the dpkg-style database it keeps in the install root: the port version lives there and nowhere
+# in the installed headers ('Version:' is the upstream version alone - the '#N' port revision is
+# a separate 'Port-Version:' field, so no stripping is needed).
+require_vcpkg_version() {
+    _got=$(awk -v port="$1" \
+        '$1 == "Package:" { _pkg = $2 } $1 == "Version:" && _pkg == port { print $2; exit }' \
+        "${PYGPLATES_DEPS}/vcpkg/vcpkg/status")
+    if [ "${_got}" != "$2" ]; then
+        echo "error: vcpkg installed $1 ${_got:-(nothing)} but 'versions.sh' pins $1 $2. The vcpkg" >&2
+        echo "       baseline in 'vcpkg.json' and the GLEW/PROJ/GDAL pins in 'versions.sh' are meant" >&2
+        echo "       to move together, as one act, so every platform's wheels ship the same versions" >&2
+        echo "       of the libraries a user can feel." >&2
+        exit 1
+    fi
+}
 #
 # The vcpkg libraries are checked by their headers rather than their import libraries: a port
 # decides for itself what to call the library it installs (glew32.lib, proj_9.lib, ...), whereas
@@ -357,6 +376,9 @@ require_file "${VCPKG_PREFIX}/include/proj.h" "PROJ"
 require_file "${VCPKG_PREFIX}/include/gdal.h" "GDAL"
 require_file "${VCPKG_PREFIX}/include/gmp.h" "GMP"
 require_file "${VCPKG_PREFIX}/include/mpfr.h" "MPFR"
+require_vcpkg_version glew "${GLEW_VERSION}"
+require_vcpkg_version proj "${PROJ_VERSION}"
+require_vcpkg_version gdal "${GDAL_VERSION}"
 # PROJ and GDAL read these data directories at run time, and the wheel build copies both into
 # the wheel ('pyproject.toml' names them; cmake/modules/Install.cmake does the copying), so a
 # missing one has to fail here rather than produce a wheel that cannot resolve a coordinate

--- a/pygplates/wheel/manylinux_2_28.dockerfile
+++ b/pygplates/wheel/manylinux_2_28.dockerfile
@@ -261,13 +261,19 @@ RUN . /tmp/versions.sh && \
     ldconfig && \
     rm -rf /tmp/build
 
-# GDAL.
+# GDAL. External libraries are off (beyond zlib, and the SQLite built above) so the driver set
+# comes from GDAL's internal copies rather than from whatever EL8 happens to provide - the same
+# configuration as the macOS build, and the closest the source builds come to the vcpkg port's
+# feature set on Windows ('vcpkg.json' explains the correspondence).
 WORKDIR /tmp/build
 RUN . /tmp/versions.sh && \
     curl -sSL https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz | tar xz --strip-components=1 && \
     mkdir build && cd build && \
     cmake \
         -DBUILD_PYTHON_BINDINGS:BOOL=OFF \
+        -DGDAL_USE_EXTERNAL_LIBS:BOOL=OFF \
+        -DGDAL_USE_ZLIB:BOOL=ON \
+        -DGDAL_USE_SQLITE3:BOOL=ON \
         .. && \
     cmake --build . --config Release --parallel $(nproc) && \
     cmake --build . --config Release --target install && \

--- a/pygplates/wheel/vcpkg.json
+++ b/pygplates/wheel/vcpkg.json
@@ -15,9 +15,10 @@
     "'builtin-baseline' is a commit of https://github.com/microsoft/vcpkg - a vcpkg release tag,",
     "which is what pins these libraries' versions. 'build_windows_deps.sh' reads it from here to",
     "check out the matching vcpkg, and stamps the installed tree with it, so bumping it below",
-    "rebuilds them. Note this makes these versions independent of 'versions.sh' (which pins what",
-    "we build ourselves): they follow the vcpkg release, and so can differ from the versions the",
-    "Linux and macOS wheels use."
+    "rebuilds them. For the libraries the other platforms also ship - GLEW, PROJ and GDAL - the",
+    "pins in 'versions.sh' are kept equal to what this baseline supplies, so every platform's",
+    "wheels carry the same versions of the libraries a user can feel; bump the baseline and",
+    "those three pins together, as one act ('build_windows_deps.sh' fails if they drift apart)."
   ],
 
   "name": "pygplates-wheel-dependencies",

--- a/pygplates/wheel/versions.sh
+++ b/pygplates/wheel/versions.sh
@@ -7,7 +7,11 @@
 # '.github/workflows/build-wheels.yml').
 #
 # Not everything is pinned here: the libraries vcpkg supplies to the Windows build are pinned
-# by the vcpkg baseline in 'vcpkg.json' instead.
+# by the vcpkg baseline in 'vcpkg.json' instead. For the libraries both systems pin - GLEW,
+# PROJ and GDAL - the versions here are kept equal to what that baseline supplies, so all three
+# platforms' wheels ship the same geospatial behaviour. Bump the baseline and these three
+# together, as one act, with vcpkg setting the cadence (it is the one of the two whose available
+# versions cannot be picked freely); 'build_windows_deps.sh' fails if they drift apart.
 #
 # Keep this file to plain NAME=VALUE assignments and comments - it is sourced by /bin/sh in
 # the Docker build steps.
@@ -21,11 +25,11 @@
 PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13 3.14"
 
 QT_VERSION=6.7.3
-GLEW_VERSION=2.2.0
+GLEW_VERSION=2.3.1
 QWT_VERSION=6.3.0
 BOOST_VERSION=1.91.0
-PROJ_VERSION=9.4.0
-GDAL_VERSION=3.8.5
+PROJ_VERSION=9.8.1
+GDAL_VERSION=3.12.4
 CGAL_VERSION=6.0.3
 SCCACHE_VERSION=0.17.0
 


### PR DESCRIPTION
The Windows wheels take GLEW, PROJ and GDAL from vcpkg, pinned by the baseline in `vcpkg.json`; the
Linux and macOS wheels build them from source, pinned in `versions.sh`. Both pinning systems buy
reproducibility, but they were set to different values: PROJ 9.4.0 and GDAL 3.8.5 (inherited from
the retired pre-conda wheel scripts) against the 9.8.1 and 3.12.4 the vcpkg baseline supplies. PROJ
and GDAL are exactly the dependencies whose version a user can feel - CRS handling, datum grids,
driver behaviour - so the wheels users download for different operating systems differed in ways
nobody chose. Worth settling now, before PyPI publishing turns the divergence from a CI artifact
into something users have.

- `versions.sh` converges up to what the baseline supplies (GLEW 2.3.1, PROJ 9.8.1, GDAL 3.12.4).
  From here the baseline and those three pins move together, as one act, with vcpkg setting the
  cadence.
- `build_windows_deps.sh` enforces the agreement: its sanity checks now compare the versions vcpkg
  actually installed (from vcpkg's status database) against `versions.sh`, so the next baseline
  bump cannot quietly re-open the gap.
- The Linux image now really does configure GDAL with `GDAL_USE_EXTERNAL_LIBS=OFF` plus zlib and
  SQLite, as `vcpkg.json` and the README already claimed and as macOS already did - the driver set
  comes from GDAL's internal copies rather than whatever EL8 provides.
- The macOS libpng `sed` patch is gone: GDAL 3.12.4 bundles the fixed libpng, making it the no-op
  its own comment predicted.

GMP, MPFR and zlib stay unaligned deliberately (Linux takes them from AlmaLinux 8 with no pin at
all; numerics and compression, not user-visible geospatial behaviour).

Note for review: the PR smoke run rebuilds the macOS and Windows deps caches cold (~1 h each, in
parallel), since `versions.sh` and both deps scripts hash into the cache keys. The Linux smoke run
still uses the previous `:latest` image - the image rebuild with the new versions triggers on the
push to `pygplates` at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)