### PR TITLE
Prune Actions caches that nothing can restore

### DIFF
--- a/.github/workflows/build-test-gplates.yml
+++ b/.github/workflows/build-test-gplates.yml
@@ -110,8 +110,8 @@ jobs:
         # A pull request can read caches written on its base branch, so PRs start warm from the
         # last push to 'gplates'.
         #
-        # The keys are namespaced 'sccache-gplates-*' (unlike the pygplates workflow's
-        # 'sccache-<platform>-*'): 'gplates' is the repository's default branch, so caches saved
+        # This workflow's keys are namespaced 'sccache-gplates-*' and the pyGPlates workflow's
+        # 'sccache-pygplates-*': 'gplates' is the repository's default branch, so caches saved
         # here are visible to every ref, and the GPlates and pyGPlates builds share no cache
         # entries at all (every shared translation unit differs in -fPIC and in the
         # GPLATES_PYTHON_EMBEDDING compile definition). Distinct prefixes stop either workflow

--- a/.github/workflows/build-test-gplates.yml
+++ b/.github/workflows/build-test-gplates.yml
@@ -172,8 +172,14 @@ jobs:
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
         # Pushes to 'gplates' warm the cache; pull requests restore from it.
-        # 'always()' so that a failed build still saves the objects it did compile.
-        if: always() && github.event_name == 'push'
+        # '!cancelled()' rather than 'success()', so that a failed build still saves the objects it
+        # did compile - and rather than 'always()', so that a cancelled one does not. A run
+        # cancelled mid-build would save no less than it restored, and is harmless; but the
+        # concurrency group above can equally cancel a run before or during the restore step, and
+        # that saves a near-empty directory under a newer key. Since 'restore-keys' matches the
+        # most recently created cache, that fragment then shadows the complete one for every
+        # later run.
+        if: "!cancelled() && github.event_name == 'push'"
         uses: actions/cache/save@v4
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/build-test-gplates.yml
+++ b/.github/workflows/build-test-gplates.yml
@@ -116,6 +116,7 @@ jobs:
         # entries at all (every shared translation unit differs in -fPIC and in the
         # GPLATES_PYTHON_EMBEDDING compile definition). Distinct prefixes stop either workflow
         # from downloading the other's (useless to it) cache.
+        id: restore-compiler-cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.SCCACHE_DIR }}
@@ -172,14 +173,17 @@ jobs:
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
         # Pushes to 'gplates' warm the cache; pull requests restore from it.
-        # '!cancelled()' rather than 'success()', so that a failed build still saves the objects it
-        # did compile - and rather than 'always()', so that a cancelled one does not. A run
-        # cancelled mid-build would save no less than it restored, and is harmless; but the
-        # concurrency group above can equally cancel a run before or during the restore step, and
-        # that saves a near-empty directory under a newer key. Since 'restore-keys' matches the
-        # most recently created cache, that fragment then shadows the complete one for every
-        # later run.
-        if: "!cancelled() && github.event_name == 'push'"
+        # 'always()' rather than 'success()', so that a failed build still saves the objects it
+        # did compile - and so does one that hits 'timeout-minutes', which the runner delivers as
+        # a cancellation. The restore-outcome guard is what a bare 'always()' would be missing:
+        # the concurrency group above can cancel a run before or during the restore step, and an
+        # unguarded save would then write a near-empty directory under a newer key. Since
+        # 'restore-keys' matches the most recently created cache, that fragment would shadow the
+        # complete one for every later run. (A restore that finds no cache to restore still
+        # succeeds, so a cold build salvages normally.)
+        if: >-
+          always() && steps.restore-compiler-cache.outcome == 'success' &&
+          github.event_name == 'push'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -164,8 +164,14 @@ jobs:
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
         # Pushes to 'pygplates' warm the cache; pull requests restore from it.
