### PR TITLE
Drop Qt6 Core5Compat (QRegExp to QRegularExpression)

### DIFF
--- a/doc-cpp/design/architecture/README.md
+++ b/doc-cpp/design/architecture/README.md
@@ -70,8 +70,8 @@ Enforcement, in CTest (run `ctest --test-dir <build-pygplates> -C Release`):
   (`dumpbin` / `readelf` / `otool`), failing if one of GPlates' GUI/rendering libraries
   (Qt Widgets, Qt Gui, Qt Svg, the Qt OpenGL modules, Qwt, GLEW) appears — or the platform's
   own OpenGL (GLVND's `libOpenGL`/`libGLX`/`libGLdispatch`, the legacy `libGL`, the macOS
-  framework, `opengl32.dll`). There is no exemption: the module links only `Qt6::Core` and
-  `Qt6::Core5Compat`, and a GL library on its link line means a GUI library has crept back in
+  framework, `opengl32.dll`). There is no exemption: the module links only `Qt6::Core`, and a
+  GL library on its link line means a GUI library has crept back in
   (`Qt6::Gui`'s imported target propagates Qt's own OpenGL dependency onto everything linking
   it, which is how the Linux wheel once needed `libGL.so.1` just to be imported).
 

--- a/doc-cpp/design/architecture/dependency-matrix.md
+++ b/doc-cpp/design/architecture/dependency-matrix.md
@@ -29,7 +29,7 @@ in the *column* directory, over every `.h`/`.cc` in the built `src/` subdirector
 | property-values |  |  |  |  |  |  | 42 | 11 | 64 | 5 | 26 | 250 |  |  | 176 |  | 103 |  | 35 |  |
 | qt-widgets |  | 17 | 253 | 7 |  | 8 | 35 | 81 | 134 | 238 | 105 | 244 | 35 | 117 | 180 | 836 |  |  | 59 | 26 |
 | scribe |  |  |  |  |  |  |  |  | 31 |  | 8 |  |  |  |  |  | 172 |  | 23 |  |
-| unit-test |  |  | 2 |  |  | 2 | 3 | 10 | 2 | 5 | 9 | 10 |  |  | 5 |  | 16 | 2 | 6 |  |
+| unit-test |  |  | 2 |  |  | 2 | 3 | 11 | 2 | 5 | 9 | 10 |  |  | 5 |  | 16 | 2 | 6 |  |
 | utils |  | 1 |  |  |  |  |  | 1 | 35 |  | 14 | 7 |  |  | 58 |  | 3 |  | 52 |  |
 | view-operations |  |  | 39 | 6 |  |  | 7 | 5 | 27 | 62 | 92 | 25 |  | 6 | 9 | 1 | 3 |  | 13 | 232 |
 
@@ -62,7 +62,7 @@ Roots: the exporter `.cc` of every `export_*()` call registered in
 | property-values | 127 / 128 |
 | qt-widgets | 0 / 439 |
 | scribe | 56 / 64 |
-| unit-test | 0 / 15 |
+| unit-test | 0 / 16 |
 | utils | 45 / 77 |
 | view-operations | 0 / 82 |
 

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -174,8 +174,8 @@ scikit-build-core (eg, `pip wheel ...`) outside of conda.
 
 ### `OpenGL_GL_PREFERENCE=LEGACY` (Linux) - history, and why the image still sets it
 
