### PR TITLE
Publish releases to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,8 +13,14 @@
 # the second, without spending six builds' worth of runner time.
 #
 # The sdist is built here too: it's what PyPI users without a matching wheel fall back to,
-# and it's what the conda-forge feedstock pulls. A future publish workflow uploads these
-# artifacts to PyPI - until then they can be downloaded from the workflow run page.
+# and it's what the conda-forge feedstock pulls.
+#
+# A release tag also publishes. Once every build has succeeded, the run rehearses the upload
+# against TestPyPI, then waits for a maintainer to approve the 'pypi' deployment environment
+# before uploading to PyPI - all via OIDC Trusted Publishing, so no API token is stored
+# anywhere. The trusted-publisher registrations on both indexes name this file, so renaming it
+# breaks publishing until they are updated to match. The release process, the one-time index
+# and environment setup, and the recovery paths are documented in 'pygplates/wheel/README.md'.
 name: pygplates wheels
 
 on:
@@ -37,7 +43,15 @@ on:
       - CMakeLists.txt
   workflow_dispatch:
 
+# The build jobs only read the repository. The publish jobs declare what they need themselves
+# (the OIDC token for the indexes) - job-level 'permissions' blocks replace this one entirely
+# for their job, they don't add to it.
+permissions:
+  contents: read
+
 # Superseded runs are cancelled rather than left to finish (a full wheel matrix takes hours).
+# The group is per-ref, so a release run - which can sit in 'waiting' for days at the approval
+# gate below - can only be superseded by re-pushing its own tag, never by other work.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -51,6 +65,27 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Check the tag matches the version
+        # A release tag must be 'PyGPlates-' plus the version in 'cmake/modules/Version.cmake'
+        # (extracted with the same pattern as pyproject.toml's version provider). Anything else
+        # means the tag was pushed without bumping the version - far better caught here, in the
+        # run's first minute, than noticed in what the publish jobs upload five hours later.
+        # Development versions are rejected outright: pip never installs them by default, and
+        # publishing one would permanently reserve its filenames on PyPI for nothing.
+        if: github.ref_type == 'tag'
+        run: |
+          version=$(sed -n 's/^set(\s*PYGPLATES_PEP440_VERSION\s\+\(\S\+\)\s*).*/\1/p' cmake/modules/Version.cmake)
+          [ -n "${version}" ] # fail here if the Version.cmake line was reformatted
+          if [ "${GITHUB_REF_NAME}" != "PyGPlates-${version}" ]; then
+              echo "Tag '${GITHUB_REF_NAME}' does not match 'PyGPlates-${version}'" \
+                   "(from cmake/modules/Version.cmake)." >&2
+              exit 1
+          fi
+          case ${version} in *.dev*)
+              echo "'${version}' is a development version - not something to tag and release." >&2
+              exit 1
+          esac
 
       - name: Check the Python version lists agree
         # A mismatch means Linux wheel builds fail much later with a Boost linker error - the