-        # 'always()' so that a failed build still saves the objects it did compile.
-        if: always() && github.event_name == 'push'
+        # '!cancelled()' rather than 'success()', so that a failed build still saves the objects it
+        # did compile - and rather than 'always()', so that a cancelled one does not. A run
+        # cancelled mid-build would save no less than it restored, and is harmless; but the
+        # concurrency group above can equally cancel a run before or during the restore step, and
+        # that saves a near-empty directory under a newer key. Since 'restore-keys' matches the
+        # most recently created cache, that fragment then shadows the complete one for every
+        # later run.
+        if: "!cancelled() && github.event_name == 'push'"
         uses: actions/cache/save@v4
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -115,6 +115,7 @@ jobs:
         # definition), and 'gplates' is the repository's default branch, so caches saved there are
         # visible to every ref. Distinct prefixes stop either workflow from downloading the
         # other's (useless to it) cache.
+        id: restore-compiler-cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.SCCACHE_DIR }}
@@ -171,14 +172,17 @@ jobs:
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
         # Pushes to 'pygplates' warm the cache; pull requests restore from it.
-        # '!cancelled()' rather than 'success()', so that a failed build still saves the objects it
-        # did compile - and rather than 'always()', so that a cancelled one does not. A run
-        # cancelled mid-build would save no less than it restored, and is harmless; but the
-        # concurrency group above can equally cancel a run before or during the restore step, and
-        # that saves a near-empty directory under a newer key. Since 'restore-keys' matches the
-        # most recently created cache, that fragment then shadows the complete one for every
-        # later run.
-        if: "!cancelled() && github.event_name == 'push'"
+        # 'always()' rather than 'success()', so that a failed build still saves the objects it
+        # did compile - and so does one that hits 'timeout-minutes', which the runner delivers as
+        # a cancellation. The restore-outcome guard is what a bare 'always()' would be missing:
+        # the concurrency group above can cancel a run before or during the restore step, and an
+        # unguarded save would then write a near-empty directory under a newer key. Since
+        # 'restore-keys' matches the most recently created cache, that fragment would shadow the
+        # complete one for every later run. (A restore that finds no cache to restore still
+        # succeeds, so a cold build salvages normally.)
+        if: >-
+          always() && steps.restore-compiler-cache.outcome == 'success' &&
+          github.event_name == 'push'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -108,11 +108,18 @@ jobs:
         # never hits, and the prefix fallback restores the most recent cache for this platform.
         # A pull request can read caches written on its base branch, so PRs start warm from the
         # last push to 'pygplates'.
+        #
+        # The keys are namespaced 'sccache-pygplates-*', and the GPlates workflow's
+        # 'sccache-gplates-*': the two builds share no cache entries at all (every shared
+        # translation unit differs in -fPIC and in the GPLATES_PYTHON_EMBEDDING compile
+        # definition), and 'gplates' is the repository's default branch, so caches saved there are
+        # visible to every ref. Distinct prefixes stop either workflow from downloading the
+        # other's (useless to it) cache.
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ matrix.name }}-${{ github.sha }}
-          restore-keys: sccache-${{ matrix.name }}-
+          key: sccache-pygplates-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: sccache-pygplates-${{ matrix.name }}-
 
       - name: Install dependencies (conda)
         uses: conda-incubator/setup-miniconda@v3
@@ -175,7 +182,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ matrix.name }}-${{ github.sha }}
+          key: sccache-pygplates-${{ matrix.name }}-${{ github.sha }}
 
       - name: Test
         # '-C Release' is required: the tests are registered with 'CONFIGURATIONS Release MinSizeRel',

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -333,7 +333,13 @@ jobs:
         # idempotent, so a partially-built cache is picked up where it left off) and, because
         # its own save key is fresh, can save the completed prefix. Skipped only when this
         # run restored an already-complete prefix and so has nothing new to save.