-> **No longer set for the module itself.** `pygplates.so` links only `Qt6Core` and
-> `Qt6Core5Compat` (its sources are the include closure of the pyGPlates API — see
+> **No longer set for the module itself.** `pygplates.so` links only `Qt6Core` (its sources
+> are the include closure of the pyGPlates API — see
 > `cmake/pygplates_source_closure.py` — and the last Gui uses, `gui/Colour`'s `QColor`
 > conversions and `file-io/RgbaRasterReader`'s `QImage`, moved to the GPlates side). Nothing on
 > its link line reaches OpenGL, so there is no GL family to choose and `pyproject.toml` no longer

--- a/pygplates/wheel/build_macos_deps.sh
+++ b/pygplates/wheel/build_macos_deps.sh
@@ -71,8 +71,7 @@ fi
 # the Linux image needs, and they're the same binaries the Qt online installer provides).
 #
 # 'qtbase' provides Core, Gui, Network, Widgets, Xml, OpenGL and OpenGLWidgets; 'qtsvg'
-# provides Svg; the 'qt5compat' module provides Core5Compat (QRegExp etc). Qwt below needs
-# Svg/OpenGL too.
+# provides Svg. Qwt below needs Svg/OpenGL too.
 #
 # The official binaries are universal (arm64 + x86_64), so each framework library is thinned
 # to the build architecture - halving what delocate later vendors into the wheels.
@@ -85,7 +84,7 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
     ./aqt-venv/bin/pip -q install 'aqtinstall<4'
     # '--archives qtbase qtsvg' limits the download to the parts of the base package we need
     # (skipping qtdeclarative, qttools etc, which are most of it).
-    ./aqt-venv/bin/aqt install-qt mac desktop ${QT_VERSION} clang_64 -m qt5compat --archives qtbase qtsvg --outputdir "${PYGPLATES_DEPS}/qt"
+    ./aqt-venv/bin/aqt install-qt mac desktop ${QT_VERSION} clang_64 --archives qtbase qtsvg --outputdir "${PYGPLATES_DEPS}/qt"
     ln -sfn "${QT_DIR}" "${PYGPLATES_DEPS}/qt/current"
     # Thin the universal framework libraries to the build architecture.
     for framework in "${QT_DIR}"/lib/Qt*.framework; do
@@ -256,7 +255,6 @@ fi
 "${QT_DIR}/bin/qmake" -query QT_VERSION
 test -d "${QT_DIR}/lib/QtSvg.framework"
 test -d "${QT_DIR}/lib/QtNetwork.framework"
-test -d "${QT_DIR}/lib/QtCore5Compat.framework"
 test -L "${PYGPLATES_DEPS}/qt/current"
 ls "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib"
 ls "${PYGPLATES_DEPS}/lib/libboost_program_options.dylib" "${PYGPLATES_DEPS}/lib/libboost_thread.dylib"

--- a/pygplates/wheel/build_windows_deps.sh
+++ b/pygplates/wheel/build_windows_deps.sh
@@ -119,7 +119,7 @@ fi
 # installer provides, and the same ones the macOS deps script uses).
 #
 # 'qtbase' provides Core, Gui, Network, Widgets, Xml, OpenGL and OpenGLWidgets; 'qtsvg' provides
-# Svg; the 'qt5compat' module provides Core5Compat (QRegExp etc). Qwt below needs Svg/OpenGL too.
+# Svg. Qwt below needs Svg/OpenGL too.
 #
 # Installed to a version-less directory (unlike macOS, which points a 'qt/current' symlink at the
 # versioned one - Git for Windows has no usable symlinks), so the Qt version stays here in
@@ -132,7 +132,7 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
     # '--archives qtbase qtsvg' limits the download to the parts of the base package we need
     # (skipping qtdeclarative, qttools etc, which are most of it).
     ./aqt-venv/Scripts/aqt install-qt windows desktop ${QT_VERSION} win64_msvc2019_64 \
-        -m qt5compat --archives qtbase qtsvg --outputdir qt-download
+        --archives qtbase qtsvg --outputdir qt-download
     mv "qt-download/${QT_VERSION}/msvc2019_64" "${QT_DIR}"
     rm -rf qt-download
 
@@ -366,8 +366,7 @@ require_vcpkg_version() {
 # installed.
 "${QT_DIR}/bin/qmake" -query QT_VERSION
 ls "${QT_DIR}/bin/Qt6Core.dll" "${QT_DIR}/bin/Qt6Gui.dll" "${QT_DIR}/bin/Qt6Widgets.dll" \
-    "${QT_DIR}/bin/Qt6Network.dll" "${QT_DIR}/bin/Qt6Svg.dll" "${QT_DIR}/bin/Qt6OpenGL.dll" \
-    "${QT_DIR}/bin/Qt6Core5Compat.dll"
+    "${QT_DIR}/bin/Qt6Network.dll" "${QT_DIR}/bin/Qt6Svg.dll" "${QT_DIR}/bin/Qt6OpenGL.dll"
 ls "${PYGPLATES_DEPS}/lib/qwt.lib"
 ls "${PYGPLATES_DEPS}/lib/boost_program_options.lib" "${PYGPLATES_DEPS}/lib/boost_thread.lib"
 require_file "${VCPKG_PREFIX}/include/GL/glew.h" "GLEW"

--- a/pygplates/wheel/manylinux_2_28.dockerfile
+++ b/pygplates/wheel/manylinux_2_28.dockerfile
@@ -135,8 +135,8 @@ RUN . /tmp/versions.sh && \
     ldconfig && \
     rm -rf /tmp/build
 
-# Qt (qtbase, qtsvg and qt5compat - pyGPlates needs Core, Gui, Widgets, Xml, OpenGL,
-# OpenGLWidgets and Svg, plus Core5Compat for QRegExp etc, and Qwt below needs Svg/OpenGL).
+# Qt (qtbase and qtsvg - pyGPlates needs Core, Gui, Widgets, Xml, OpenGL, OpenGLWidgets and
+# Svg, and Qwt below needs Svg/OpenGL).
 #
 # FEATURE_xcb=ON is asserted explicitly so that configure *fails* if the xcb dependencies are
 # incomplete (rather than silently building a Qt that cannot connect to an X display).
@@ -171,21 +171,6 @@ RUN . /tmp/versions.sh && \
 WORKDIR /tmp/build
 RUN . /tmp/versions.sh && \
     curl -sSL https://download.qt.io/archive/qt/${QT_VERSION%.*}/${QT_VERSION}/submodules/qtsvg-everywhere-src-${QT_VERSION}.tar.xz | tar xJ --strip-components=1 && \
-    mkdir build && cd build && \
-    cmake -G Ninja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DCMAKE_PREFIX_PATH=/usr/local \
-        -DQT_BUILD_EXAMPLES=OFF \
-        -DQT_BUILD_TESTS=OFF \
-        .. && \
-    ninja && \
-    ninja install && \
-    ldconfig && \
-    rm -rf /tmp/build
-WORKDIR /tmp/build
-RUN . /tmp/versions.sh && \
-    curl -sSL https://download.qt.io/archive/qt/${QT_VERSION%.*}/${QT_VERSION}/submodules/qt5compat-everywhere-src-${QT_VERSION}.tar.xz | tar xJ --strip-components=1 && \
     mkdir build && cd build && \
     cmake -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
@@ -293,7 +278,6 @@ WORKDIR /
 RUN . /tmp/versions.sh && \
     ldconfig && \
     qmake -query QT_VERSION && \
-    test -f /usr/local/lib/libQt6Core5Compat.so -o -f /usr/local/lib64/libQt6Core5Compat.so && \
     test -f /usr/local/lib/libQt6Svg.so -o -f /usr/local/lib64/libQt6Svg.so && \
     ls /usr/local/lib/libqwt.so && \
     for python_version in ${PYTHON_VERSIONS}; do \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,8 +296,8 @@ before-test = "sccache --show-stats"
 # See the notes in [tool.cibuildwheel.config-settings] - this table replaces it, not extends it.
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
 "build-dir" = "build/wheel"
-# No 'OpenGL_GL_PREFERENCE' here any more: the module links only Qt6Core and Qt6Core5Compat,
-# so nothing on its link line reaches OpenGL and there is no GL family to choose. It was
+# No 'OpenGL_GL_PREFERENCE' here any more: the module links only Qt6Core, so nothing on its
+# link line reaches OpenGL and there is no GL family to choose. It was
 # needed while the module linked Qt6Gui (whose imported target propagates Qt's OpenGL
 # dependency) - the history, and the two-libGLdispatch segfault the define prevented, is in
 # 'pygplates/wheel/README.md'. The docker image still sets it when building Qt and GLEW

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,23 +330,22 @@ set(CMAKE_AUTORCC ON)
 # Our minimum supported Ubuntu is Jammy 22.04 which uses Qt 5.15.
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
 #
-# The pygplates module needs only Qt Core (plus Core5Compat under Qt6). In particular it must
-# not link Qt Gui: on Linux and macOS 'Qt6::Gui' propagates Qt's own OpenGL dependency, which
-# is what used to make the Linux wheel require libGL. The Gui, Network, Svg, Widgets and OpenGL
-# modules serve code the module does not compile (see 'cmake/pygplates_source_closure.py' and
-# the pygplates-linkage test). All of the module's XML work, the GeoSciML reader included, is
-# QXmlStreamReader/Writer, which lives in Core under both Qt5 and Qt6.
+# The pygplates module needs only Qt Core. In particular it must not link Qt Gui: on Linux and
+# macOS 'Qt6::Gui' propagates Qt's own OpenGL dependency, which is what used to make the Linux
+# wheel require libGL. The Gui, Network, Svg, Widgets and OpenGL modules serve code the module
+# does not compile (see 'cmake/pygplates_source_closure.py' and the pygplates-linkage test).
+# All of the module's XML work, the GeoSciML reader included, is QXmlStreamReader/Writer, which
+# lives in Core under both Qt5 and Qt6.
 #
 if (QT_VERSION_MAJOR EQUAL 6)
-	# Temporarily use Core5Compat API (until fully moved to Qt6) so can still use some deprecated Qt5 APIs.
-	# For example, QRegExp instead of QRegularExpression.
-	# Remove Core5Compat when no longer supporting Qt5.
+	# Note: We don't need Qt6::Core5Compat since we no longer use any Qt5-only APIs
+	# (the last was QRegExp, now QRegularExpression, which is in Qt Core under both Qt5 and Qt6).
 	#
-	# Also Qt6 moved the QOpenGL* classes from (Gui and Widgets modules in Qt5) into OpenGL (and new OpenGLWidgets) modules.
+	# Qt6 moved the QOpenGL* classes from (Gui and Widgets modules in Qt5) into OpenGL (and new OpenGLWidgets) modules.
 	if (GPLATES_BUILD_GPLATES)
-		find_package(Qt6 REQUIRED COMPONENTS Core Gui Network Svg Widgets Xml Core5Compat OpenGL OpenGLWidgets)
+		find_package(Qt6 REQUIRED COMPONENTS Core Gui Network Svg Widgets Xml OpenGL OpenGLWidgets)
 	else()
-		find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat)
+		find_package(Qt6 REQUIRED COMPONENTS Core)
 	endif()
 else()
 	# In Qt5, the modern QOpenGL* classes are in the Gui and Widgets modules (not OpenGL and OpenGLWidgets modules).
@@ -1036,8 +1035,8 @@ endif()
 #
 # Qt dependency.
 #
-# The pygplates module links only Qt Core (plus Core5Compat under Qt6) - see the Qt
-# find_package split above for why. The pygplates-linkage test fails if Gui creeps back in.
+# The pygplates module links only Qt Core - see the Qt find_package split above for why.
+# The pygplates-linkage test fails if Gui creeps back in.
 target_link_libraries(${SOURCE_TARGET} PUBLIC Qt${QT_VERSION_MAJOR}::Core)
 if (GPLATES_BUILD_GPLATES)
 	target_link_libraries(${SOURCE_TARGET} PUBLIC
@@ -1048,10 +1047,6 @@ if (GPLATES_BUILD_GPLATES)
 			Qt${QT_VERSION_MAJOR}::Xml)
 endif()
 if (QT_VERSION_MAJOR EQUAL 6)
-	# Temporarily use Core5Compat API (until fully moved to Qt6) so can still use some deprecated Qt5 APIs.
-	# For example, QRegExp instead of QRegularExpression.
-	# Remove this when no longer supporting Qt5.
-	target_link_libraries(${SOURCE_TARGET} PUBLIC Qt6::Core5Compat)
 	if (GPLATES_BUILD_GPLATES)
 		# Qt6 moved the QOpenGL* classes from (Gui module in Qt5) back into OpenGL (and new OpenGLWidgets) modules.
 		target_link_libraries(${SOURCE_TARGET} PUBLIC Qt6::OpenGL Qt6::OpenGLWidgets)

--- a/src/api/APIVersion.cc
+++ b/src/api/APIVersion.cc
@@ -176,9 +176,12 @@ GPlatesApi::Version::extract_release_suffix(
 	// Note the trailing "\z" (end of string) rather than "$" (which would also match just before
 	// a trailing newline).
 	const QRegularExpression release_suffix_regex(
-			"^(?:(a|b|rc)(0|[1-9][0-9]*))?(?:\\.post(0|[1-9][0-9]*))?(?:\\.dev(0|[1-9][0-9]*))?\\z");
+			"^(?:(a|b|rc)(0|[1-9][0-9]*))?"
+			"(?:\\.post(0|[1-9][0-9]*))?"
+			"(?:\\.dev(0|[1-9][0-9]*))?\\z");
 
-	const QRegularExpressionMatch release_suffix_match = release_suffix_regex.match(release_suffix_string);
+	const QRegularExpressionMatch release_suffix_match =
+			release_suffix_regex.match(release_suffix_string);
 
 	if (!release_suffix_match.hasMatch())
 	{

--- a/src/api/APIVersion.cc
+++ b/src/api/APIVersion.cc
@@ -28,7 +28,7 @@
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
 #include <QDebug>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
@@ -118,21 +118,27 @@ GPlatesApi::Version::Version(
 	bool valid_version = true;
 
 	// Version string should match "N.N[.N][<release_suffix>]".
-	const QRegExp version_regex("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:\\.(0|[1-9][0-9]*))?(.+)?$");
+	//
+	// Note the trailing "\z" (end of string) rather than "$" (which would also match just before
+	// a trailing newline, and so would accept "1.2\n" as a valid version string).
+	const QRegularExpression version_regex(
+			"^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:\\.(0|[1-9][0-9]*))?(.+)?\\z");
 
-	if (version_regex.indexIn(version_string) == -1)
+	const QRegularExpressionMatch version_match = version_regex.match(version_string);
+
+	if (!version_match.hasMatch())
 	{
 		valid_version = false;
 	}
 	else
 	{
 		// Extract from regex.
-		d_major = version_regex.cap(1).toUInt();
-		d_minor = version_regex.cap(2).toUInt();
+		d_major = version_match.captured(1).toUInt();
+		d_minor = version_match.captured(2).toUInt();
 
 		// Extract optional patch (defaults to 0).
 		d_patch = 0;
-		const QString patch_match = version_regex.cap(3);
+		const QString patch_match = version_match.captured(3);
 		if (!patch_match.isEmpty())
 		{
 			// Convert patch string to integer.
@@ -140,7 +146,7 @@ GPlatesApi::Version::Version(
 		}
 
 		// Extract optional release suffix (defaults to none).
-		const QString release_suffix_match = version_regex.cap(4);
+		const QString release_suffix_match = version_match.captured(4);
 		if (!release_suffix_match.isEmpty())
 		{
 			if (!extract_release_suffix(release_suffix_match))
@@ -166,17 +172,22 @@ GPlatesApi::Version::extract_release_suffix(
 		QString release_suffix_string)
 {
 	// Release suffix should match "[{a|b|rc}N][.postN][.devN]".
-	const QRegExp release_suffix_regex(
-			"^(?:(a|b|rc)(0|[1-9][0-9]*))?(?:\\.post(0|[1-9][0-9]*))?(?:\\.dev(0|[1-9][0-9]*))?$");
+	//
+	// Note the trailing "\z" (end of string) rather than "$" (which would also match just before
+	// a trailing newline).
+	const QRegularExpression release_suffix_regex(
+			"^(?:(a|b|rc)(0|[1-9][0-9]*))?(?:\\.post(0|[1-9][0-9]*))?(?:\\.dev(0|[1-9][0-9]*))?\\z");
 
-	if (release_suffix_regex.indexIn(release_suffix_string) == -1)
+	const QRegularExpressionMatch release_suffix_match = release_suffix_regex.match(release_suffix_string);
+
+	if (!release_suffix_match.hasMatch())
 	{
 		// Regular expression didn't match so the release suffix string is not valid.
 		return false;
 	}
 
 	// Extract from pre-release suffix (if any) from regex.
-	const QString pre_release_suffix_type_string = release_suffix_regex.cap(1);
+	const QString pre_release_suffix_type_string = release_suffix_match.captured(1);
 	if (!pre_release_suffix_type_string.isEmpty())
 	{
 		// Convert type string to type enum.
@@ -200,13 +211,13 @@ GPlatesApi::Version::extract_release_suffix(
 			GPlatesGlobal::Abort(GPLATES_ASSERTION_SOURCE);
 		}
 
-		const unsigned int pre_release_suffix_number = release_suffix_regex.cap(2).toUInt();
+		const unsigned int pre_release_suffix_number = release_suffix_match.captured(2).toUInt();
 
 		d_pre_release_suffix = PreReleaseSuffix{ pre_release_suffix_type, pre_release_suffix_number };
 	}
 
 	// Extract from post-release suffix (if any) from regex.
-	const QString post_release_suffix_number_string = release_suffix_regex.cap(3);
+	const QString post_release_suffix_number_string = release_suffix_match.captured(3);
 	if (!post_release_suffix_number_string.isEmpty())
 	{
 		const unsigned int post_release_suffix_number = post_release_suffix_number_string.toUInt();
@@ -215,7 +226,7 @@ GPlatesApi::Version::extract_release_suffix(
 	}
 
 	// Extract from development-release suffix (if any) from regex.
-	const QString development_release_suffix_number_string = release_suffix_regex.cap(4);
+	const QString development_release_suffix_number_string = release_suffix_match.captured(4);
 	if (!development_release_suffix_number_string.isEmpty())
 	{
 		const unsigned int development_release_suffix_number = development_release_suffix_number_string.toUInt();

--- a/src/file-io/CptReader.cc
+++ b/src/file-io/CptReader.cc
@@ -682,21 +682,13 @@ void
 GPlatesFileIO::CptParser::process_comment(
 		const QString& line)
 {
-	//remove all spaces
-	QString str = line.toUpper();
-	int i = 0;
-	while( i<str.length() )
-	{
-		if(str.at(i).isSpace())
-			str = str.remove(i,1);
-		else
-			i++;
-	}
-
-	static const QRegularExpression hsv_regex("COLOR_MODEL\\s*=\\s*\\+?HSV");
+	// Match case-insensitively since GMT writes "# COLOR_MODEL = hsv" in lower case.
+	static const QRegularExpression hsv_regex(
+			"COLOR_MODEL\\s*=\\s*\\+?HSV",
+			QRegularExpression::CaseInsensitiveOption);
 	if(hsv_regex.match(line).hasMatch())
 	{
-			d_default_model = HSV;
+		d_default_model = HSV;
 	}
 }
 

--- a/src/file-io/CptReader.cc
+++ b/src/file-io/CptReader.cc
@@ -29,7 +29,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "CptReader.h"
 
@@ -693,8 +693,8 @@ GPlatesFileIO::CptParser::process_comment(
 			i++;
 	}
 
-	static const QRegExp hsv_regex("COLOR_MODEL\\s*=\\s*\\+?HSV");			
-	if(-1 != hsv_regex.indexIn(line))
+	static const QRegularExpression hsv_regex("COLOR_MODEL\\s*=\\s*\\+?HSV");
+	if(hsv_regex.match(line).hasMatch())
 	{
 			d_default_model = HSV;
 	}
@@ -704,8 +704,8 @@ GPlatesFileIO::CptParser::ColourData
 GPlatesFileIO::CptParser::parse_gmt_fill(
 		const QString& token)
 {
-	QRegExp rx("p\\d+/");
-	if(rx.indexIn(token) != -1)
+	static const QRegularExpression rx("p\\d+/");
+	if(rx.match(token).hasMatch())
 	{
 		//We don't support "fill pattern" yet. 
 		//It looks something like "p200/16". 
@@ -717,7 +717,7 @@ GPlatesFileIO::CptParser::parse_gmt_fill(
 	ColourData data;
 
 	//TODO: this function needs to be rewritten.
-	//try QRegExp
+	//try QRegularExpression
 	if (token.contains('/'))
 	{
 		// R/G/B triplet.

--- a/src/file-io/DeformationExport.cc
+++ b/src/file-io/DeformationExport.cc
@@ -24,7 +24,6 @@
  */
 
 #include <QLocale>
-#include <QRegExp>
 #include <QTextStream>
 
 #include "DeformationExport.h"

--- a/src/file-io/ExportTemplateFilenameSequenceFormats.cc
+++ b/src/file-io/ExportTemplateFilenameSequenceFormats.cc
@@ -24,7 +24,7 @@
  */
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "ExportTemplateFilenameSequenceFormats.h"
 
@@ -217,16 +217,17 @@ boost::optional<int>
 GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::match_format(
 		const QString &rest_of_filename_template)
 {
-	QRegExp regex = get_full_regular_expression();
+	const QRegularExpression &regex = get_full_regular_expression();
 
-	if (regex.indexIn(rest_of_filename_template) == -1)
+	const QRegularExpressionMatch match = regex.match(rest_of_filename_template);
+	if (!match.hasMatch())
 	{
 		// Regular expression didn't match so this is not our format string.
 		return boost::none;
 	}
 
 	// Get the entire matched string.
-	const QString format_string = regex.cap(0);
+	const QString format_string = match.captured(0);
 	return format_string.size();
 }
 
@@ -235,11 +236,11 @@ GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::Reconstru
 		const QString &format_string) :
 	d_format_string(format_string.toStdString())
 {
-	QRegExp regex = get_integer_regular_expression();
+	const QRegularExpression &regex = get_integer_regular_expression();
 
 	// See if we need to convert the reconstruction time to the nearest integer before
 	// passing to printf-style format specifier.
-	d_is_integer_format = (regex.indexIn(format_string) != -1);
+	d_is_integer_format = regex.match(format_string).hasMatch();
 }
 
 
@@ -264,7 +265,7 @@ GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::expand_fo
 }
 
 
-const QRegExp &
+const QRegularExpression &
 GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::get_full_regular_expression()
 {
 	// QString::sprintf() does not support the length modifiers (eg, h for short, ll for long long)
@@ -274,18 +275,21 @@ GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::get_full_
 	// Where flags is one or more of space, +, -, 0, #.
 	// And 'length' has been omitted.
 	// And 'specifier' is limited to 'd' and 'f'.
-	static QRegExp s_regex("^%[ +-#0]*\\d*(?:\\.\\d+)?[df]");
+	//
+	// Note the '-' is listed first in the flags character class so that it is a literal '-'
+	// rather than the start of a character range.
+	static const QRegularExpression s_regex("^%[-+ #0]*\\d*(?:\\.\\d+)?[df]");
 
 	return s_regex;
 }
 
 
-const QRegExp &
+const QRegularExpression &
 GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat::get_integer_regular_expression()
 {
 	// Same as returned by 'get_full_regular_expression()' but only for
 	// the '%d' integer specifier.
-	static QRegExp s_regex("^%[ +-#0]*\\d*(?:\\.\\d+)?d");
+	static const QRegularExpression s_regex("^%[-+ #0]*\\d*(?:\\.\\d+)?d");
 
 	return s_regex;
 }

--- a/src/file-io/ExportTemplateFilenameSequenceFormats.h
+++ b/src/file-io/ExportTemplateFilenameSequenceFormats.h
@@ -31,7 +31,7 @@
 #include <boost/optional.hpp>
 #include <QDateTime>
 #include <QString>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "global/AssertionFailureException.h"
 #include "model/types.h"
@@ -425,12 +425,12 @@ namespace GPlatesFileIO
 
 			//! Returns regular expression used to match reconstruction time printf-style.
 			static
-			const QRegExp &
+			const QRegularExpression &
 			get_full_regular_expression();
 
 			//! Returns regular expression used to match reconstruction time printf-style integer.
 			static
-			const QRegExp &
+			const QRegularExpression &
 			get_integer_regular_expression();
 		};
 

--- a/src/file-io/MultiPointVectorFieldExport.cc
+++ b/src/file-io/MultiPointVectorFieldExport.cc
@@ -267,21 +267,25 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_ter
 
 	// Convert the velocity domain file name template to a regular expression by replacing the
 	// placeholders with regular expressions that match the Terra integer parameters.
+	// The template is user-entered, so escape it first (and hence also search for the escaped
+	// placeholders) so that any regular expression metacharacters in it are matched literally.
 	const QString unsigned_integer_reg_exp_string("(\\d+)");
-	QString velocity_domain_file_name_reg_exp_string(velocity_domain_file_name_template);
+	QString velocity_domain_file_name_reg_exp_string =
+			QRegularExpression::escape(velocity_domain_file_name_template);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_mt_place_holder,
+			QRegularExpression::escape(velocity_domain_mt_place_holder),
 			unsigned_integer_reg_exp_string);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_nt_place_holder,
+			QRegularExpression::escape(velocity_domain_nt_place_holder),
 			unsigned_integer_reg_exp_string);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_nd_place_holder,
+			QRegularExpression::escape(velocity_domain_nd_place_holder),
 			unsigned_integer_reg_exp_string);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_processor_place_holder,
+			QRegularExpression::escape(velocity_domain_processor_place_holder),
 			unsigned_integer_reg_exp_string);
-	const QRegularExpression velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
+	const QRegularExpression velocity_domain_file_name_reg_exp(
+			velocity_domain_file_name_reg_exp_string);
 
 	// Determine the order of the template parameter placeholders.
 	const int index_of_mt = velocity_domain_file_name_template.indexOf(velocity_domain_mt_place_holder);
@@ -409,15 +413,19 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_cit
 
 	// Convert the velocity domain file name template to a regular expression by replacing the
 	// placeholders with regular expressions that match the CitcomS integer parameters.
+	// The template is user-entered, so escape it first (and hence also search for the escaped
+	// placeholders) so that any regular expression metacharacters in it are matched literally.
 	const QString unsigned_integer_reg_exp_string("(\\d+)");
-	QString velocity_domain_file_name_reg_exp_string(velocity_domain_file_name_template);
+	QString velocity_domain_file_name_reg_exp_string =
+			QRegularExpression::escape(velocity_domain_file_name_template);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_density_place_holder,
+			QRegularExpression::escape(velocity_domain_density_place_holder),
 			unsigned_integer_reg_exp_string);
 	velocity_domain_file_name_reg_exp_string.replace(
-			velocity_domain_cap_number_place_holder,
+			QRegularExpression::escape(velocity_domain_cap_number_place_holder),
 			unsigned_integer_reg_exp_string);
-	const QRegularExpression velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
+	const QRegularExpression velocity_domain_file_name_reg_exp(
+			velocity_domain_file_name_reg_exp_string);
 
 	// Determine the order of the template parameter placeholders.
 	const int index_of_density = velocity_domain_file_name_template.indexOf(velocity_domain_density_place_holder);

--- a/src/file-io/MultiPointVectorFieldExport.cc
+++ b/src/file-io/MultiPointVectorFieldExport.cc
@@ -25,7 +25,7 @@
  */
 
 #include <QLocale>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QTextStream>
 
 #include "MultiPointVectorFieldExport.h"
@@ -281,7 +281,7 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_ter
 	velocity_domain_file_name_reg_exp_string.replace(
 			velocity_domain_processor_place_holder,
 			unsigned_integer_reg_exp_string);
-	const QRegExp velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
+	const QRegularExpression velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
 
 	// Determine the order of the template parameter placeholders.
 	const int index_of_mt = velocity_domain_file_name_template.indexOf(velocity_domain_mt_place_holder);
@@ -316,12 +316,14 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_ter
 		const QString velocity_domain_filename = qfile_info.completeBaseName();
 
 		// See if the current velocity domain filename matches the template.
-		if (velocity_domain_file_name_reg_exp.indexIn(velocity_domain_filename) < 0)
+		const QRegularExpressionMatch velocity_domain_file_name_match =
+				velocity_domain_file_name_reg_exp.match(velocity_domain_filename);
+		if (!velocity_domain_file_name_match.hasMatch())
 		{
 			continue;
 		}
 
-		const QStringList template_parameters = velocity_domain_file_name_reg_exp.capturedTexts();
+		const QStringList template_parameters = velocity_domain_file_name_match.capturedTexts();
 
 		// All template parameters must have matched to get here.
 		GPlatesGlobal::Assert<GPlatesGlobal::AssertionFailureException>(
@@ -415,7 +417,7 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_cit
 	velocity_domain_file_name_reg_exp_string.replace(
 			velocity_domain_cap_number_place_holder,
 			unsigned_integer_reg_exp_string);
-	const QRegExp velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
+	const QRegularExpression velocity_domain_file_name_reg_exp(velocity_domain_file_name_reg_exp_string);
 
 	// Determine the order of the template parameter placeholders.
 	const int index_of_density = velocity_domain_file_name_template.indexOf(velocity_domain_density_place_holder);
@@ -442,12 +444,14 @@ GPlatesFileIO::MultiPointVectorFieldExport::export_velocity_vector_fields_to_cit
 		const QString velocity_domain_filename = qfile_info.completeBaseName();
 
 		// See if the current velocity domain filename matches the template.
-		if (velocity_domain_file_name_reg_exp.indexIn(velocity_domain_filename) < 0)
+		const QRegularExpressionMatch velocity_domain_file_name_match =
+				velocity_domain_file_name_reg_exp.match(velocity_domain_filename);
+		if (!velocity_domain_file_name_match.hasMatch())
 		{
 			continue;
 		}
 
-		const QStringList template_parameters = velocity_domain_file_name_reg_exp.capturedTexts();
+		const QStringList template_parameters = velocity_domain_file_name_match.capturedTexts();
 
 		// All template parameters must have matched to get here.
 		GPlatesGlobal::Assert<GPlatesGlobal::AssertionFailureException>(

--- a/src/file-io/PlatesRotationFileProxy.cc
+++ b/src/file-io/PlatesRotationFileProxy.cc
@@ -342,7 +342,7 @@ GPlatesFileIO::RotationFileReaderV2::read(
 		RegExpVector::iterator begin = d_regexp_vec.begin(), end = d_regexp_vec.end();
 		for(;begin != end; begin++)
 		{
-			if( -1 != (*begin)->indexIn(next_line))
+			if((*begin)->match(next_line).hasMatch())
 			{
 				(this->*d_function_map[*begin])(rot_file, d_segmetns);
 				break;
@@ -412,25 +412,26 @@ GPlatesFileIO::RotationFileReaderV2::process_attribute_line(
 		}
 	}
 
+	static const QRegularExpression attr_rx(ATTRIBUTE_REGEXP);
+
 	while(-1 != buf.indexOf(ATTRIBUTE_LEADING_CHARACTER))
 	{
-		QRegExp rx (ATTRIBUTE_REGEXP);
 		bool is_multi_line_attr=false;
-		int idx = rx.indexIn(buf);
-		if(-1 == idx)// no simple attribute
+		QRegularExpressionMatch match = attr_rx.match(buf);
+		if(!match.hasMatch())// no simple attribute
 		{
-			rx = d_multi_line_attr_rx;
-			idx = rx.indexIn(buf);
-			if(-1 == idx) // no multiple line attribute either
+			match = d_multi_line_attr_rx.match(buf);
+			if(!match.hasMatch()) // no multiple line attribute either
 				break;
 			else
 				is_multi_line_attr = true;
 		}
 
 		//get the matched strings
-		QString attr_str = rx.cap(0);
-		QString attr_name = rx.cap(1);
-		QString attr_value = rx.cap(2);
+		int idx = match.capturedStart(0);
+		QString attr_str = match.captured(0);
+		QString attr_name = match.captured(1);
+		QString attr_value = match.captured(2);
 		container.push_back(boost::shared_ptr<RotationFileSegment>(
 				new AttributeSegment(attr_name, attr_value, is_multi_line_attr)));
 
@@ -554,11 +555,8 @@ bool
 GPlatesFileIO::RotationFileReaderV2::is_valid_rotation_pole_line(
 		const QString& str)
 {
-	QRegExp rx(ROTATION_POLE_REGEXP);
-	if(-1 == rx.indexIn(str))
-		return false;
-	else
-		return true;
+	static const QRegularExpression rx(ROTATION_POLE_REGEXP);
+	return rx.match(str).hasMatch();
 }
 
 bool
@@ -571,18 +569,19 @@ GPlatesFileIO::RotationFileReaderV2::parse_rotation_pole_line(
 	if(line.startsWith(COMMENT_LEADING_CHARACTER))
 		data.disabled = true;
 
-	QRegExp rx(ROTATION_POLE_REGEXP);
-	
-	if(-1 == rx.indexIn(str))
+	static const QRegularExpression rx(ROTATION_POLE_REGEXP);
+
+	const QRegularExpressionMatch match = rx.match(str);
+	if(!match.hasMatch())
 		return false;
-	
-	data.text = rx.cap(0);
-	data.moving_plate_id = rx.cap(1).toInt(); 
-	data.time = rx.cap(2).toDouble();
-	data.lat = rx.cap(3).toDouble();
-	data.lon = rx.cap(4).toDouble();
-	data.angle = rx.cap(5).toDouble();
-	data.fix_plate_id = rx.cap(6).toInt();
+
+	data.text = match.captured(0);
+	data.moving_plate_id = match.captured(1).toInt();
+	data.time = match.captured(2).toDouble();
+	data.lat = match.captured(3).toDouble();
+	data.lon = match.captured(4).toDouble();
+	data.angle = match.captured(5).toDouble();
+	data.fix_plate_id = match.captured(6).toInt();
 	return true;
 }
 

--- a/src/file-io/PlatesRotationFileProxy.cc
+++ b/src/file-io/PlatesRotationFileProxy.cc
@@ -264,11 +264,13 @@ GPlatesFileIO::PlatesRotationFileProxy::init(
 
 
 GPlatesFileIO::RotationFileReaderV2::RotationFileReaderV2() :
-	d_commnet_line_rx(COMMENT_LINE_REGEXP),
-	d_pole_rx(ROTATION_POLE_REGEXP),
-	d_attr_rx(ATTRIBUTE_LINE_REGEXP),
+	// Rotation files are user data, so match "\s" and "\d" against Unicode whitespace and digits
+	// (as QRegExp did) rather than the ASCII-only default of QRegularExpression.
+	d_commnet_line_rx(COMMENT_LINE_REGEXP, QRegularExpression::UseUnicodePropertiesOption),
+	d_pole_rx(ROTATION_POLE_REGEXP, QRegularExpression::UseUnicodePropertiesOption),
+	d_attr_rx(ATTRIBUTE_LINE_REGEXP, QRegularExpression::UseUnicodePropertiesOption),
 	d_multi_line_attr_rx(MULTI_LINE_ATTR_REGEXP),
-	d_mprs_header_rx(MPRS_HEADER_REGEXP),
+	d_mprs_header_rx(MPRS_HEADER_REGEXP, QRegularExpression::UseUnicodePropertiesOption),
 	d_last_moving_pid(0),
 	d_processing_mprs(false)
 {
@@ -555,8 +557,7 @@ bool
 GPlatesFileIO::RotationFileReaderV2::is_valid_rotation_pole_line(
 		const QString& str)
 {
-	static const QRegularExpression rx(ROTATION_POLE_REGEXP);
-	return rx.match(str).hasMatch();
+	return d_pole_rx.match(str).hasMatch();
 }
 
 bool
@@ -569,9 +570,7 @@ GPlatesFileIO::RotationFileReaderV2::parse_rotation_pole_line(
 	if(line.startsWith(COMMENT_LEADING_CHARACTER))
 		data.disabled = true;
 
-	static const QRegularExpression rx(ROTATION_POLE_REGEXP);
-
-	const QRegularExpressionMatch match = rx.match(str);
+	const QRegularExpressionMatch match = d_pole_rx.match(str);
 	if(!match.hasMatch())
 		return false;
 

--- a/src/file-io/PlatesRotationFileProxy.h
+++ b/src/file-io/PlatesRotationFileProxy.h
@@ -30,7 +30,7 @@
 
 #include <boost/tuple/tuple.hpp>
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QTextStream>
 
 #include "File.h"
@@ -713,13 +713,13 @@ namespace GPlatesFileIO
 				RotationPoleData&);
 	protected:
 		
-		QRegExp d_commnet_line_rx, d_pole_rx, d_attr_rx, 
-			d_multi_line_attr_rx, d_disabled_pole_rx, d_mprs_header_rx;
-		
+		QRegularExpression d_commnet_line_rx, d_pole_rx, d_attr_rx,
+			d_multi_line_attr_rx, d_mprs_header_rx;
+
 		typedef void (RotationFileReaderV2::*function)
 			(QIODevice&, RotationFileSegmentContainer&) ;
-		typedef std::map<QRegExp*, function> FunctionMap;
-		typedef std::vector<QRegExp*> RegExpVector;
+		typedef std::map<QRegularExpression*, function> FunctionMap;
+		typedef std::vector<QRegularExpression*> RegExpVector;
 
 		FunctionMap d_function_map;
 		RegExpVector d_regexp_vec;

--- a/src/file-io/ReconstructedScalarCoverageExport.cc
+++ b/src/file-io/ReconstructedScalarCoverageExport.cc
@@ -24,7 +24,6 @@
  */
 
 #include <QLocale>
-#include <QRegExp>
 #include <QTextStream>
 
 #include "ReconstructedScalarCoverageExport.h"

--- a/src/gplates-lib_pch.h
+++ b/src/gplates-lib_pch.h
@@ -310,7 +310,6 @@
 #include <QRadioButton>
 #include <QRect>
 #include <QRectF>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QResizeEvent>
 #include <QScopedPointer>

--- a/src/gui/CommandServer.h
+++ b/src/gui/CommandServer.h
@@ -35,7 +35,6 @@
 #include <QTcpSocket>
 #include <QTimer>
 #include <QStringList>
-#include <QRegExp>
 #include <QXmlStreamReader>
 
 #include "app-logic/ApplicationState.h"

--- a/src/gui/PythonManager.cc
+++ b/src/gui/PythonManager.cc
@@ -80,7 +80,8 @@ GPlatesGui::PythonManager::PythonManager() :
 	d_show_python_init_fail_dlg = user_pref.get_value("python/show_python_init_fail_dialog").toBool();
 	d_python_home = user_pref.get_value("python/python_home").toString();
 
-	static const QRegularExpression rx("^\\d.\\d"); // Match d.d
+	// Match the leading "major.minor" (eg, "3.12" from "3.12.4 (main, ...)").
+	static const QRegularExpression rx("^\\d+\\.\\d+");
 	d_python_version = rx.match(QString(Py_GetVersion())).captured();
 	//qDebug() << "Python Version: " << d_python_version;
 }

--- a/src/gui/PythonManager.cc
+++ b/src/gui/PythonManager.cc
@@ -30,6 +30,7 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QMap>
+#include <QRegularExpression>
 #include <iostream>
 #include <string>
 
@@ -79,9 +80,8 @@ GPlatesGui::PythonManager::PythonManager() :
 	d_show_python_init_fail_dlg = user_pref.get_value("python/show_python_init_fail_dialog").toBool();
 	d_python_home = user_pref.get_value("python/python_home").toString();
 
-	QRegExp rx("^\\d.\\d"); // Match d.d
-	rx.indexIn(QString(Py_GetVersion()));
-	d_python_version = rx.cap();
+	static const QRegularExpression rx("^\\d.\\d"); // Match d.d
+	d_python_version = rx.match(QString(Py_GetVersion())).captured();
 	//qDebug() << "Python Version: " << d_python_version;
 }
 

--- a/src/presentation/TranscribeSession.cc
+++ b/src/presentation/TranscribeSession.cc
@@ -37,7 +37,7 @@
 #include <boost/variant.hpp>
 #include <QDebug>
 #include <QFileInfo>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "TranscribeSession.h"
 
@@ -989,7 +989,7 @@ namespace GPlatesPresentation
 		 * Regular expression for a variant of a draw style name that ends with
 		 * an underscore and a number (eg, "_1").
 		 */
-		const QRegExp DRAW_STYLE_NAME_VARIANT_REGEXP("^(.*)_\\d+$");
+		const QRegularExpression DRAW_STYLE_NAME_VARIANT_REGEXP("^(.*)_\\d+$");
 
 		/**
 		 * Return the draw style name with any integer suffixes (eg, "_1") removed.
@@ -999,9 +999,11 @@ namespace GPlatesPresentation
 				const QString &draw_style_name)
 		{
 			// Return the base part if ends with "_1" for example.
-			if (DRAW_STYLE_NAME_VARIANT_REGEXP.indexIn(draw_style_name) >= 0)
+			const QRegularExpressionMatch draw_style_name_variant_match =
+					DRAW_STYLE_NAME_VARIANT_REGEXP.match(draw_style_name);
+			if (draw_style_name_variant_match.hasMatch())
 			{
-				return DRAW_STYLE_NAME_VARIANT_REGEXP.cap(1);
+				return draw_style_name_variant_match.captured(1);
 			}
 
 			return draw_style_name;

--- a/src/pygplates_pch.h
+++ b/src/pygplates_pch.h
@@ -166,7 +166,7 @@
 #include <QProcess>
 #include <QQueue>
 #include <QRect>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSet>
 #include <QStack>
 #include <QString>

--- a/src/scribe/TranscribeUtils.cc
+++ b/src/scribe/TranscribeUtils.cc
@@ -25,7 +25,7 @@
 
 #include <boost/optional.hpp>
 #include <QDir>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <QtGlobal>
@@ -42,12 +42,12 @@ namespace GPlatesScribe
 		/**
 		 * Regular expression for a Windows drive letter (eg, "C:/").
 		 */
-		const QRegExp WINDOWS_DRIVE_LETTER_REGEXP("^[a-zA-Z]\\:/");
+		const QRegularExpression WINDOWS_DRIVE_LETTER_REGEXP("^[a-zA-Z]\\:/");
 
 		/**
 		 * Regular expression for a Windows share name (eg, "//sharename/").
 		 */
-		const QRegExp WINDOWS_SHARE_NAME_REGEXP("^//[^/]+/");
+		const QRegularExpression WINDOWS_SHARE_NAME_REGEXP("^//[^/]+/");
 
 
 		/**
@@ -64,28 +64,33 @@ namespace GPlatesScribe
 		{
 			QStringList dir_path;
 
-			if (WINDOWS_DRIVE_LETTER_REGEXP.indexIn(file_path) >= 0)
+			// Both regular expressions are anchored at the start of the file path, so the length
+			// of the whole match is the length of the matched prefix.
+			const QRegularExpressionMatch drive_letter_match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
+			const QRegularExpressionMatch share_name_match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
+
+			if (drive_letter_match.hasMatch())
 			{
 				// Split "C:/dir/file.txt" into "C:" and "dir/file.txt" for example.
 
-				const QString drive_letter = file_path.left(WINDOWS_DRIVE_LETTER_REGEXP.matchedLength() - 1);
+				const QString drive_letter = file_path.left(drive_letter_match.capturedLength(0) - 1);
 
 				// Make the drive letters are uppercase so they compare properly later on.
 				// They should already be uppercase if QFileInfo::absoluteFilePath() was used to create them.
 				// But we make sure anyway.
 				dir_path.append(drive_letter.toUpper());
 
-				file_path = file_path.mid(WINDOWS_DRIVE_LETTER_REGEXP.matchedLength());
+				file_path = file_path.mid(drive_letter_match.capturedLength(0));
 			}
-			else if (WINDOWS_SHARE_NAME_REGEXP.indexIn(file_path) >= 0)
+			else if (share_name_match.hasMatch())
 			{
 				// Split "//sharename/dir/file.txt" into "//sharename" and "dir/file.txt" for example.
 
-				const QString share_name = file_path.left(WINDOWS_SHARE_NAME_REGEXP.matchedLength() - 1);
+				const QString share_name = file_path.left(share_name_match.capturedLength(0) - 1);
 
 				dir_path.append(share_name);
 
-				file_path = file_path.mid(WINDOWS_SHARE_NAME_REGEXP.matchedLength());
+				file_path = file_path.mid(share_name_match.capturedLength(0));
 			}
 
 			dir_path = dir_path + file_path.split('/');
@@ -370,7 +375,7 @@ GPlatesScribe::TranscribeUtils::convert_file_path(
 	// Add a Windows drive letter to absolute paths if necessary.
 	if (file_path.startsWith('/') &&
 		// But exclude sharenames ('//sharename/') since they are compatible with Windows...
-		WINDOWS_SHARE_NAME_REGEXP.indexIn(file_path) < 0)
+		!WINDOWS_SHARE_NAME_REGEXP.match(file_path).hasMatch())
 	{
 		// Change "/dir/file.txt" into "C:/dir/file.txt" for example.
 		return QDir::rootPath() + file_path.mid(1);
@@ -378,16 +383,21 @@ GPlatesScribe::TranscribeUtils::convert_file_path(
 
 #else // Mac or Linux...
 
+	// Both regular expressions are anchored at the start of the file path, so the length of the
+	// whole match is the length of the matched prefix.
+	const QRegularExpressionMatch drive_letter_match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
+	const QRegularExpressionMatch share_name_match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
+
 	// Remove Windows drive letter if necessary.
-	if (WINDOWS_DRIVE_LETTER_REGEXP.indexIn(file_path) >= 0)
+	if (drive_letter_match.hasMatch())
 	{
 		// Change "C:/dir/file.txt" into "/dir/file.txt" for example.
-		return '/' + file_path.mid(WINDOWS_DRIVE_LETTER_REGEXP.matchedLength());
+		return '/' + file_path.mid(drive_letter_match.capturedLength(0));
 	}
-	else if (WINDOWS_SHARE_NAME_REGEXP.indexIn(file_path) >= 0)
+	else if (share_name_match.hasMatch())
 	{
 		// Change "//sharename/dir/file.txt" into "/dir/file.txt" for example.
-		return '/' + file_path.mid(WINDOWS_SHARE_NAME_REGEXP.matchedLength());
+		return '/' + file_path.mid(share_name_match.capturedLength(0));
 	}
 
 #endif

--- a/src/scribe/TranscribeUtils.cc
+++ b/src/scribe/TranscribeUtils.cc
@@ -66,31 +66,34 @@ namespace GPlatesScribe
 
 			// Both regular expressions are anchored at the start of the file path, so the length
 			// of the whole match is the length of the matched prefix.
-			const QRegularExpressionMatch drive_letter_match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
-			const QRegularExpressionMatch share_name_match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
-
-			if (drive_letter_match.hasMatch())
+			QRegularExpressionMatch match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
+			if (match.hasMatch())
 			{
 				// Split "C:/dir/file.txt" into "C:" and "dir/file.txt" for example.
 
-				const QString drive_letter = file_path.left(drive_letter_match.capturedLength(0) - 1);
+				const QString drive_letter = file_path.left(match.capturedLength(0) - 1);
 
 				// Make the drive letters are uppercase so they compare properly later on.
 				// They should already be uppercase if QFileInfo::absoluteFilePath() was used to create them.
 				// But we make sure anyway.
 				dir_path.append(drive_letter.toUpper());
 
-				file_path = file_path.mid(drive_letter_match.capturedLength(0));
+				file_path = file_path.mid(match.capturedLength(0));
 			}
-			else if (share_name_match.hasMatch())
+			else
 			{
-				// Split "//sharename/dir/file.txt" into "//sharename" and "dir/file.txt" for example.
+				match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
+				if (match.hasMatch())
+				{
+					// Split "//sharename/dir/file.txt" into "//sharename" and "dir/file.txt"
+					// for example.
 
-				const QString share_name = file_path.left(share_name_match.capturedLength(0) - 1);
+					const QString share_name = file_path.left(match.capturedLength(0) - 1);
 
-				dir_path.append(share_name);
+					dir_path.append(share_name);
 
-				file_path = file_path.mid(share_name_match.capturedLength(0));
+					file_path = file_path.mid(match.capturedLength(0));
+				}
 			}
 
 			dir_path = dir_path + file_path.split('/');
@@ -385,19 +388,21 @@ GPlatesScribe::TranscribeUtils::convert_file_path(
 
 	// Both regular expressions are anchored at the start of the file path, so the length of the
 	// whole match is the length of the matched prefix.
-	const QRegularExpressionMatch drive_letter_match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
-	const QRegularExpressionMatch share_name_match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
 
 	// Remove Windows drive letter if necessary.
-	if (drive_letter_match.hasMatch())
+	QRegularExpressionMatch match = WINDOWS_DRIVE_LETTER_REGEXP.match(file_path);
+	if (match.hasMatch())
 	{
 		// Change "C:/dir/file.txt" into "/dir/file.txt" for example.
-		return '/' + file_path.mid(drive_letter_match.capturedLength(0));
+		return '/' + file_path.mid(match.capturedLength(0));
 	}
-	else if (share_name_match.hasMatch())
+
+	// Remove Windows share name if necessary.
+	match = WINDOWS_SHARE_NAME_REGEXP.match(file_path);
+	if (match.hasMatch())
 	{
 		// Change "//sharename/dir/file.txt" into "/dir/file.txt" for example.
-		return '/' + file_path.mid(share_name_match.capturedLength(0));
+		return '/' + file_path.mid(match.capturedLength(0));
 	}
 
 #endif

--- a/src/unit-test/CMakeLists.txt
+++ b/src/unit-test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(srcs
     CptPaletteTest.cc
     CsvExportTest.cc
     DataAssociationDataTableTest.cc
+    ExportTemplateFilenameTest.cc
     GenerateVelocityDomainCitcomsTest.cc
     GeoscimlReaderTest.cc
     GsmlXmlQueryTest.cc

--- a/src/unit-test/CptPaletteTest.cc
+++ b/src/unit-test/CptPaletteTest.cc
@@ -23,8 +23,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 #include <iostream>
+#include <string>
 
 #include <QDebug>
+#include <QFile>
+#include <QString>
+#include <QTemporaryDir>
+#include <QTextStream>
 #include <gtest/gtest.h>
 
 #include "gui/ColourQt.h"
@@ -65,4 +70,106 @@ TEST(CptPaletteTest, cpt_palette)
 	EXPECT_TRUE(GPlatesGui::qcolor_from_colour(f).name().toStdString()=="#ffffff");
 	std::cout << GPlatesGui::qcolor_from_colour(n).name().toStdString() << std::endl;
 	EXPECT_TRUE(GPlatesGui::qcolor_from_colour(n).name().toStdString()=="#808080");
+}
+
+
+namespace
+{
+	/**
+	 * Writes @a contents to a file named @a file_name inside @a temp_dir, and returns its path.
+	 */
+	QString
+	write_cpt_file(
+			const QTemporaryDir &temp_dir,
+			const QString &file_name,
+			const QString &contents)
+	{
+		const QString file_path = temp_dir.filePath(file_name);
+
+		QFile file(file_path);
+		EXPECT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+		QTextStream(&file) << contents;
+
+		return file_path;
+	}
+
+
+	/**
+	 * A CPT colouring everything green when read as HSV (hue 120 degrees, fully saturated),
+	 * preceded by @a colour_model_comment - which is what selects the colour model those three
+	 * numbers are read in.
+	 */
+	QString
+	cpt_file_contents(
+			const QString &colour_model_comment)
+	{
+		return colour_model_comment + "\n0 120 1 1 100 120 1 1\n";
+	}
+
+
+	//! Returns the "#rrggbb" name of the colour @a palette gives @a key, for a legible failure.
+	std::string
+	colour_name_at(
+			const GPlatesGui::CptPalette &palette,
+			long key)
+	{
+		const boost::optional<GPlatesGui::Colour> colour =
+				palette.get_colour(GPlatesGui::Palette::Key(key));
+		if (!colour)
+		{
+			return "<no colour>";
+		}
+
+		return GPlatesGui::qcolor_from_colour(*colour).name().toStdString();
+	}
+}
+
+
+TEST(CptPaletteTest, colour_model_comment_selects_hsv_whatever_its_case)
+{
+	using namespace GPlatesGui;
+
+	QTemporaryDir temp_dir;
+	ASSERT_TRUE(temp_dir.isValid());
+
+	// GMT writes this comment in lower case, but CPT files exist carrying it in any case, so
+	// every one of these selects the HSV colour model.
+	const QString hsv_comments[] = {
+			"# COLOR_MODEL = hsv",
+			"# COLOR_MODEL = HSV",
+			"# COLOR_MODEL = +hsv",
+			"#COLOR_MODEL=HsV"
+	};
+
+	int index = 0;
+	for (const QString &hsv_comment : hsv_comments)
+	{
+		const QString file_path = write_cpt_file(
+				temp_dir,
+				QString("hsv_%1.cpt").arg(index++),
+				cpt_file_contents(hsv_comment));
+
+		EXPECT_EQ("#00ff00", colour_name_at(CptPalette(file_path), 50))
+				<< "for colour model comment: " << hsv_comment.toStdString();
+	}
+}
+
+
+TEST(CptPaletteTest, colour_model_defaults_to_rgb)
+{
+	using namespace GPlatesGui;
+
+	QTemporaryDir temp_dir;
+	ASSERT_TRUE(temp_dir.isValid());
+
+	// Without a COLOR_MODEL comment the same three numbers are read as RGB...
+	const QString rgb_file_path = write_cpt_file(
+			temp_dir, "rgb.cpt", cpt_file_contents("# no colour model stated here"));
+	EXPECT_EQ("#780101", colour_name_at(CptPalette(rgb_file_path), 50));
+
+	// ...as they are when the comment says the colour model is *not* HSV. (The CPT file in
+	// 'unit-test/data/cpt' carries exactly that comment.)
+	const QString not_hsv_file_path = write_cpt_file(
+			temp_dir, "not_hsv.cpt", cpt_file_contents("# COLOR_MODEL != HSV"));
+	EXPECT_EQ("#780101", colour_name_at(CptPalette(not_hsv_file_path), 50));
 }

--- a/src/unit-test/ExportTemplateFilenameTest.cc
+++ b/src/unit-test/ExportTemplateFilenameTest.cc
@@ -46,7 +46,10 @@ using GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat;
 
 namespace
 {
-	//! Returns the length of the matched format specifier, or -1 if @a filename_template doesn't match.
+	/**
+	 * Returns the length of the matched format specifier, or -1 if @a filename_template
+	 * doesn't match.
+	 */
 	int
 	match_length(
 			const QString &filename_template)

--- a/src/unit-test/ExportTemplateFilenameTest.cc
+++ b/src/unit-test/ExportTemplateFilenameTest.cc
@@ -1,0 +1,119 @@
+/* $Id$ */
+
+/**
+ * \file
+ * $Revision$
+ * $Date$
+ *
+ * Copyright (C) 2026 The University of Sydney, Australia
+ *
+ * This file is part of GPlates.
+ *
+ * GPlates is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * GPlates is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <QDateTime>
+#include <QString>
+#include <gtest/gtest.h>
+
+#include "file-io/ExportTemplateFilenameSequenceFormats.h"
+
+
+//
+// The printf-style reconstruction time format specifier ("%d", "%0.2f", ...) in an export
+// template filename is recognised by a regular expression, so these tests pin the flags that
+// regular expression accepts.
+//
+// Note that the '-' (left justify) flag really is expected to match: the regular expression
+// used to spell its flag set '[ +-#0]', in which '+-#' is a character *range* rather than three
+// literals, and so it never matched a '-' (and would be rejected outright by QRegularExpression).
+// It is spelled '[-+ #0]' now.
+//
+
+using GPlatesFileIO::ExportTemplateFilename::ReconstructionTimePrintfFormat;
+
+
+namespace
+{
+	//! Returns the length of the matched format specifier, or -1 if @a filename_template doesn't match.
+	int
+	match_length(
+			const QString &filename_template)
+	{
+		const boost::optional<int> matched_length =
+				ReconstructionTimePrintfFormat::match_format(filename_template);
+
+		return matched_length ? matched_length.get() : -1;
+	}
+
+
+	//! Expands @a format_string at @a reconstruction_time (the date/time is unused by this format).
+	QString
+	expand(
+			const QString &format_string,
+			const double &reconstruction_time)
+	{
+		return ReconstructionTimePrintfFormat(format_string).expand_format_string(
+				0/*sequence_index*/,
+				reconstruction_time,
+				QDateTime());
+	}
+}
+
+
+TEST(ExportTemplateFilenameTest, match_format_accepts_each_printf_flag)
+{
+	// Each of the five flags (space, '+', '-', '#', '0'), and no flag at all.
+	EXPECT_EQ(2, match_length("%d"));
+	EXPECT_EQ(2, match_length("%f"));
+	EXPECT_EQ(3, match_length("% d"));
+	EXPECT_EQ(3, match_length("%+d"));
+	EXPECT_EQ(4, match_length("%-5d"));
+	EXPECT_EQ(3, match_length("%#f"));
+	EXPECT_EQ(5, match_length("%0.2f"));
+	EXPECT_EQ(6, match_length("%05.1f"));
+
+	// Only the leading format specifier is matched - the rest of the template is left alone.
+	EXPECT_EQ(2, match_length("%d_velocity"));
+}
+
+
+TEST(ExportTemplateFilenameTest, match_format_rejects_other_specifiers)
+{
+	// Only the 'd' and 'f' specifiers are supported.
+	EXPECT_EQ(-1, match_length("%s"));
+	EXPECT_EQ(-1, match_length("%x"));
+	EXPECT_EQ(-1, match_length("%"));
+	EXPECT_EQ(-1, match_length("%ld"));
+
+	// Not anchored at the start of the (remainder of the) template.
+	EXPECT_EQ(-1, match_length("velocity_%d"));
+}
+
+
+TEST(ExportTemplateFilenameTest, expand_format_string)
+{
+	// A 'd' specifier rounds the reconstruction time to the nearest integer.
+	EXPECT_EQ(QString("13"), expand("%d", 12.6));
+	EXPECT_EQ(QString("12"), expand("%d", 12.4));
+
+	// An 'f' specifier keeps the reconstruction time as a floating-point value.
+	EXPECT_EQ(QString("12.50"), expand("%0.2f", 12.5));
+	EXPECT_EQ(QString("012.5"), expand("%05.1f", 12.5));
+
+	// The flags reach printf.
+	EXPECT_EQ(QString("+13"), expand("%+d", 12.6));
+	EXPECT_EQ(QString("13   "), expand("%-5d", 12.6));
+	EXPECT_EQ(QString(" 13"), expand("% 3d", 12.6));
+}

--- a/src/utils/ConfigBundle.cc
+++ b/src/utils/ConfigBundle.cc
@@ -24,7 +24,6 @@
  */
 
 #include <QDebug>
-#include <QRegExp>
 #include <QSet>
 #include <QtGlobal>
 

--- a/src/utils/FeatureUtils.cc
+++ b/src/utils/FeatureUtils.cc
@@ -242,10 +242,14 @@ boost::optional<GPlatesModel::PropertyName>
 GPlatesUtils::convert_property_name(
 		const QString& name)
 {
-	QRegExp rx("^\\s*(gpml|gml)\\s*:\\s*(\\w+)\\s*"); // (gpml|gml):(name)
-	rx.indexIn(name);
-	QString prefix = rx.cap(1);
-	QString short_name = rx.cap(2);
+	// Property names come from user data, so match "\w" against Unicode letters (as QRegExp did)
+	// rather than the ASCII-only default of QRegularExpression.
+	static const QRegularExpression rx(
+			"^\\s*(gpml|gml)\\s*:\\s*(\\w+)\\s*", // (gpml|gml):(name)
+			QRegularExpression::UseUnicodePropertiesOption);
+	const QRegularExpressionMatch rx_match = rx.match(name);
+	QString prefix = rx_match.captured(1);
+	QString short_name = rx_match.captured(2);
 	
 	boost::optional<GPlatesModel::PropertyName> ret = boost::none;
 	if(prefix.length() == 0 || short_name.length() == 0)

--- a/src/utils/FeatureUtils.h
+++ b/src/utils/FeatureUtils.h
@@ -28,7 +28,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/tuple/tuple.hpp>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "maths/Real.h"
 
@@ -79,10 +79,15 @@ namespace GPlatesUtils
 			const QString& name)
 	{
 		boost::optional<QString> shape_name = boost::none;
-		QRegExp rx("^\\s*(gpml:shapefileAttributes)\\s*:\\s*\\b(\\w+)\\b\\s*"); // gpml:shapefileAttributes
-		if(rx.indexIn(name) != -1)
+		// Attribute names come from user data, so match "\w" and "\b" against Unicode letters
+		// (as QRegExp did) rather than the ASCII-only default of QRegularExpression.
+		static const QRegularExpression rx(
+				"^\\s*(gpml:shapefileAttributes)\\s*:\\s*\\b(\\w+)\\b\\s*", // gpml:shapefileAttributes
+				QRegularExpression::UseUnicodePropertiesOption);
+		const QRegularExpressionMatch rx_match = rx.match(name);
+		if(rx_match.hasMatch())
 		{
-			shape_name = rx.cap(2);
+			shape_name = rx_match.captured(2);
 		//	qDebug() << "Shapefile attribute name: " << *shape_name;
 		}
 		return shape_name;


### PR DESCRIPTION
Under Qt6 both products linked `Qt6::Core5Compat`, kept "temporarily" so Qt5-era APIs still compiled. The tree used exactly **one** Core5Compat API: `QRegExp`. Nothing else from that module was referenced (no `QTextCodec`, `QStringRef`, `QLinkedList`, SAX `QXml*`, `QRegExpValidator`, `setFilterRegExp`; the `QTextStream::setCodec` calls are already `QT_VERSION`-guarded to `setEncoding`).

`QRegularExpression` has been in QtCore since Qt 5.0, so replacing `QRegExp` with it gives **one code path for Qt5 and Qt6** with no new `#if QT_VERSION` blocks — and the Core5Compat link, the `qt5compat` submodule in all three wheel dependency builds and one DLL/framework/`.so` from every wheel go away.

## The two behavioural differences that mattered

**1. `[ +-#0]` was an invalid character class.** `ExportTemplateFilenameSequenceFormats` spelled the printf flags of a reconstruction-time format specifier (`%d`, `%0.2f`, …) that way, in which `+-#` is a character *range* — a reversed one (`+` is 0x2B, `#` is 0x23). QRegExp quietly swapped its ends and matched `# $ % & ' ( ) * +`, so the `-` (left justify) flag it meant to list never matched. PCRE rejects the range outright, which would have silently made every `%d`/`%f` export filename stop matching. It is `[-+ #0]` now, which also fixes the `-` flag.

**2. `$` matches before a trailing newline in PCRE**, but only at the end of the string in QRegExp. Only `Version`'s two PEP440 patterns care — they validate user input, and the test suite checks the rejects — so they end with `\z`.

Two more differences handled without a behaviour change: `\w`/`\b`/`\s` are ASCII-only in PCRE and Unicode-aware in QRegExp, so the patterns that read user-authored text construct with `UseUnicodePropertiesOption` — `FeatureUtils` (shapefile attribute names and property names) and the `.grot` reader (comments, MPRS headers and attribute values are free text); the rest are version strings, printf formats, CPT keywords and paths, ASCII by definition. And patterns matched repeatedly are `static` now: QRegExp had a global pattern cache that made per-call construction cheap, whereas a fresh `QRegularExpression` recompiles its pattern (matching is const and thread-safe, unlike QRegExp's mutable match state).

## Tests

New `src/unit-test/ExportTemplateFilenameTest.cc` pins the one place behaviour intentionally changes: the flag set `match_format` accepts (each of ` `, `+`, `-`, `#`, `0`, plus width/precision), what it rejects (`%s`, `%x`, `%ld`, an unanchored match), and the expansions (`%d` rounding, `%0.2f`, `%05.1f`, `%+d`, `%-5d`, `% 3d`).

Two cases added to `src/unit-test/CptPaletteTest.cc` cover the CPT colour-model fix below. The CPT they write into a `QTemporaryDir` has one regular line whose three numbers read as pure green in HSV and dark red in RGB, so the colour that comes back says which model the parser chose.

The rotation-file reader is the one place the rewrite restructured control flow (the attribute loop copied whichever `QRegExp` had matched into a local and read `cap()` off it afterwards; it keeps the match object now). Verified by round-tripping `src/unit-test/data/plates4-rotation/grot_example.grot` — multi-line `"""` attributes, `#`-disabled poles, MPRS headers — through pyGPlates built before and after the change: **byte-identical output**.

Also removed: `RotationFileReaderV2::d_disabled_pole_rx`, declared but never initialised or used.

## Review follow-ups

A review of the port turned up seven things, fixed in the six commits on top of it. Three are behavioural, and two of those predate this branch:

- **`.grot` patterns lost Unicode `\s` and `\d`.** Rotation files were judged ASCII by definition, but they are user data. The four patterns carrying either escape now ask for `UseUnicodePropertiesOption`. Two functions were also building their own function-local static copy of `ROTATION_POLE_REGEXP` instead of using the `d_pole_rx` member beside them, so they would have kept the ASCII behaviour regardless.
- **A CPT `COLOR_MODEL` comment was matched case-sensitively** (pre-existing). `CptParser::process_comment()` upper-cased the line into a local and then matched the *original*, so the normalisation was dead code — and GMT writes `# COLOR_MODEL = hsv` in lower case, so an HSV palette was read as RGB. The sibling reader in `CptReader.h` had already hit this and matches case-insensitively.
- **The Python version was read as `^\d.\d`** (pre-existing), where the `.` is any character, so Python 3.12 reported itself as `3.1` — and has done since 3.10. On Linux and macOS `validate_python_home()` looks for `<home>/lib/python<version>/os.py`, so the truncated version made that check fail.

The rest are hardening and style:

- The Terra and CitcomS velocity exporters spliced the user-entered file name template into a regular expression unescaped; it is escaped now (and the placeholders are searched for escaped too).
- `TranscribeUtils` matched the Windows drive-letter and share-name patterns up front and only then chose between them; the share-name pattern is tried only when the drive-letter one misses.
- Four lines the port added ran past the 100-column target.

## Verified locally

Built and tested all four in-source trees, plus both precompiled-header trees:

| tree | build | ctest |
|---|---|---|
| `build-pygplates` (Qt6) | ✅ | ✅ 4/4 |
| `build-gplates` (Qt6) | ✅ | ✅ 63/63 |
| `build-pygplates-qt5` | ✅ | ✅ 4/4 |
| `build-gplates-qt5` | ✅ | ✅ 63/63 |
| `build-pygplates-pch`, `build-gplates-pch` | ✅ | — |

`dumpbin /dependents` on the built module lists `Qt6Core.dll` and no `Qt6Core5Compat.dll`.

Both precompiled headers are regenerated (from `build-pygplates` + `build-pygplates-qt5` and `build-gplates` + `build-gplates-qt5`), in their own commit *before* Core5Compat is dropped, so a `GPLATES_USE_PRECOMPILED_HEADERS` build works at every commit. The review follow-ups add no includes to a pch target, so they leave both headers unchanged.

Also smoke-tested by hand in the Qt6 GPlates build: loading a `.rot` carrying `@`-attributes and a `#`-disabled pole, an export with a `%0.2f` template filename, and opening a project saved with `C:/` paths.

The wheel workflow is the only place the dockerfile and dependency-script edits are proven — the wheels build on Qt 6.7.3, not the conda Qt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