@@ -307,3 +342,132 @@ jobs:
           name: wheels-${{ matrix.id }}
           path: wheelhouse/*.whl
           if-no-files-found: ignore
+
+  publish-testpypi:
+    name: publish to TestPyPI
+    # A rehearsal of the release upload, against the index where a rejection costs nothing:
+    # what the indexes validate server-side (the metadata, most of all) is exactly what local
+    # checks cannot prove will be accepted. Only a subset is uploaded - the sdist plus one
+    # platform's wheels - because every wheel carries the same metadata, so one platform
+    # rehearses everything the index could object to, while a full ~1.2 GB matrix would burn
+    # through TestPyPI's project quota in a handful of releases.
+    #
+    # Publishing is for release tags pushed to the upstream repository: not pull requests, not
+    # manual dispatches (even of a tag ref), and not forks - where these jobs are skipped,
+    # which also stops GitHub silently auto-creating the deployment environments there.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/PyGPlates-') && github.repository == 'GPlates/GPlates'
+    # Every leg of the matrix green - not merely "artifacts exist", which even failed legs
+    # leave behind ('if: always()' above). ('build-sdist' is implied, 'build-wheels' needs it.)
+    needs: build-wheels
+    runs-on: ubuntu-24.04
+    # Bounds a hung upload.
+    timeout-minutes: 30
+
+    # The OIDC token this job trades for upload permission carries the environment name, and
+    # TestPyPI's trusted-publisher registration requires it to be 'testpypi' - see the README's
+    # one-time setup. No approval gate on this environment: the rehearsal is what runs first.
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pygplates
+
+    # Mandatory for Trusted Publishing - and, being a job-level block, it also drops every
+    # other permission (this job checks nothing out).
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download the sdist
+        uses: actions/download-artifact@v6
+        with:
+          name: sdist
+          path: dist
+
+      - name: Download one platform's wheels
+        uses: actions/download-artifact@v6
+        with:
+          name: wheels-linux-x86_64
+          path: dist
+
+      - name: Publish to TestPyPI
+        # 'release/v1' is the branch the PyPA maintains for exactly this use - an exact pin
+        # would rot silently here (no dependabot), and has broken before for others (the
+        # v1.12 prebuilt-container switch). Attestations (PEP 740) are generated and uploaded
+        # by default under Trusted Publishing. 'skip-existing' makes a re-run idempotent:
+        # an index rejects re-uploads of a filename it has already accepted, so without it a
+        # rehearsal could never be run twice for the same release.
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: publish to PyPI
+    # Runs only after the TestPyPI rehearsal succeeded - and then waits for a maintainer to
+    # approve the deployment to the 'pypi' environment (a required reviewer configured on the
+    # environment, see the README). The same trigger condition again, even though 'needs' on a
+    # skipped job would skip this one anyway: the gate on the real index should never depend
+    # on another job's condition staying correct.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/PyGPlates-') && github.repository == 'GPlates/GPlates'
+    needs: publish-testpypi
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pygplates
+
+    # 'id-token' is mandatory for Trusted Publishing; 'contents' is for the checkout, which is
+    # only there so the completeness check can read the Python version list. Everything else
+    # this job might have been given is dropped by this block existing.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download the sdist
+        uses: actions/download-artifact@v6
+        with:
+          name: sdist
+          path: dist
+
+      - name: Download the wheels
+        # All the wheel artifacts, merged into 'dist/' alongside the sdist. Two named download
+        # steps rather than one bare merge of every artifact in the run, so that a future
+        # non-distribution artifact (crash logs, say) can never leak into the upload.
+        uses: actions/download-artifact@v6
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Check every distribution is present
+        # One sdist, and one wheel per Python version per platform. 'needs' above already
+        # proves every job succeeded - this proves they built what a release needs: a job goes
+        # green building whatever CIBW_BUILD selects, so a selection mistake (say, the pull
+        # request limiter's condition drifting) would otherwise publish a release with holes
+        # in its wheel matrix. The Python versions come from the same list the builds use; the
+        # platform count is this file's 'build-wheels' matrix.
+        run: |
+          python_count=$(sed -n 's/^PYTHON_VERSIONS="\(.*\)"/\1/p' pygplates/wheel/versions.sh | wc -w)
+          [ "${python_count}" -gt 0 ] # fail here if the versions.sh line was reformatted
+          expected_wheels=$((python_count * 5))
+          sdist_count=$(find dist -name '*.tar.gz' | wc -l)
+          wheel_count=$(find dist -name '*.whl' | wc -l)
+          echo "dist/ holds ${sdist_count} sdist (expected 1) and ${wheel_count} wheels (expected ${expected_wheels})."
+          [ "${sdist_count}" -eq 1 ] && [ "${wheel_count}" -eq "${expected_wheels}" ]
+
+      - name: Publish to PyPI
+        # See the TestPyPI step for the choice of 'release/v1' and the attestations note.
+        # 'skip-existing' here is what makes a partial upload recoverable: PyPI reserves
+        # filenames forever (even after deletion) and rejects re-uploads, and the upload stops
+        # at the first rejection - so a network failure partway through 31 files would
+        # otherwise wedge the release permanently, with re-runs dying on the first
+        # already-uploaded file. With it, "Re-run failed jobs" finishes the job. The risk
+        # 'skip-existing' usually carries - quietly not uploading a stale rebuild - is closed
+        # by the tag check in 'build-sdist': what is in 'dist/' can only be the tagged version.
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -43,11 +43,13 @@ on:
       - CMakeLists.txt
   workflow_dispatch:
 
-# The build jobs only read the repository. The publish jobs declare what they need themselves
-# (the OIDC token for the indexes) - job-level 'permissions' blocks replace this one entirely
-# for their job, they don't add to it.
+# What the build jobs need: the repository, and the GHCR packages the Linux builds pull their
+# dependency image from. Both are spelled out because naming any permission drops every one not
+# named - which is also why the publish jobs' own 'permissions' blocks restate what they need
+# rather than adding to this.
 permissions:
   contents: read
+  packages: read
 
 # Superseded runs are cancelled rather than left to finish (a full wheel matrix takes hours).
 # The group is per-ref, so a release run - which can sit in 'waiting' for days at the approval
@@ -101,10 +103,13 @@ jobs:
         run: pipx run twine check dist/*.tar.gz
 
       - name: Upload sdist
+        # 'overwrite' for the same reason as the wheels below: re-running every job of a run
+        # that already uploaded would otherwise be refused as a duplicate artifact name.
         uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
+          overwrite: true
 
   build-wheels:
     name: wheels ${{ matrix.id }}
@@ -149,6 +154,10 @@ jobs:
         # the completeness check below never finding its stamp and every run re-saving the
         # multi-gigabyte cache). The Linux entries have none: their dependencies live in the
         # GHCR images, and every deps step is gated on runner.os != 'Linux'.
+        #
+        # Adding or removing an entry here changes how many wheels a release consists of:
+        # 'publish-pypi' multiplies the number of entries by the number of Python versions to
+        # know what a complete release looks like, and cannot read this list for itself.
         include:
           - id: linux-x86_64
             os: ubuntu-24.04
@@ -336,12 +345,18 @@ jobs:
         # wheels to a test flake on the sixth would force the whole job to run again.
         # 'if-no-files-found: ignore' keeps the step green when the failure came before any
         # wheel finished.
+        # 'overwrite' because an artifact belongs to the run, not to the attempt: a leg that
+        # died on its last wheel has already uploaded the earlier ones, and without this the
+        # re-run that the comment above is describing would rebuild everything and then fail
+        # at this step, refused as a duplicate name. (Safe here, unlike the case it guards
+        # against upstream: each leg writes its own artifact name, never a shared one.)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.id }}
           path: wheelhouse/*.whl
           if-no-files-found: ignore
+          overwrite: true
 
   publish-testpypi:
     name: publish to TestPyPI
@@ -451,8 +466,10 @@ jobs:
         # in its wheel matrix. The Python versions come from the same list the builds use; the
         # platform count is this file's 'build-wheels' matrix.
         run: |
-          python_count=$(sed -n 's/^PYTHON_VERSIONS="\(.*\)"/\1/p' pygplates/wheel/versions.sh | wc -w)
+          python_count=$(sed -n 's/^PYTHON_VERSIONS="\(.*\)".*/\1/p' pygplates/wheel/versions.sh | wc -w)
           [ "${python_count}" -gt 0 ] # fail here if the versions.sh line was reformatted