-        if: always() && runner.os != 'Linux' && steps.deps-complete.outputs.complete != 'true'
+        #
+        # '!cancelled()' rather than 'always()' for the same reason as the compiler caches in
+        # 'build-test-*.yml': a run cancelled before or during the restore step would save a
+        # near-empty directory under a newer key, and the completeness check above - which has no
+        # 'always()' of its own - would not have run to veto it, so the fragment shadows a usable
+        # prefix for every later run of this pull request.
+        if: "!cancelled() && runner.os != 'Linux' && steps.deps-complete.outputs.complete != 'true'"
         uses: actions/cache/save@v4
         with:
           path: ${{ matrix.deps-path }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -334,12 +334,17 @@ jobs:
         # its own save key is fresh, can save the completed prefix. Skipped only when this
         # run restored an already-complete prefix and so has nothing new to save.
         #
-        # '!cancelled()' rather than 'always()' for the same reason as the compiler caches in
-        # 'build-test-*.yml': a run cancelled before or during the restore step would save a
+        # 'always()' is what keeps the salvage-on-timeout promise made by the 'timeout-minutes'
+        # comment above - the runner delivers a timeout as a cancellation, so anything weaker
+        # skips this step exactly when the retry needs it most. The restore-outcome guard closes
+        # the loophole 'always()' alone would leave (the same one as the compiler caches in
+        # 'build-test-*.yml'): a run cancelled before or during the restore step would save a
         # near-empty directory under a newer key, and the completeness check above - which has no
-        # 'always()' of its own - would not have run to veto it, so the fragment shadows a usable
-        # prefix for every later run of this pull request.
-        if: "!cancelled() && runner.os != 'Linux' && steps.deps-complete.outputs.complete != 'true'"
+        # 'always()' of its own - would not have run to veto it, so the fragment would shadow a
+        # usable prefix for every later run of this pull request.
+        if: >-
+          always() && steps.restore-deps-cache.outcome == 'success' &&
+          runner.os != 'Linux' && steps.deps-complete.outputs.complete != 'true'
         uses: actions/cache/save@v4
         with:
           path: ${{ matrix.deps-path }}

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -53,8 +53,11 @@ on:
         type: boolean
         default: true
 
-# Not per-ref, unlike the build workflows: two sweeps must never race on the same delete. Not
-# cancelled either - the job takes seconds, and a half-finished prune is worse than a queued one.
+# Not per-ref, unlike the build workflows: two sweeps must never race on the same delete. Note
+# GitHub holds at most one *pending* run per group - a newer pending run cancels the older one,
+# 'cancel-in-progress: false' notwithstanding (that only protects the run in progress) - so a
+# burst of pull requests closing together can drop a close-event run outright. That is fine: the
+# nightly sweep's catch-up pass reclaims anything a dropped run would have.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -66,10 +69,14 @@ jobs:
     # Seconds of API calls. The ceiling is only here to stop a hung request holding a runner.
     timeout-minutes: 10
 
-    # The one scope this needs. Being a job-level block it also drops every other permission,
-    # which is right: this job checks nothing out and touches nothing but the cache API.
+    # Being a job-level block this drops every unnamed permission, which is right: the job checks
+    # nothing out and touches nothing but the cache API and pull-request state. 'pull-requests:
+    # read' is load-bearing, not a courtesy - 'gh pr view' goes through the GraphQL API, where the
+    # workflow token gets no default read access even on a public repository, so without the scope
+    # every state lookup fails, and the abandoned-ref pass silently reclaims nothing.
     permissions:
       actions: write
+      pull-requests: read
 
     env:
       # 'gh' needs a token and a repository. Supplying both here is what lets the job skip the
@@ -95,9 +102,11 @@ jobs:
         run: |
           ref="refs/pull/${PR_NUMBER}/merge"
 
+          # No '|| true': an empty listing exits 0, so a non-zero exit means the API call itself
+          # failed, and that must fail the step red rather than read as "nothing to list".
           rows=$(gh cache list --limit 1000 --ref "${ref}" --sort size_in_bytes --order desc \
                      --json key,sizeInBytes \
-                     -q '.[] | "| `\(.key)` | \(.sizeInBytes / 1048576 | floor) MiB |"' || true)
+                     -q '.[] | "| `\(.key)` | \(.sizeInBytes / 1048576 | floor) MiB |"')
 
           gh cache delete --all --ref "${ref}" --succeed-on-no-caches
 
@@ -119,9 +128,12 @@ jobs:
         # recently created match, so within any group the first row is the only one CI can still
         # restore.
         run: |
+          # No '|| true': an empty listing exits 0, so a non-zero exit means the API call itself
+          # failed, and that must fail the step red - masking it would disable the whole sweep
+          # while every run stayed green.
           all=$(gh cache list --limit 1000 --sort created_at --order desc \
                     --json id,key,ref,sizeInBytes \
-                    -q '.[] | [.id, .key, .ref, .sizeInBytes] | @tsv' || true)
+                    -q '.[] | [.id, .key, .ref, .sizeInBytes] | @tsv')
 
           if [ -z "${all}" ]; then
               echo "### Cache prune" >> "${GITHUB_STEP_SUMMARY}"
@@ -138,7 +150,12 @@ jobs:
           #
           # Only an explicit MERGED or CLOSED counts. Anything else - including an API call that
           # failed - leaves the ref alone, because the cost of guessing wrong is a cold rebuild.
+          # But failed lookups are *counted* and surfaced in the summary: if every one fails (say,
+          # the token has lost the 'pull-requests: read' scope) this pass is doing nothing, and
+          # that must not look like a healthy sweep of a tidy repository.
+          # (The '|| true' belongs to grep, whose exit 1 just means no pull-request refs exist.)
           abandoned_refs=""
+          unknown=0
           for ref in $(printf '%s\n' "${all}" | cut -f3 | grep '^refs/pull/' | sort -u || true); do
               number=${ref#refs/pull/}
               number=${number%/merge}
@@ -146,14 +163,23 @@ jobs:
               echo "pull request #${number} is ${state}"
               case "${state}" in
                   MERGED|CLOSED) abandoned_refs="${abandoned_refs}${ref}"$'\n' ;;
+                  OPEN) ;;
+                  *) unknown=$((unknown + 1)) ;;
               esac
           done
 
-          # Pass 2: entries superseded within their own (ref, key prefix) group. Stripping the last
-          # '-'-separated segment off a key recovers exactly the prefix CI restores by, for all
-          # three key shapes in this repository, because in every one the volatile segment is last:
+          # Pass 2: entries superseded within their own (ref, key prefix) group. Only the key
+          # shapes named below take part; in each of them the volatile segment - the commit SHA or
+          # the run id - is last, so stripping the last '-'-separated segment recovers exactly the
+          # prefix CI restores by:
           # 'sccache-gplates-<platform>-<sha>', 'sccache-pygplates-<platform>-<sha>' and
           # 'pygplates-wheel-deps-<id>[-target<x>]-<hash>-<run-id>'.
+          #
+          # Any key this sweep does not recognise is logged and left to GitHub's 7-day idle
+          # expiry. Fail closed, because "newest per prefix" is only the reachable set for keys
+          # built the 'restore-keys' way: a future cache restored by exact key (the
+          # 'key: foo-<hashFiles(...)>' idiom, with no 'restore-keys') keeps its *older* entries
+          # reachable too, and whoever adds one has no reason to know this file exists.
           #
           # Grouping by ref as well as prefix is not optional: caches are ref-scoped, and dropping
           # the newest 'refs/heads/pygplates' entry because a newer 'refs/heads/gplates' one
@@ -162,7 +188,11 @@ jobs:
           # Keeping exactly one per group is not a heuristic - it is the reachable set. It also
           # needs no special case for a partial cache saved by a failed build: that partial is the
           # newest, so it is the one kept, and the next run restores it and completes it.