+          # The five entries of the 'build-wheels' matrix above (which is not readable from
+          # here); that block says so too, since this is the side that fails if they part.
           expected_wheels=$((python_count * 5))
           sdist_count=$(find dist -name '*.tar.gz' | wc -l)
           wheel_count=$(find dist -name '*.whl' | wc -l)

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -20,7 +20,7 @@ The pieces fit together like this:
 | `build_boost_python.sh` (this directory) | Builds Boost.Python against each wheel's Python version, on macOS and Windows (run automatically by cibuildwheel before each wheel build). |
 | `check_wheel_contents.py` (this directory) | Checks each repaired wheel carries the data PROJ and GDAL read at run time (run automatically by cibuildwheel, after the test suite). |
 | `.github/workflows/build-wheel-images.yml` | Builds the Docker images (natively, per architecture) and pushes them to GHCR. |
-| `.github/workflows/build-wheels.yml` | CI builds of the sdist and the wheels (full matrix on release tags and manual dispatch; single-Python smoke test on pull requests touching the wheel machinery). |
+| `.github/workflows/build-wheels.yml` | CI builds of the sdist and the wheels (full matrix on release tags and manual dispatch; two-Python smoke test on pull requests touching the wheel machinery). On a release tag it also publishes to PyPI - see [Publishing a release](#publishing-a-release). |
 
 ## Building a wheel locally
 
@@ -333,3 +333,72 @@ NumPy wheels is not usable anyway). To add or remove a version:
    disagree, so this cannot be forgotten quietly.
    (macOS and Windows need no equivalent step: `build_boost_python.sh` builds Boost.Python for
    whatever Python version each wheel build brings.)