-          superseded=$(printf '%s\n' "${all}" | awk -F'\t' '
+          recognised='^(sccache-(gplates|pygplates)-|pygplates-wheel-deps-)'
+          printf '%s\n' "${all}" | awk -F'\t' -v re="${recognised}" \
+              '$2 !~ re { print "pass 2 does not recognise " $2 " (" $3 ") - leaving it alone" }'
+          superseded=$(printf '%s\n' "${all}" | awk -F'\t' -v re="${recognised}" '
+              $2 !~ re { next }
               { prefix = $2; sub(/-[^-]*$/, "", prefix) }
               seen[$3 "\t" prefix]++ { print }
           ')
@@ -182,6 +212,12 @@ jobs:
               echo
               if [ "${DRY_RUN}" = true ]; then
                   echo "Dry run - nothing was deleted."
+                  echo
+              fi
+              if [ "${unknown}" -gt 0 ]; then
+                  echo "**Warning: ${unknown} pull-request state lookup(s) failed** - those refs" \
+                       "were left alone this run. If this repeats nightly, the abandoned-ref pass" \
+                       "is broken (a missing 'pull-requests: read' permission, most likely)."
                   echo
               fi
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -1,0 +1,232 @@
+# Deletes GitHub Actions caches that nothing can restore any more.
+#
+# The whole repository shares a 10 GB Actions cache budget with LRU eviction. Nothing ever
+# reclaimed it, and in August 2026 it filled to the point where every 'sccache-gplates-*' entry
+# had been evicted and a merge built all three platforms cold - a 30-60 minute penalty per
+# platform. GitHub's own 7-day idle expiry does eventually clear the debris, so the point of this
+# workflow is not garbage collection for its own sake: it is keeping the *peak* under 10 GB during
+# an active week, which is exactly when an eviction costs the most.
+#
+# Two kinds of cache go stale here, for different reasons.
+#
+# Superseded entries. Every cache key in this repository deliberately ends in a segment that never
+# repeats - the commit SHA for the compiler caches, the run id for the wheel dependencies - so the
+# primary key never hits and 'restore-keys' does the real work by prefix. That is what lets an
+# incomplete cache be completed by a later run. But it also means every push and every run adds an
+# entry under each prefix while nothing removes the old ones, and because 'restore-keys' returns
+# the *most recently created* match, only the newest entry of each prefix is reachable at all.
+# Everything behind it is already dead.
+#
+# Abandoned pull-request caches. A cache is scoped to the ref that wrote it, and a run can restore
+# only from its own ref, its base branch and the default branch. 'build-wheels.yml' runs on
+# 'pull_request', so its multi-gigabyte dependency caches land on 'refs/pull/<n>/merge' and become
+# unreachable the moment the pull request closes. That is where the bulk of the waste is: one
+# merged wheels pull request was holding 1.39 GB of the 1.92 GB in use.
+#
+# Deleting a cache is not free - it costs whoever needed it a rebuild - so both rules are
+# conservative, and 'workflow_dispatch' can rehearse the sweep without deleting anything.
+name: prune actions caches
+
+on:
+  schedule:
+    # Daily, at 03:27 in Sydney (17:27 UTC). Off the hour because GitHub's scheduler is most
+    # congested there and delays a run by however long the backlog takes to clear.
+    #
+    # Note that GitHub disables scheduled workflows in a repository that has seen no activity for
+    # 60 days; if the sweep ever goes quiet, check that first.
+    - cron: '27 17 * * *'
+  pull_request_target:
+    # Frees a pull request's caches as it closes, rather than leaving up to a gigabyte and a half
+    # parked until the nightly sweep notices.
+    #
+    # 'pull_request_target' rather than 'pull_request' for two reasons: it runs the base branch's
+    # copy of this file, so a pull request need not carry it, and it gets a token that can write,
+    # which a pull request from a fork does not. The usual reason to be wary of this trigger -
+    # that it grants a writable token to a workflow which may be handling untrusted code - does
+    # not apply: the job below checks nothing out and runs nothing from the pull request. It reads
+    # one integer from the event payload and calls the REST API with it.
+    types: [ closed ]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: List what would be deleted, without deleting anything
+        type: boolean
+        default: true
+
+# Not per-ref, unlike the build workflows: two sweeps must never race on the same delete. Not
+# cancelled either - the job takes seconds, and a half-finished prune is worse than a queued one.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: prune
+    runs-on: ubuntu-latest
+    # Seconds of API calls. The ceiling is only here to stop a hung request holding a runner.
+    timeout-minutes: 10
+
+    # The one scope this needs. Being a job-level block it also drops every other permission,
+    # which is right: this job checks nothing out and touches nothing but the cache API.
+    permissions:
+      actions: write
+
+    env:
+      # 'gh' needs a token and a repository. Supplying both here is what lets the job skip the
+      # checkout that 'gh' would otherwise need to infer the repository from the git remote.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      # Only 'workflow_dispatch' offers the input; on the other two events the 'inputs' context is
+      # empty and this falls through to a real run.
+      DRY_RUN: ${{ inputs.dry-run || false }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Delete the caches of the closed pull request
+        if: github.event_name == 'pull_request_target'
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        # Listed before deleting because 'gh cache delete --all' reports only a count, and the run
+        # summary is the only place anyone will look. '--succeed-on-no-caches' is mandatory
+        # alongside '--all': without it a pull request that cached nothing fails the run.
+        run: |
+          ref="refs/pull/${PR_NUMBER}/merge"
+
+          rows=$(gh cache list --limit 1000 --ref "${ref}" --sort size_in_bytes --order desc \
+                     --json key,sizeInBytes \
+                     -q '.[] | "| `\(.key)` | \(.sizeInBytes / 1048576 | floor) MiB |"' || true)
+
+          gh cache delete --all --ref "${ref}" --succeed-on-no-caches
+
+          {
+              echo "### Caches freed by closing #${PR_NUMBER}"
+              echo
+              if [ -n "${rows}" ]; then
+                  echo "| key | size |"
+                  echo "| --- | ---: |"
+                  echo "${rows}"
+              else
+                  echo "None - the pull request left no caches on \`${ref}\`."
+              fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Prune superseded and abandoned caches
+        if: github.event_name != 'pull_request_target'
+        # Both passes work from one listing, ordered newest first: 'restore-keys' returns the most
+        # recently created match, so within any group the first row is the only one CI can still
+        # restore.
+        run: |
+          all=$(gh cache list --limit 1000 --sort created_at --order desc \
+                    --json id,key,ref,sizeInBytes \
+                    -q '.[] | [.id, .key, .ref, .sizeInBytes] | @tsv' || true)
+
+          if [ -z "${all}" ]; then
+              echo "### Cache prune" >> "${GITHUB_STEP_SUMMARY}"
+              echo >> "${GITHUB_STEP_SUMMARY}"
+              echo "The repository holds no caches." >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+          fi
+
+          # Pass 1: refs belonging to pull requests that are no longer open. Such a cache can only
+          # ever be restored by that same pull request, so it is unreachable by construction
+          # whatever its key. The 'pull_request_target' trigger above catches these as they close;
+          # this is the catch-up path for pull requests that closed before this workflow existed,
+          # or whose close-event run failed.
+          #
+          # Only an explicit MERGED or CLOSED counts. Anything else - including an API call that
+          # failed - leaves the ref alone, because the cost of guessing wrong is a cold rebuild.
+          abandoned_refs=""
+          for ref in $(printf '%s\n' "${all}" | cut -f3 | grep '^refs/pull/' | sort -u || true); do
+              number=${ref#refs/pull/}
+              number=${number%/merge}
+              state=$(gh pr view "${number}" --json state -q .state 2>/dev/null || echo UNKNOWN)
+              echo "pull request #${number} is ${state}"
+              case "${state}" in
+                  MERGED|CLOSED) abandoned_refs="${abandoned_refs}${ref}"$'\n' ;;
+              esac
+          done
+
+          # Pass 2: entries superseded within their own (ref, key prefix) group. Stripping the last
+          # '-'-separated segment off a key recovers exactly the prefix CI restores by, for all
+          # three key shapes in this repository, because in every one the volatile segment is last:
+          # 'sccache-gplates-<platform>-<sha>', 'sccache-pygplates-<platform>-<sha>' and
+          # 'pygplates-wheel-deps-<id>[-target<x>]-<hash>-<run-id>'.
+          #
+          # Grouping by ref as well as prefix is not optional: caches are ref-scoped, and dropping
+          # the newest 'refs/heads/pygplates' entry because a newer 'refs/heads/gplates' one
+          # happened to share its prefix would cost that branch a cold build.
+          #
+          # Keeping exactly one per group is not a heuristic - it is the reachable set. It also
+          # needs no special case for a partial cache saved by a failed build: that partial is the
+          # newest, so it is the one kept, and the next run restores it and completes it.
+          superseded=$(printf '%s\n' "${all}" | awk -F'\t' '
+              { prefix = $2; sub(/-[^-]*$/, "", prefix) }
+              seen[$3 "\t" prefix]++ { print }
+          ')
+
+          doomed=$(
+              {
+                  printf '%s' "${abandoned_refs}" | while read -r ref; do
+                      [ -n "${ref}" ] || continue
+                      printf '%s\n' "${all}" | awk -F'\t' -v ref="${ref}" '$3 == ref'
+                  done
+                  printf '%s\n' "${superseded}"
+              } | grep -v '^[[:space:]]*$' | sort -u || true
+          )
+
+          {
+              echo "### Cache prune"
+              echo
+              if [ "${DRY_RUN}" = true ]; then
+                  echo "Dry run - nothing was deleted."
+                  echo
+              fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ -z "${doomed}" ]; then
+              echo "Every cache is still reachable; nothing to delete." >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+          fi
+
+          # A here-string rather than a pipe, so the totals survive the loop.
+          deleted=0
+          freed=0
+          rows=""
+          while IFS=$'\t' read -r id key ref size; do
+              [ -n "${id}" ] || continue
+              if [ "${DRY_RUN}" = true ]; then
+                  echo "would delete ${id} ${key} (${ref})"
+              else
+                  echo "deleting ${id} ${key} (${ref})"
+                  # One failure must not abandon the rest of the sweep: a cache can disappear
+                  # between the listing and the delete, and the next run would retry it anyway.
+                  gh cache delete "${id}" || { echo "  ...failed, skipping"; continue; }
+              fi
+              deleted=$((deleted + 1))
+              freed=$((freed + size))
+              rows="${rows}| \`${key}\` | \`${ref}\` | $((size / 1048576)) MiB |"$'\n'
+          done <<< "${doomed}"
+
+          {
+              echo "| key | ref | size |"
+              echo "| --- | --- | ---: |"
+              printf '%s' "${rows}"
+              echo
+              echo "**${deleted} entries, $((freed / 1048576)) MiB.**"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Report the remaining cache usage
+        # Against the 10 GB budget every workflow in this repository is competing for. Always, so
+        # the figure is in the summary even when a prune step failed part way.
+        if: always()
+        run: |
+          usage=$(gh api "repos/${GH_REPO}/actions/cache/usage" \
+                      -q '"\(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1048576 | floor) MiB of 10240 MiB"')
+
+          {
+              echo
+              echo "In use after this run: ${usage}."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/doc-cpp/design/testing/README.md
+++ b/doc-cpp/design/testing/README.md
@@ -120,11 +120,11 @@ take everything.
 - The two workflows are branch-scoped: `build-test-gplates.yml` on `gplates`,
   `build-test-pygplates.yml` on `pygplates`. The branches are normally at the same HEAD, so the
   per-branch split covers both products without doubling CI cost.
-- sccache cache keys are namespaced per product (`sccache-gplates-*` vs the pygplates workflow's
-  `sccache-<platform>-*`): `gplates` is the repository's *default* branch, so its caches are
-  visible to every ref, and the two build configurations share no cache entries (every common
-  translation unit differs in `-fPIC` and the `GPLATES_PYTHON_EMBEDDING` define). All caches
-  share the repository's 10 GB Actions budget.
+- sccache cache keys are namespaced per product (`sccache-gplates-*` and `sccache-pygplates-*`):
+  `gplates` is the repository's *default* branch, so its caches are visible to every ref, and the
+  two build configurations share no cache entries (every common translation unit differs in
+  `-fPIC` and the `GPLATES_PYTHON_EMBEDDING` define). All caches share the repository's 10 GB
+  Actions budget.
 - A possible future change: pyGPlates may stop linking Qt Widgets (it is a non-graphical Python
   module). Nothing in the C++ test design depends on pyGPlates linking Qt GUI libraries — the
   `gplates-unit-test` executable exists only in GPlates build configs.

--- a/doc-cpp/design/testing/README.md
+++ b/doc-cpp/design/testing/README.md
@@ -124,7 +124,8 @@ take everything.
   `gplates` is the repository's *default* branch, so its caches are visible to every ref, and the
   two build configurations share no cache entries (every common translation unit differs in
   `-fPIC` and the `GPLATES_PYTHON_EMBEDDING` define). All caches share the repository's 10 GB
-  Actions budget.
+  Actions budget, which `prune-caches.yml` sweeps nightly — see its header for what it deletes and
+  why an entry stops being reachable.
 - A possible future change: pyGPlates may stop linking Qt Widgets (it is a non-graphical Python
   module). Nothing in the C++ test design depends on pyGPlates linking Qt GUI libraries — the
   `gplates-unit-test` executable exists only in GPlates build configs.


### PR DESCRIPTION
The repository shares a 10 GB Actions cache budget with LRU eviction — a constraint three of the existing workflows already cite as a reason for restraint — and nothing has ever reclaimed it. Yesterday it had filled to the point where every `sccache-gplates-*` entry had been evicted, so #51 built all three platforms cold. A manual sweep then deleted 25 unreachable entries and recovered 7.97 GB.

This adds the workflow that does that on a schedule, and fixes two things the investigation turned up.

## What is actually unreachable

**Superseded entries.** Every cache key here deliberately ends in a segment that never repeats — the commit SHA for the compiler caches, the run id for the wheel dependencies — so the primary key never hits and `restore-keys` does the real work by prefix. That design is right: it is what lets an incomplete cache be *completed* by a later run. But it also means every push adds an entry under each prefix while nothing removes the old ones, and because `restore-keys` returns the **most recently created** match, only the newest entry of each prefix is reachable at all.

So keeping exactly one per (ref, prefix) is not a heuristic — it is precisely the reachable set, and it needs no special case for a partial cache saved by a failed build: that partial is the newest, so it is the one kept, and the next run restores it and completes it. Grouping by ref as well as prefix does matter, though: caches are ref-scoped, and dropping a branch's only copy because another branch has a newer one under the same prefix would cost that branch a cold build.

That reasoning only holds for keys built the `restore-keys` way, so the sweep is fail-closed: it prunes only the key shapes it was derived from, and logs anything else and leaves it to GitHub's 7-day expiry — a future cache restored by *exact* key (the `hashFiles(...)` idiom) keeps its older entries reachable, and whoever adds one has no reason to know this workflow exists. For the same reason the failure modes fail loud: an API error fails the run red rather than reading as "no caches", and failed pull-request state lookups are counted in the run summary.

**Abandoned pull-request caches.** `build-wheels.yml` runs on `pull_request`, so its dependency caches land on `refs/pull/<n>/merge` and become unreachable the moment the pull request closes. That is where the bulk of the waste is — #57 alone was holding 1.39 GB of the 1.92 GB then in use. `pull_request_target: closed` frees them as the pull request closes; the nightly pass catches any it misses.

`pull_request_target` rather than `pull_request` because it runs the base branch's copy of the file and gets a token that can write. The usual objection does not apply here: the job checks nothing out and runs nothing from the pull request — it reads one integer from the event payload and calls the REST API.

GitHub's own 7-day idle expiry does eventually clear all of this, so the goal is not garbage collection for its own sake. It is keeping the *peak* under 10 GB during an active week, which is exactly when an eviction costs the most.

## Two fixes alongside

**A run cancelled before it restored no longer saves a cache.** The save steps were gated `always()`, chosen so a *failed* build still contributes what it compiled. It also fires on cancellation, and the concurrency groups cancel aggressively — that is how three 7–16 MB partial `sccache-gplates-*` entries got written. A run cancelled mid-build is harmless (it saves no less than it restored); the damaging case is one cancelled before or during the *restore*, which saves a near-empty directory under a newer key that then shadows the complete one. So the gate is now `always() && steps.<restore>.outcome == 'success'` — that names the damaging case exactly, while a failed build, a timed-out one (which the runner delivers as a *cancellation*, so `!cancelled()` would drop the salvage-on-timeout that `build-wheels.yml`'s timeout comment promises), and one cancelled mid-build all still save. The wheel dependency cache had the same defect, and is the more expensive one to get wrong.

**The pyGPlates compiler-cache keys are namespaced by product**, `sccache-pygplates-*`, matching `sccache-gplates-*`. Nothing collides today; the asymmetry just invites a future key that is restorable by both workflows, which share no cache entries at all. Costs one cold build per platform on the first push to `pygplates` after this reaches it.

## Verified

The sweep was run against this repository's live cache list before committing, and its classification cross-checked independently: it selected exactly the entries that were either superseded within their (ref, prefix) group or sitting on merged #57's ref, and kept exactly one live entry per prefix per branch. The delete path is confirmed working — #57's caches are already gone.

## After merging

It can only run from `gplates`: GitHub fires `schedule` and registers `workflow_dispatch` from the default branch alone. So dispatch it once with the default `dry-run: true` to see what it proposes before letting it run for real.