+
+## Publishing a release
+
+Releasing to [PyPI](https://pypi.org/p/pygplates) is part of `build-wheels.yml`: pushing a
+release tag builds the full matrix and then publishes it, with two safeguards between building
+and the real index. Nothing holds an API token - the publish jobs authenticate with
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/), where the index trusts short-lived
+OIDC tokens GitHub mints for this specific workflow file.
+
+The flow, end to end:
+
+1. Set the release version in `cmake/modules/Version.cmake` (`PYGPLATES_PEP440_VERSION`) and
+   commit. For a first pass at a release, use an `rc` version (eg, `1.1.0rc1`): pip ignores
+   release candidates by default, so it exercises this whole pipeline - the tag check, the
+   rehearsal, the approval gate, a real PyPI upload - with low stakes.
+2. Tag that commit `PyGPlates-<version>` (exactly the version string - the run fails in its
+   first minute if the two disagree, or if the version is a `.dev` one) and push the tag.
+3. The run builds the sdist and every wheel (about 2.5 hours warm, 4.5 cold), then uploads the
+   sdist plus one platform's wheels to [TestPyPI](https://test.pypi.org/p/pygplates) - a
+   rehearsal that catches anything the index itself would reject (metadata, most of all)
+   before the real upload.
+4. The run then sits at **waiting** until a maintainer approves the `pypi` deployment (repo
+   page -> the run -> "Review deployments"). This is the moment to eyeball the TestPyPI
+   project page. Approval waits expire after 30 days.
+5. On approval the whole matrix - one sdist, one wheel per Python version per platform, counted
+   before upload - goes to PyPI, each file with a [PEP 740](https://peps.python.org/pep-0740/)
+   attestation.
+
+Recovery paths, should something fail:
+
+- **A build failed**: "Re-run failed jobs". The publish jobs only start once every build job is
+  green, and wheels already built are not rebuilt (they upload from the run's artifacts, which
+  is also why re-runs must happen within the artifact retention window - 90 days).
+- **An upload failed partway**: also "Re-run failed jobs". `skip-existing` on the publish steps
+  skips the files that made it and uploads the rest - without that, the index's refusal to
+  accept a filename twice would wedge the release permanently.
+- **Something is wrong with the release itself**: don't approve; cancel the run, fix, bump the
+  version, re-tag. PyPI reserves every uploaded filename forever (deleting a release does not
+  free its names), which is why a suspect release should be stopped *before* approval.
+
+Housekeeping to be aware of:
+
+- PyPI's default project quota is 10 GiB, and a full release is ~1.2 GiB - about seven releases'
+  worth. File a [size-limit increase](https://docs.pypi.org/project-management/storage-limits/)
+  before it becomes urgent, and delete superseded `rc` releases (deletion does free quota - it's
+  only the *filenames* that stay reserved).
+- TestPyPI has the same quota and rehearsals accrete there too; delete old ones now and then.
+
+### One-time setup (already done - recorded for when it must be redone)
+
+The trusted-publisher registrations bind to this repository **and the workflow filename**, so
+renaming `build-wheels.yml` (or moving the repository) silently breaks publishing until the
+registrations are updated to match. The order below matters: a workflow run referencing a
+deployment environment that does not exist *auto-creates it unprotected*, so the environments
+must exist - with their protection rules - before the first tag push.
+
+1. Create the `pypi` [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+   in the repository settings: required reviewers = the release maintainer(s); deployment
+   branches/tags restricted to tags matching `PyGPlates-*`. Leave "prevent self-review" off -
+   a lone maintainer must be able to approve their own release.
+2. Create the `testpypi` environment (no reviewers - the rehearsal is what runs unattended).
+3. On **TestPyPI** (separate account from PyPI, 2FA required): pygplates doesn't exist there,
+   so register a [pending publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/):
+   owner `GPlates`, repository `GPlates`, workflow `build-wheels.yml`, environment `testpypi`.
+   (A pending publisher doesn't reserve the name, so do this close to first use; it becomes a
+   normal publisher on the first upload.)
+4. On **PyPI**, in the pygplates project -> Settings -> Publishing, add the trusted publisher:
+   owner `GPlates`, repository `GPlates`, workflow `build-wheels.yml`, environment `pypi`.
+5. After the first successful trusted publish, revoke any remaining pygplates API tokens.

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -363,9 +363,10 @@ The flow, end to end:
 
 Recovery paths, should something fail:
 
-- **A build failed**: "Re-run failed jobs". The publish jobs only start once every build job is
-  green, and wheels already built are not rebuilt (they upload from the run's artifacts, which
-  is also why re-runs must happen within the artifact retention window - 90 days).
+- **A build failed**: "Re-run failed jobs" - only the failed platform runs again (from its
+  dependency cache), and the publish jobs then start as if the run had been green all along.
+  They upload what the run's artifacts hold, so this works within the artifact retention
+  window - 90 days.
 - **An upload failed partway**: also "Re-run failed jobs". `skip-existing` on the publish steps
   skips the files that made it and uploads the rest - without that, the index's refusal to
   accept a filename twice would wedge the release permanently.


### PR DESCRIPTION
Pushing a `PyGPlates-*` tag now publishes the release, not just builds it. Two new jobs in `build-wheels.yml` run once every build in the matrix is green:

1. **`publish-testpypi`** — a rehearsal upload to [TestPyPI](https://test.pypi.org/p/pygplates): the sdist plus one platform's wheels. Every wheel carries the same metadata, so one platform exercises everything the index validates server-side (which is exactly what local checks cannot prove will be accepted), without burning TestPyPI's 10 GiB quota on the full ~1.2 GB matrix.
2. **`publish-pypi`** — after a maintainer approves the `pypi` deployment environment, the full matrix (one sdist + one wheel per Python version per platform, counted before upload) goes to PyPI, each file with a PEP 740 attestation.

Both jobs authenticate with **OIDC Trusted Publishing** — no API token stored anywhere. The registrations on both indexes bind to this repository and the workflow *filename* (renaming `build-wheels.yml` breaks publishing until they're updated; the file and README both say so).

Guards added alongside:

- **Tag/version check** in `build-sdist`: a tag that doesn't equal `PyGPlates-` + `PYGPLATES_PEP440_VERSION` from `Version.cmake` fails in the run's first minute instead of surfacing five hours later; `.dev` versions are rejected outright (pip never installs them by default, and PyPI reserves filenames forever).
- **Distribution-count check** before the PyPI upload: a green matrix only proves the jobs built whatever `CIBW_BUILD` selected — this proves the selection had no holes.
- **Top-level `permissions: contents: read`**: least privilege for the build jobs now that the file contains publish jobs; each publish job declares only what it needs.
- `skip-existing: true` on the publish steps — a deliberate deviation from the usual advice, reasoned in the step comments: indexes reject filename re-uploads permanently and an upload aborts at its first rejection, so without it a network failure partway through 31 files would wedge the release unrecoverably. The stale-rebuild risk it usually carries is closed by the tag check.

`pygplates/wheel/README.md` gains a **Publishing a release** section: the flow, the recovery paths ("Re-run failed jobs" for both build and upload failures), the quota arithmetic (~7 full releases fit PyPI's default 10 GiB — file a size-limit increase early), and the one-time setup checklist.

**Before the first tag push** (manual, maintainer): create the `pypi` environment (required reviewer + `PyGPlates-*` tag rule) and `testpypi` environment, register the pending publisher on TestPyPI and the trusted publisher on PyPI — in that order, because a workflow referencing a missing environment silently auto-creates it *unprotected*. Details in the README section.

Verified locally: workflow YAML parses; the tag check was dry-run against all three cases (mismatched tag ✗, matching-but-`.dev` ✗, matching `rc` ✓) and the count check against complete (1+30 ✓) and one-wheel-missing (✗) sets. The PR's own smoke run is the pre-merge check that both publish jobs show **skipped** on a pull request; the real end-to-end test is the next release's `rc` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
