### PR TITLE
Build only the dependencies the pygplates module links

### DIFF
--- a/.github/workflows/build-wheel-images.yml
+++ b/.github/workflows/build-wheel-images.yml
@@ -7,11 +7,21 @@
 # the wheel builds themselves just pull the images (see '.github/workflows/build-wheels.yml'
 # and '[tool.cibuildwheel.linux]' in 'pyproject.toml').
 #
-# Each architecture builds natively on its own runner (no QEMU emulation - a Qt source build
-# under emulation would take many times longer than the native ~2 hours).
+# Each architecture builds natively on its own runner (no QEMU emulation - these are source
+# builds of Boost, Qt, PROJ and GDAL, and emulating them would take many times longer).
 #
 # Images are tagged ':latest' (what wheel builds pull) and ':<commit-sha>' (so any previous
 # image remains pullable, eg, to rebuild an old release or bisect a dependency problem).
+#
+# To prove a dockerfile change from its branch, before it is merged - which is the only way to
+# find out whether wheels actually build inside the new image - build the image without moving
+# ':latest' off the merged one, then build wheels against the tag it produced:
+#
+#   gh workflow run build-wheel-images.yml --ref <branch> -f push-latest=false
+#   gh workflow run build-wheels.yml --ref <branch> -f linux-image-tag=<the run's commit sha>
+#
+# Nothing about that needs a temporary edit to either workflow, so nothing has to be remembered
+# and reverted before merging.
 #
 # NOTE: After the very first push, the two GHCR packages must be manually marked *public*
 #       (GitHub organization -> Packages -> package settings -> Change visibility) so that
@@ -26,8 +36,14 @@ on:
       - pygplates/wheel/versions.sh
       - .github/workflows/build-wheel-images.yml
   workflow_dispatch:
+    inputs:
+      push-latest:
+        description: "Move the ':latest' tag to this image (the wheel builds' default image)"
+        type: boolean
+        default: true
 
-# Superseded runs are cancelled rather than left to finish (an image build takes ~2 hours).
+# Superseded runs are cancelled rather than left to finish (an image build takes tens of
+# minutes).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,9 +52,12 @@ jobs:
   build-image:
     name: ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    # A Qt source build on a 4-core runner dominates this (~1-2 hours); the rest of the
-    # dependencies add another hour or so.
-    timeout-minutes: 300
+    # Building Boost.Python once per supported Python version dominates this; the rest of the
+    # dependencies are minutes each. (Qt used to dominate instead, by a wide margin - building
+    # Qt Core alone rather than Gui/Widgets/OpenGL took the whole image build from tens of
+    # minutes to a fraction of that.) The limit is several times the expected duration, so
+    # hitting it means something is broken rather than merely slow.
+    timeout-minutes: 120
 
     permissions:
       # To push to GHCR. 'contents: read' restated because specifying any permission
@@ -58,6 +77,12 @@ jobs:
 
     env:
       IMAGE: ghcr.io/gplates/pygplates-manylinux_2_28_${{ matrix.arch }}
+      # Whether this run moves ':latest' - the tag wheel builds pull by default. Every run
+      # except a manual one that says otherwise does; the header says what that is for.
+      # (Written the long way round because on a 'push' the input is the empty string, and
+      # GitHub's '==' would compare that equal to false - skipping ':latest' on exactly the
+      # runs that must move it.)
+      PUSH_LATEST: ${{ github.event_name != 'workflow_dispatch' || inputs.push-latest }}
 
     steps:
       - name: Check out repository
@@ -81,14 +106,23 @@ jobs:
       - name: Build image
         # '--pull' so a stale locally cached manylinux base (with old /opt/python interpreters)
         # is never used - the Boost.Python builds need the base image to be current.
+        #
+        # ':<commit sha>' always; ':latest' only when this run is meant to move it.
         run: >
           docker build
           --pull
           --build-arg ARCH=${{ matrix.arch }}
-          -t ${{ env.IMAGE }}:latest
           -t ${{ env.IMAGE }}:${{ github.sha }}
+          ${{ env.PUSH_LATEST == 'true' && format('-t {0}:latest', env.IMAGE) || '' }}
           -f pygplates/wheel/manylinux_2_28.dockerfile
           pygplates/wheel
 
       - name: Push image
-        run: docker push --all-tags ${{ env.IMAGE }}
+        # The tags are pushed by name rather than with '--all-tags': that pushes every tag the
+        # local daemon holds for the repository, which would put ':latest' back whenever the
+        # step above deliberately did not apply it.
+        run: |
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          if [ '${{ env.PUSH_LATEST }}' = 'true' ]; then
+            docker push ${{ env.IMAGE }}:latest
+          fi

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -42,6 +42,11 @@ on:
       - cmake/**
       - CMakeLists.txt
   workflow_dispatch:
+    inputs:
+      linux-image-tag:
+        description: "Tag of the GHCR dependency image the Linux wheels build inside"
+        type: string
+        default: latest
 
 # What the build jobs need: the repository, and the GHCR packages the Linux builds pull their
 # dependency image from. Both are spelled out because naming any permission drops every one not
@@ -294,6 +299,25 @@ jobs:
           for ((i = ${#added[@]} - 1; i >= 0; i--)); do
               cygpath --windows "${added[i]}" >> "$GITHUB_PATH"
           done
+
+      - name: Build the Linux wheels against a specific dependency image
+        # A dockerfile change can only be proved by building wheels inside the image it
+        # produces, and that image does not become ':latest' until the change is merged. So a
+        # manual run can name any tag the image workflow pushed - see the recipe in the header
+        # of '.github/workflows/build-wheel-images.yml'.
+        #
+        # cibuildwheel reads the image from the environment in preference to 'pyproject.toml',
+        # so the file stays the authoritative default for every other run.
+        if: runner.os == 'Linux' && inputs.linux-image-tag != '' && inputs.linux-image-tag != 'latest'
+        # The tag reaches the script through the environment rather than by '${{ }}'
+        # interpolation into its text, so that a tag containing whitespace or shell syntax is
+        # data rather than script.
+        env:
+          IMAGE_TAG: ${{ inputs.linux-image-tag }}
+        run: |
+          image=ghcr.io/gplates/pygplates-manylinux_2_28
+          echo "CIBW_MANYLINUX_X86_64_IMAGE=${image}_x86_64:${IMAGE_TAG}" >> "$GITHUB_ENV"
+          echo "CIBW_MANYLINUX_AARCH64_IMAGE=${image}_aarch64:${IMAGE_TAG}" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -322,6 +322,66 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0
 
+      - name: Check the Linux wheel imports with no system packages installed
+        # The manylinux wheel is meant to need nothing from the user's system beyond glibc and
+        # the C++ runtime, and every other job here runs somewhere that has far more than that -
+        # so this is the only check of that claim. It regressed once already: while the module
+        # linked Qt6Gui the wheel needed libGL and some forty apt packages, and until the Qt in
+        # the dependency image was built with FEATURE_glib=OFF it still needed libglib-2.0.
+        #
+        # 'python:3.13-slim' is Debian with a Python and nothing else; installing anything into
+        # it would defeat the point, so the container runs no 'apt-get'. x86_64 only: the same
+        # dockerfile builds both images, and importing the aarch64 wheel here would mean QEMU.
+        #
+        # NOTE: this checks the *dependency image* as much as the wheel, and a pull request
+        #       cannot change which image it uses (see the failure message below). A PR that
+        #       edits the dockerfile is expected to fail here until its new image is built.
+        if: matrix.id == 'linux-x86_64'
+        run: |
+          # '|| true' because the job's shell is 'bash -eo pipefail': with no match, 'ls'
+          # exits 2, pipefail makes that the pipeline's status, and the step would die there -
+          # before the message below, which is the whole reason the check is here.
+          wheel=$(ls wheelhouse/pygplates-*-cp313-*manylinux*_x86_64.whl 2> /dev/null | head -1 || true)
+          if [ -z "${wheel}" ]; then
+              # Every run builds cp313 (full runs build all six versions, pull request runs
+              # build cp312 and cp313), so there is no case where skipping is right.
+              echo "No cp313 manylinux x86_64 wheel in wheelhouse/ to check." >&2
+              exit 1
+          fi
+          # The container script arrives on stdin and the wheel's name in the environment, so
+          # that nothing in either has to survive a round of shell quoting.
+          status=0
+          docker run --rm -i -e WHEEL="$(basename "${wheel}")" \
+              -v "$PWD/wheelhouse:/wheelhouse:ro" python:3.13-slim sh -s <<'CONTAINER' || status=$?
+          set -e
+          pip install --no-cache-dir --root-user-action=ignore -q "/wheelhouse/${WHEEL}"
+          if python -c 'import pygplates; print(pygplates.__version__)'; then
+              exit 0
+          fi
+          # The traceback names only the first missing library. List every one, over the
+          # module and everything the wheel repair step vendored beside it.
+          echo "--- shared libraries this wheel needs that a bare image does not provide:"
+          site=$(python -c 'import site; print(site.getsitepackages()[0])')
+          for object in "${site}"/pygplates/pygplates.so "${site}"/pygplates.libs/*; do
+              ldd "${object}" 2> /dev/null | grep 'not found' | sed "s|^|  $(basename "${object}"): |"
+          done
+          exit 1
+          CONTAINER
+          if [ "${status}" -ne 0 ]; then
+              # Worth saying, because it is the likeliest reason to be reading this: the wheel
+              # above was built inside the ':latest' dependency image, which is built from the
+              # *merged* dockerfile. A pull request that changes 'manylinux_2_28.dockerfile' is
+              # therefore testing the old image and cannot pass this step until its own image
+              # exists - build one and re-run against it with the two-command recipe under
+              # "Proving a dockerfile change before it is merged" in 'pygplates/wheel/README.md'.
+              echo "::error::The wheel does not import on a bare python image - see the unmet libraries above."
+              echo "If this pull request changes the dependency image, that is expected until"
+              echo "the new image is built: the wheel above was built inside ':latest', which"
+              echo "comes from the *merged* dockerfile. See 'Proving a dockerfile change"
+              echo "before it is merged' in 'pygplates/wheel/README.md'."
+              exit 1
+          fi
+
       - name: Report crashes
         # If a test command crashed outright (rather than failing an assertion), the exit code
         # is all cibuildwheel reports - the native stack trace is in the crash report macOS

--- a/cmake/check_linkage.py
+++ b/cmake/check_linkage.py
@@ -13,10 +13,20 @@
 # QProgressDialog, which linked Qt Widgets into the module).
 #
 # Usage: check_linkage.py <path-to-pygplates-module>
+#        check_linkage.py --installed
+#
+# Two callers, checking two different artifacts. The CTest passes the module in the build tree.
+# The wheel 'test-command' (see '[tool.cibuildwheel]' in the root 'pyproject.toml') passes
+# --installed, which imports the installed package and checks the module inside it: that is the
+# artifact the user gets, and it is not the one the build produced - the wheel repair step
+# (auditwheel/delocate/delvewheel) rewrites the module's dependency names on the way in.
+# (--installed rather than a path because the wheel test command runs under 'cmd' on Windows,
+# where there is no '$(python -c ...)' to compute one with.)
 #
 # Uses the platform's native tool to list direct dependencies: dumpbin on Windows (available
-# in the MSVC environment every build of this project already requires), otool on macOS,
-# readelf on Linux.
+# in the MSVC environment every build of this project already requires, and on the wheel job's
+# PATH because the workflow imports that environment into the job), otool on macOS, readelf on
+# Linux.
 
 import re
 import subprocess
@@ -31,12 +41,18 @@ import sys
 # imported target propagates Qt's own OpenGL dependency onto everything linking it. That is
 # how the Linux wheel once came to need libGL.so.1 (and ~40 apt packages) just to be
 # imported. So this also forbids the platform OpenGL libraries themselves - GLVND's
-# libOpenGL/libGLX/libGLdispatch, the legacy libGL, macOS' OpenGL framework and Windows'
+# libOpenGL/libGLX/libGLdispatch, the legacy libGL, EGL, macOS' OpenGL framework and Windows'
 # opengl32.dll - because any of them appearing here means some GUI library has crept back
 # into the link line. "opengl" catches Qt6OpenGL/Qt6OpenGLWidgets, libOpenGL.so, opengl32.dll
-# and the macOS framework alike.
-FORBIDDEN = re.compile(r'qwt|glew|opengl|libGL\.|libGLX\.|libGLU\.|libGLdispatch\.'
-                       r'|qt\w*(gui|widgets|svg)', re.I)
+# and the macOS framework alike; libEGL needs naming separately (it is how Qt6Gui used to drag
+# libGLdispatch in), and it is on the same list as the wheel and image checks for that reason.
+#
+# The separator after the "libGL" family is [-.] rather than "." because --installed runs
+# against a repaired wheel, where the vendored libraries carry a hash in their names
+# ("libQt6Core-598a0482.so.6", "Qt6Core-7e1f2a3b.dll"). The name stems survive that, which is
+# what the rest of the pattern matches on.
+FORBIDDEN = re.compile(r'qwt|glew|opengl|libGL[-.]|libGLX[-.]|libGLU[-.]|libGLdispatch[-.]'
+                       r'|libEGL[-.]|qt\w*(gui|widgets|svg)', re.I)
 
 
 def direct_dependencies(module_path):
@@ -54,10 +70,21 @@ def direct_dependencies(module_path):
         return re.findall(r'\(NEEDED\)[^[]*\[([^]]+)\]', output)
 
 
+def installed_module_path():
+    # The private submodule, not the 'pygplates' package: the package is a directory, and its
+    # '__init__.py' is what re-exports the extension module's names (see the note about 'dill'
+    # in AGENTS.md). 'pygplates.pygplates.__file__' is the extension module itself.
+    import pygplates.pygplates
+    return pygplates.pygplates.__file__
+
+
 def main():
     if len(sys.argv) != 2:
-        sys.exit('usage: check_linkage.py <path-to-pygplates-module>')
-    module_path = sys.argv[1]
+        sys.exit('usage: check_linkage.py <path-to-pygplates-module>|--installed')
+    if sys.argv[1] == '--installed':
+        module_path = installed_module_path()
+    else:
+        module_path = sys.argv[1]
 
     try:
         dependencies = direct_dependencies(module_path)

--- a/doc-python-api/pygplates_getting_started.rst
+++ b/doc-python-api/pygplates_getting_started.rst
@@ -243,36 +243,48 @@ This section covers issues you might encounter when installing or running pyGPla
 
 .. _pygplates_getting_started_troubleshooting_:
 
-glib ImportError on Linux
-^^^^^^^^^^^^^^^^^^^^^^^^^
+libGL or glib ImportError on Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have installed pyGPlates :ref:`using pip<pygplates_getting_started_install_using_pip>` and
-you get the following error on a Linux distribution (when pyGPlates is imported)...
+.. note:: This applies to pyGPlates **1.0.x** only. From pyGPlates **1.1.0** the Linux wheels no longer link
+          Qt's GUI library or OpenGL, and their Qt Core is built with GLib support disabled, so they import on
+          a bare ``python:3.x-slim`` container with no system packages installed at all.
+
+If you have installed pyGPlates 1.0.x :ref:`using pip<pygplates_getting_started_install_using_pip>` and
+you get one of the following errors on a Linux distribution (when pyGPlates is imported)...
 
 ::
 
+  ImportError: libGL.so.1: cannot open shared object file: No such file or directory
   ImportError: libglib-2.0.so.0: cannot open shared object file: No such file or directory
 
 ...then it's likely you are using a *minimal* Linux distribution.
+PyGPlates 1.0.x needs *both* of these libraries, so you might fix the first error only to be met by the second.
 
 .. note:: This shouldn't happen when installing pyGPlates :ref:`using conda<pygplates_getting_started_install_using_conda>`.
 
 For example, you might have a Dockerfile that builds on a Debian or Ubuntu Docker base image (such as ``python:3.x-slim``) by installing pyGPlates (using ``pip``).
-Or you might be installing pyGPlates (using ``pip``) in an environment like WSL (Windows Subsystem for Linux) where not all system libraries are pre-installed.
+Or you might be installing pyGPlates (using ``pip``) in an environment like WSL (Windows Subsystem for Linux) where graphical and other system libraries are not always pre-installed.
 
-The solution is to install the GLib library. For example, in a Debian or Ubuntu Dockerfile you could add the following...
+The solution is to upgrade to pyGPlates 1.1.0 or later, or - if you must stay on 1.0.x - to install the libGL and GLib libraries.
+For example, in a Debian or Ubuntu Dockerfile you could add the following...
 
 ::
 
-  RUN apt-get install -y libglib2.0-0
+  RUN apt-get install -y libgl1 libglib2.0-0
 
-.. note:: PyGPlates uses the Qt Core library (for its non-graphical functionality such as strings, files and XML), and on Linux Qt Core requires GLib
-          even though pyGPlates doesn't actually use it. PyGPlates does not use any of Qt's graphical libraries and so does not require a display or OpenGL.
+On older Debian and Ubuntu releases the ``libgl1`` package is called ``libgl1-mesa-glx`` instead.
+
+.. note:: PyGPlates 1.0.x was built from the GPlates (desktop) sources as a whole, and so it linked the graphical libraries
+          that GPlates draws with - Qt's GUI library and OpenGL - even though pyGPlates itself never draws anything.
+          That is where its requirement on ``libGL.so.1`` came from. The requirement on ``libglib-2.0.so.0`` came from Qt itself:
+          pyGPlates uses the Qt Core library (for its non-graphical functionality such as strings and files), and the Qt Core
+          that pyGPlates 1.0.x was built against required GLib.
           When you install pyGPlates with ``pip install pygplates`` it downloads and installs a wheel for your platform and Python version.
-          However, on Linux platforms, GLib was not copied into the pyGPlates wheel when it was built (like the other dependency libraries were).
-          This is because the ``auditwheel`` tool (used when building the wheel) whitelisted GLib (since it is expected to be available by default on all Linux distributions).
-          However ``libglib-2.0.so.0`` is not always included by default in some *minimal* Linux distributions (such as the ``python:3.x-slim`` Docker base images)
-          even though it is available in the usual Linux desktop distributions.
+          However, on Linux platforms, neither libGL nor GLib was copied into the pyGPlates 1.0.x wheel when it was built (like the other dependency libraries were).
+          This is because the ``auditwheel`` tool (used when building the wheel) whitelisted them (since they are expected to be available by default on all Linux distributions).
+          However ``libGL.so.1`` and ``libglib-2.0.so.0`` are not always included by default in some *minimal* Linux distributions (such as the ``python:3.x-slim`` Docker base images)
+          even though they are available in the usual Linux desktop distributions.
 
 
 .. _pygplates_getting_started_tutorial:

--- a/pygplates/test/CMakeLists.txt
+++ b/pygplates/test/CMakeLists.txt
@@ -33,6 +33,13 @@ add_test(
 # Note: on Windows the dependency lister is dumpbin, so (like the build itself) this test
 # must run from an MSVC-enabled environment; the script fails loudly rather than silently
 # passing if the lister is unavailable.
+#
+# The wheel builds run this script a second time, over the module inside the repaired wheel
+# ("check_linkage.py --installed" in 'test-command', root 'pyproject.toml'), because the wheel
+# is a different artifact from the build tree this test sees. A check added in either place is
+# worth considering for the other - and the wheels also run
+# 'pygplates/wheel/check_wheel_contents.py', which has no CTest counterpart because there is no
+# wheel to check at CTest time.
 add_test(
 	NAME pygplates-linkage-test
 	COMMAND ${GPLATES_PYTHON_EXECUTABLE} "${PROJECT_SOURCE_DIR}/cmake/check_linkage.py" "$<TARGET_FILE:pygplates>"

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -58,6 +58,14 @@ non-EOL mainstream distribution. `manylinux_2_28.dockerfile` extends the officia
 source in the image because EL8 has no Qt6 packages; Boost.Python is built once per supported
 Python version against the interpreters the base image provides in `/opt/python`.
 
+Only Qt **Core** is built, and it is configured with `FEATURE_gui`, `FEATURE_glib`,
+`FEATURE_dbus` and `FEATURE_icu` off. The module links `Qt6Core` and nothing else
+(`cmake/check_linkage.py` fails the build if that changes), so a Gui Qt meant building - and
+installing two dozen X11 development packages for - libraries no wheel ever loads. Turning GLib
+off is what removes the wheel's last system dependency: it now imports on a bare
+`python:3.x-slim` container with no packages installed at all, which
+`.github/workflows/build-wheels.yml` proves on every run.
+
 There is one image per architecture, both built by `.github/workflows/build-wheel-images.yml`:
 
 - `ghcr.io/gplates/pygplates-manylinux_2_28_x86_64`
@@ -91,6 +99,29 @@ local `cibuildwheel` run uses your local image rather than pulling from GHCR.
 > GitHub organization -> Packages -> package settings -> Change visibility.
 > (The CI wheel builds log in with `GITHUB_TOKEN`, so they work either way.)
 
+### Proving a dockerfile change before it is merged
+
+A dockerfile change is only really proved by building wheels inside the image it produces - and
+that image does not become `latest` until the change is merged. Two `workflow_dispatch` inputs
+close that gap without any temporary edit to either workflow:
+
+```
+gh workflow run build-wheel-images.yml --ref <branch> -f push-latest=false
+gh workflow run build-wheels.yml --ref <branch> -f linux-image-tag=<that run's commit SHA>
+```
+
+Until that second run exists, a pull request that changes the dockerfile is expected to fail
+the wheel workflow's "Check the Linux wheel imports with no system packages installed" step: the
+automatic run builds inside `latest`, which is the image built from the *merged* dockerfile, so
+that step is testing the old image. It says as much when it fails.
+
+The first command builds both architectures and pushes only the `:<SHA>` tag, leaving `latest`
+on the merged image that everything else pulls. The second builds the full wheel matrix against
+the image that tag names (cibuildwheel reads the image from the environment in preference to
+`pyproject.toml`, so the file stays the authoritative default for every other run). Build the
+image locally first, though - see above - because a CI round costs tens of minutes and a local
+one is the only place a dockerfile should ever be iterated on.
+
 ## The macOS dependency libraries
 
 macOS wheels are thin (single-architecture) `macosx_11_0_arm64` and `macosx_11_0_x86_64`
@@ -100,8 +131,9 @@ installs the dependency libraries into a single prefix, `~/pygplates-wheel-deps`
 
 - Qt comes as the official binaries (downloaded with [aqtinstall](https://github.com/miurahr/aqtinstall)),
   with each framework library thinned from universal to the build architecture - halving what
-  delocate later vendors into the wheels.
-- Qwt, GLEW, Boost, PROJ, GDAL, GMP, MPFR and CGAL are built from source (macOS has no
+  delocate later vendors into the wheels. Only the `qtbase` archive is downloaded; it is the
+  smallest aqt offers, and of the modules in it only QtCore is ever linked or vendored.
+- Boost, PROJ, GDAL, GMP, MPFR and CGAL are built from source (macOS has no
   system package manager, and Homebrew binaries must not leak into the wheels - see below).
   The versions come from `versions.sh`, shared with the Linux image - so the platforms
   cannot drift apart.
@@ -129,7 +161,7 @@ path limit):
   that the official MSVC packages carry - most of their size - are deleted afterwards. The debug
   libraries themselves stay, unused: Qt's CMake package declares a Debug configuration for every
   imported target and CMake checks that each file it names is there.
-- GLEW, zlib, PROJ, GDAL, GMP and MPFR come from [vcpkg](https://vcpkg.io) (see `vcpkg.json`).
+- zlib, PROJ, GDAL, GMP and MPFR come from [vcpkg](https://vcpkg.io) (see `vcpkg.json`).
   PROJ's and GDAL's run-time data - the coordinate reference system database and GDAL's driver
   data, which the build copies into the wheel - are named explicitly in `pyproject.toml`, since
   vcpkg installs a port's tools apart from its libraries and `projinfo`, which the build asks
@@ -137,22 +169,21 @@ path limit):
   GMP and MPFR are the reason vcpkg is here at all: they have no MSVC build system. PROJ and GDAL
   come along with them because they are a deep stack that vcpkg already knows how to build on
   Windows. These versions are pinned by the vcpkg baseline commit in `vcpkg.json` rather than by
-  `versions.sh` - but the `versions.sh` pins for GLEW, PROJ and GDAL are kept equal to what the
+  `versions.sh` - but the `versions.sh` pins for PROJ and GDAL are kept equal to what the
   baseline supplies, so every platform's wheels ship the same versions of the libraries a user
-  can feel (CRS handling, datum grids, driver behaviour). Bump the baseline and those three pins
+  can feel (CRS handling, datum grids, driver behaviour). Bump the baseline and those two pins
   together, as one act, with vcpkg setting the cadence; `build_windows_deps.sh` compares what
   vcpkg installed against `versions.sh` and fails if they have drifted apart.
-- Qwt, Boost and CGAL are built from source against the `versions.sh` pins, as on the other
-  platforms. Qwt is built as a *static* library, because a Qwt DLL would require everything that
-  includes its headers to be compiled with `-DQWT_DLL`.
+- Boost and CGAL are built from source against the `versions.sh` pins, as on the other
+  platforms.
 - Boost.Python is per-Python-version, so - as on macOS - cibuildwheel runs
   `build_boost_python.sh` (its `before-build` hook) with each build's Python on PATH, reusing the
   Boost source tree left in the prefix.
 
-Neither Boost's `b2` nor Qwt's `qmake`/`nmake` is a CMake build, so neither can locate Visual
-Studio for itself. Both scripts therefore source `msvc_env.sh`, which runs `vcvarsall.bat` in a
-cmd shell and imports the environment it produces. That is what lets them run under cibuildwheel,
-whose hooks run in a plain cmd shell, instead of requiring an "x64 Native Tools Command Prompt".
+Boost's `b2` is not a CMake build, so it cannot locate Visual Studio for itself. The script
+therefore sources `msvc_env.sh`, which runs `vcvarsall.bat` in a cmd shell and imports the
+environment it produces. That is what lets it run under cibuildwheel, whose hooks run in a plain
+cmd shell, instead of requiring an "x64 Native Tools Command Prompt".
 
 In CI the prefix is cached exactly as on macOS. The CI job does not run from a developer command
 prompt either - it imports the same environment with `msvc_env.sh` before running cibuildwheel,
@@ -172,76 +203,35 @@ subsequently run to repair our wheel. Note that this variable is only used if
 `GPLATES_INSTALL_STANDALONE` is `TRUE`, which it is by default when building using
 scikit-build-core (eg, `pip wheel ...`) outside of conda.
 
-### `OpenGL_GL_PREFERENCE=LEGACY` (Linux) - history, and why the image still sets it
+### `OpenGL_GL_PREFERENCE=LEGACY` (Linux) - retired
 
-> **No longer set for the module itself.** `pygplates.so` links only `Qt6Core` (its sources
-> are the include closure of the pyGPlates API — see
-> `cmake/pygplates_source_closure.py` — and the last Gui uses, `gui/Colour`'s `QColor`
-> conversions and `file-io/RgbaRasterReader`'s `QImage`, moved to the GPlates side). Nothing on
-> its link line reaches OpenGL, so there is no GL family to choose and `pyproject.toml` no longer
-> sets this variable; `cmake/check_linkage.py` fails the build if any GL library reappears.
-> Dropping the module's `Qt6Gui` also dropped `Qt6Network`, `Qt6Xml`, `Qt6DBus`, fontconfig,
-> freetype, libpng, libxkbcommon, libbz2 and libuuid from the vendored libraries - ten of the
-> twenty-six, about 37 MB of the unpacked wheel.
->
-> The variable did have to stay for one intermediate period: after the module stopped compiling
-> any OpenGL of its own but while it still linked `Qt6Gui`, whose CMake imported target
-> propagates Qt's own OpenGL dependency onto everything linking it. Removing it then, as a
-> supposed no-op, produced exactly the `import pygplates` segmentation fault described at the
-> end of this section. The rest of this section is kept because the docker image builds Qt and
-> GLEW with `OpenGL_GL_PREFERENCE=LEGACY` for the same reason (`manylinux_2_28.dockerfile`),
-> and that reasoning still stands for `libQt6Gui`/`libGLEW` until the image builds a Core-only
-> Qt.
+Neither the wheels nor the dependency image builds against OpenGL any more, so this variable is
+set nowhere. It is recorded here because what it prevented was expensive to diagnose and cheap
+to reintroduce.
 
-We set the CMake variable `OpenGL_GL_PREFERENCE` to `LEGACY` (instead of the default `GLVND`).
-This caused pyGPlates to prefer to use the `libGL` LEGACY dependency (instead of the default
-`libOpenGL` GLVND dependency). The `libGL` library is whitelisted by auditwheel (meaning it
-will not be copied into the wheel repaired by auditwheel). This is presumably because it is
-available by default on all Linux distributions. Whereas `libOpenGL` is NOT whitelisted
-(presumably because it is NOT available by default on all Linux distros) and hence would need
-to be copied into the wheel (if it was used). However copying into the wheel is problematic if
-`libOpenGL` itself needs to come from the end machine (eg, if it's NOT hardware-independent -
-see <https://github.com/pypa/auditwheel/issues/241>). Alternatively, if `libOpenGL` actually
-is hardware-independent and we copy it into the wheel then the end machine might still need to
-have the `libglvnd` package installed (which is not the case for all Linux distros by
-default - see <https://github.com/linuxdeploy/linuxdeploy/issues/152#issuecomment-830975582>).
-So we prefer to link to `libGL` instead (which should be available by default on all Linux
-distros).
+The problem was two copies of `libGLdispatch` in one process, which segfaulted `import
+pygplates` (a null jump in `__glDispatchInit`, reproduced under gdb). It arose whenever
+something on the link line reached GLVND's `libOpenGL`: auditwheel vendored that into the wheel
+along with its `libGLdispatch`, while Qt reached the *system* `libGLdispatch` through the
+whitelisted `libGL` - and GLVND dispatches every OpenGL call through one table, so two tables is
+one too many. Setting `OpenGL_GL_PREFERENCE=LEGACY` made CMake's `FindOpenGL` choose the
+whitelisted `libGL` instead, and the same reasoning kept EL8's `glew-devel` package (which links
+GLVND) and Qt's `FEATURE_egl` (which drags in `libGLdispatch`) out of the image.
 
-Besides pyGPlates, Qt is the other library that uses `libGL`. And they made an effort to not
-use `libOpenGL` for the same reasons (ie, it's not installed by default on all Linux distros).
-See <https://bugreports.qt.io/browse/QTBUG-89754>.
+None of that applies now: the module links only `Qt6Core`, and the image builds neither GLEW,
+Qwt, QtSvg nor Qt Gui. What remains is the guard, in three places, because the failure is
+silent until a user's `import` crashes:
 
-Previously we linked to `libOpenGL` (because we didn't set `OpenGL_GL_PREFERENCE` to `LEGACY`)
-and so it was copied into the wheel (because it's not whitelisted by auditwheel). It, in turn,
-links to `libGLdispatch` and so that was also copied into the wheel. That caused a
-segmentation fault during `import pygplates` because there were two copies of `libGLdispatch`
-being referenced. One was copied into the wheel (due to being a dependency of `libOpenGL` that
-was referenced by pyGPlates). The other was referenced by `libGL` (via Qt) and hence was not
-copied into the wheel (since `libGL` is whitelisted). The segmentation fault was most likely
-because, according to <https://github.com/NVIDIA/libglvnd>:
+- `cmake/check_linkage.py` - the module's *direct* dependencies, run as the
+  `pygplates-linkage-test` CTest and again over the module inside each repaired wheel
+  (`--installed`, from the wheel `test-command`).
+- `pygplates/wheel/check_wheel_contents.py` - every library the repair step vendored, which is
+  where a GL library arriving through a dependency's dependency would show up.
+- The dependency image's final layer - the `NEEDED` list of `libQt6Core`, and the absence of
+  `libQt6Gui`, `libqwt` and `libGLEW`.
 
-> "since all OpenGL functions are dispatched through the same table in libGLdispatch,
-> it doesn't matter which library is used to find the entrypoint"
-
-...where by "it doesn't matter which library is used to find the entrypoint" they mean
-`libOpenGL` and `libGL` (not `libGLdispatch`). So having Qt reference
-`/usr/lib64/libGLdispatch.so.0` (via `libGL`) and pyGPlates reference the `libGLdispatch`
-copied into the wheel (via `libOpenGL`) would result in *two* dispatch tables (instead of one
-central table). And this is likely what caused the segmentation fault.
-
-The same two-dispatch-tables segfault can be reintroduced through *any* dependency that links
-the GLVND libraries, not just pyGPlates itself. It resurfaced twice while moving the image to
-manylinux_2_28 (reproduced with gdb - the crash is a null jump in `__glDispatchInit`):
-
-- EL8's `glew-devel` package links `libGLX`/`libOpenGL`/`libGLdispatch` (the CentOS 7 package
-  linked plain `libGL`) - so the image builds GLEW from source against `libGL` instead.
-- Qt 6 links `libEGL` (which also drags in `libGLdispatch`) when EGL headers are present at
-  configure time - so the image configures Qt with `FEATURE_egl=OFF` (desktop OpenGL on X11
-  goes through GLX and does not need EGL).
-
-The image's final sanity-check layer fails the build if `libQt6Gui` or `libGLEW` links any
-GLVND library, so a dependency change that reintroduces one is caught at image-build time.
+The full account is in the git history: PRs #49, #59, #60 and #63, and the commit that removed
+this section.
 
 ### `CMAKE_INSTALL_RPATH` (macOS)
 
@@ -252,9 +242,9 @@ the pyGPlates build system doesn't set an install rpath of its own) - leaving de
 to resolve any `@rpath/...` dependency. So `pyproject.toml` passes `CMAKE_INSTALL_RPATH`
 (pointing at the deps prefix's `lib` and Qt `lib` directories) to the pyGPlates build, and
 `build_macos_deps.sh` does the equivalent for the dependencies' own dependencies (PROJ's rpath
-in GDAL, Qt's in Qwt). The rpaths only need to be valid on the *build* machine: delocate
-follows them to find the libraries, copies the libraries into the wheel, and rewrites every
-reference to `@loader_path/...`.
+in GDAL, and Boost's in the Boost libraries). The rpaths only need to be valid on the *build*
+machine: delocate follows them to find the libraries, copies the libraries into the wheel, and
+rewrites every reference to `@loader_path/...`.
 
 ### No Homebrew, no libpython (macOS)
 
@@ -274,8 +264,18 @@ Python runtime anyway.
 
 ### Checking the wheel, not just the code
 
-`test-command` runs the pyGPlates test suite and then `check_wheel_contents.py`, which confirms the
-wheel carries PROJ's coordinate reference system database and GDAL's driver data.
+`test-command` runs the pyGPlates test suite, then `check_wheel_contents.py`, then
+`cmake/check_linkage.py --installed`. The last two check the wheel rather than the code, and they
+are in the wheel test command rather than in CTest because at CTest time there is no wheel: the
+repair step (auditwheel/delocate/delvewheel) rewrites what the module depends on and vendors a
+set of libraries around it, and none of that exists in the build tree.
+
+`check_wheel_contents.py` confirms the wheel carries PROJ's coordinate reference system database
+and GDAL's driver data, and lists every library the repair step vendored, with its size - which
+is both the record of what a wheel actually ships and the check that no GUI, rendering or system
+library got in. `check_linkage.py --installed` is the CTest of the same name, re-run over the
+module inside the wheel. The Linux job also imports the wheel in a bare `python:3.x-slim`
+container, which is the only place the "needs no system packages" claim is actually tested.
 
 The suite cannot stand in for that check, because it passes either way. `cmake/modules/Install.cmake`
 locates both data directories while configuring, and used to report failure as a CMake warning and

--- a/pygplates/wheel/build_macos_deps.sh
+++ b/pygplates/wheel/build_macos_deps.sh
@@ -70,8 +70,9 @@ fi
 # Qt (the official binaries, downloaded with aqtinstall - much faster than the source build
 # the Linux image needs, and they're the same binaries the Qt online installer provides).
 #
-# 'qtbase' provides Core, Gui, Network, Widgets, Xml, OpenGL and OpenGLWidgets; 'qtsvg'
-# provides Svg. Qwt below needs Svg/OpenGL too.
+# 'qtbase' is the smallest archive aqt offers and carries every base module; the pyGPlates
+# module links only QtCore ('cmake/check_linkage.py' fails the build if that ever changes) and
+# only QtCore is vendored into the wheels, since delocate copies what is actually referenced.
 #
 # The official binaries are universal (arm64 + x86_64), so each framework library is thinned
 # to the build architecture - halving what delocate later vendors into the wheels.
@@ -82,9 +83,9 @@ QT_DIR=${PYGPLATES_DEPS}/qt/${QT_VERSION}/macos
 if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
     python3 -m venv aqt-venv
     ./aqt-venv/bin/pip -q install 'aqtinstall<4'
-    # '--archives qtbase qtsvg' limits the download to the parts of the base package we need
+    # '--archives qtbase' limits the download to the part of the base package we need
     # (skipping qtdeclarative, qttools etc, which are most of it).
-    ./aqt-venv/bin/aqt install-qt mac desktop ${QT_VERSION} clang_64 --archives qtbase qtsvg --outputdir "${PYGPLATES_DEPS}/qt"
+    ./aqt-venv/bin/aqt install-qt mac desktop ${QT_VERSION} clang_64 --archives qtbase --outputdir "${PYGPLATES_DEPS}/qt"
     ln -sfn "${QT_DIR}" "${PYGPLATES_DEPS}/qt/current"
     # Thin the universal framework libraries to the build architecture.
     for framework in "${QT_DIR}"/lib/Qt*.framework; do
@@ -95,49 +96,6 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
         fi
     done
     touch "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}"
-fi
-
-# GLEW ('make' auto-detects darwin and links the system OpenGL framework; the darwin makefile
-# gives the library an absolute install name under GLEW_DEST, which is what delocate needs).
-if [ ! -f "${PYGPLATES_DEPS}/stamps/glew-${GLEW_VERSION}" ]; then
-    rm -rf glew && mkdir glew && cd glew
-    curl -sSL https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/glew-${GLEW_VERSION}.tgz | tar xz --strip-components=1
-    make -j ${NPROC} GLEW_DEST="${PYGPLATES_DEPS}"
-    make install GLEW_DEST="${PYGPLATES_DEPS}"
-    cd .. && rm -rf glew
-    touch "${PYGPLATES_DEPS}/stamps/glew-${GLEW_VERSION}"
-fi
-
-# Qwt (must be built against the Qt above - it has no Qt6 binary packages anywhere).
-#
-# Same qwtconfig.pri edits as the Linux image (install prefix, and no designer plugin/
-# examples/playground/tests), plus QwtFramework is disabled so Qwt builds as a plain dylib
-# (simpler for FindQwt.cmake and delocate than a framework).
-#
-# qmake does not give the installed dylib a usable install name, and does not record where
-# the Qt frameworks it links live - so the install name is set to the installed path (which
-# the pyGPlates build then records, for delocate to follow) and an rpath entry is added for
-# Qt (which delocate follows from the Qwt library to the Qt frameworks).
-if [ ! -f "${PYGPLATES_DEPS}/stamps/qwt-${QWT_VERSION}" ]; then
-    rm -rf qwt && mkdir qwt && cd qwt
-    curl -sSL -o qwt.tar.bz2 https://sourceforge.net/projects/qwt/files/qwt/${QWT_VERSION}/qwt-${QWT_VERSION}.tar.bz2
-    tar xjf qwt.tar.bz2 --strip-components=1
-    # (BSD sed: '-E' extended regexes, since the basic ones have no alternation; '@' as the
-    # substitution delimiter, since the deps prefix contains '/' and the regexes contain '|'.)
-    sed -i '' -E \
-        -e "s@^([[:space:]]*QWT_INSTALL_PREFIX[[:space:]]*=).*@\1 ${PYGPLATES_DEPS}@" \
-        -e 's@^QWT_CONFIG[[:space:]]*[+]=[[:space:]]*(QwtDesigner|QwtExamples|QwtPlayground|QwtTests)@# &@' \
-        -e 's@^([[:space:]]*)QWT_CONFIG[[:space:]]*[+]=[[:space:]]*QwtFramework@\1# QWT_CONFIG += QwtFramework@' \
-        qwtconfig.pri
-    "${QT_DIR}/bin/qmake" qwt.pro
-    make -j ${NPROC}
-    make install
-    install_name_tool -id "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib" "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib"
-    if ! otool -l "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib" | grep -q "${QT_DIR}/lib"; then
-        install_name_tool -add_rpath "${QT_DIR}/lib" "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib"
-    fi
-    cd .. && rm -rf qwt
-    touch "${PYGPLATES_DEPS}/stamps/qwt-${QWT_VERSION}"
 fi
 
 # Boost (only the compiled non-Python libraries pyGPlates needs - Boost.Python is built per
@@ -253,12 +211,9 @@ fi
 
 # Sanity-check the installs (fails the run if anything is missing).
 "${QT_DIR}/bin/qmake" -query QT_VERSION
-test -d "${QT_DIR}/lib/QtSvg.framework"
-test -d "${QT_DIR}/lib/QtNetwork.framework"
+test -d "${QT_DIR}/lib/QtCore.framework"
 test -L "${PYGPLATES_DEPS}/qt/current"
-ls "${PYGPLATES_DEPS}/lib/libqwt.${QWT_VERSION}.dylib"
 ls "${PYGPLATES_DEPS}/lib/libboost_program_options.dylib" "${PYGPLATES_DEPS}/lib/libboost_thread.dylib"
-ls "${PYGPLATES_DEPS}/lib/libGLEW.dylib"
 ls "${PYGPLATES_DEPS}/lib/libproj.dylib"
 ls "${PYGPLATES_DEPS}/lib/libgdal.dylib"
 ls "${PYGPLATES_DEPS}/lib/libgmp.dylib" "${PYGPLATES_DEPS}/lib/libmpfr.dylib"
@@ -269,8 +224,8 @@ test -d "${PYGPLATES_DEPS}/include/CGAL"
 # disappear or change ABI with runner image updates. Print the dependencies first so a
 # failure here is diagnosable from the log. ('/usr/local/opt' and '/usr/local/Cellar' are
 # the Homebrew prefixes on Intel, '/opt/homebrew' on Apple Silicon.)
-otool -L "${PYGPLATES_DEPS}"/lib/libqwt.${QWT_VERSION}.dylib "${PYGPLATES_DEPS}"/lib/libGLEW.*.*.dylib "${PYGPLATES_DEPS}"/lib/libproj.*.dylib "${PYGPLATES_DEPS}"/lib/libgdal.*.dylib
-! otool -L "${PYGPLATES_DEPS}"/lib/libqwt.${QWT_VERSION}.dylib "${PYGPLATES_DEPS}"/lib/libGLEW.*.*.dylib "${PYGPLATES_DEPS}"/lib/libproj.*.dylib "${PYGPLATES_DEPS}"/lib/libgdal.*.dylib | grep -E '/opt/homebrew/|/usr/local/opt/|/usr/local/Cellar/'
+otool -L "${PYGPLATES_DEPS}"/lib/libproj.*.dylib "${PYGPLATES_DEPS}"/lib/libgdal.*.dylib
+! otool -L "${PYGPLATES_DEPS}"/lib/libproj.*.dylib "${PYGPLATES_DEPS}"/lib/libgdal.*.dylib | grep -E '/opt/homebrew/|/usr/local/opt/|/usr/local/Cellar/'
 
 # Mark the whole prefix built and checked. The CI cache-save step skips re-saving a prefix
 # that already carried this stamp when restored (see '.github/workflows/build-wheels.yml').

--- a/pygplates/wheel/build_windows_deps.sh
+++ b/pygplates/wheel/build_windows_deps.sh
@@ -29,8 +29,8 @@
 # Where the dependencies come from:
 #
 # - Qt: the official binaries, as on macOS (downloaded with aqtinstall).
-# - GLEW, zlib, PROJ, GDAL, GMP and MPFR: vcpkg (see 'vcpkg.json' for what is there and why).
-# - Qwt, Boost and CGAL: built here from the 'versions.sh' pins shared with the other platforms.
+# - zlib, PROJ, GDAL, GMP and MPFR: vcpkg (see 'vcpkg.json' for what is there and why).
+# - Boost and CGAL: built here from the 'versions.sh' pins shared with the other platforms.
 #
 # Requirements: Visual Studio 2022 (or its Build Tools) with the C++ x64 toolset, Git for
 # Windows (this is a bash script - cibuildwheel's hooks run in cmd, which is why 'pyproject.toml'
@@ -72,8 +72,8 @@ WHEEL_DIR=$(cd "$(dirname "$(cygpath --unix "$0")")" && pwd)
 # the single source of truth for all three platforms).
 . "${WHEEL_DIR}/versions.sh"
 
-# Put cl/nmake/the Windows SDK in this shell's environment (for Boost's b2 and Qwt's qmake,
-# which are not CMake builds and so cannot find Visual Studio for themselves).
+# Put cl/the Windows SDK in this shell's environment (for Boost's b2, which is not a CMake
+# build and so cannot find Visual Studio for itself).
 . "${WHEEL_DIR}/msvc_env.sh"
 
 NPROC=$(nproc)
@@ -118,8 +118,11 @@ fi
 # Qt (the official binaries, downloaded with aqtinstall - the same binaries the Qt online
 # installer provides, and the same ones the macOS deps script uses).
 #
-# 'qtbase' provides Core, Gui, Network, Widgets, Xml, OpenGL and OpenGLWidgets; 'qtsvg' provides
-# Svg. Qwt below needs Svg/OpenGL too.
+# 'qtbase' is the smallest archive aqt offers and carries every base module; the pyGPlates
+# module links only Qt6Core ('cmake/check_linkage.py' fails the build if that ever changes) and
+# only Qt6Core.dll is vendored into the wheels, since delvewheel copies what is actually
+# referenced. Qt6Gui.dll and the rest still land in 'qt/bin' - the archive is all or nothing -
+# so do not read their presence as a sign that anything needs them.
 #
 # Installed to a version-less directory (unlike macOS, which points a 'qt/current' symlink at the
 # versioned one - Git for Windows has no usable symlinks), so the Qt version stays here in
@@ -129,10 +132,10 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
     rm -rf "${QT_DIR}" qt-download aqt-venv
     "${PYTHON_EXE}" -m venv aqt-venv
     ./aqt-venv/Scripts/pip -q install 'aqtinstall<4'
-    # '--archives qtbase qtsvg' limits the download to the parts of the base package we need
+    # '--archives qtbase' limits the download to the part of the base package we need
     # (skipping qtdeclarative, qttools etc, which are most of it).
     ./aqt-venv/Scripts/aqt install-qt windows desktop ${QT_VERSION} win64_msvc2019_64 \
-        --archives qtbase qtsvg --outputdir qt-download
+        --archives qtbase --outputdir qt-download
     mv "qt-download/${QT_VERSION}/msvc2019_64" "${QT_DIR}"
     rm -rf qt-download
 
@@ -150,7 +153,7 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}" ]; then
     touch "${PYGPLATES_DEPS}/stamps/qt-${QT_VERSION}"
 fi
 
-# The vcpkg libraries (GLEW, zlib, PROJ, GDAL, GMP, MPFR - see 'vcpkg.json').
+# The vcpkg libraries (zlib, PROJ, GDAL, GMP, MPFR - see 'vcpkg.json').
 #
 # vcpkg is checked out at the baseline commit named in 'vcpkg.json', which is what pins these
 # libraries' versions - so the stamp is named after it and a baseline bump rebuilds them. The
@@ -238,40 +241,6 @@ if [ ! -f "${PYGPLATES_DEPS}/stamps/vcpkg-${VCPKG_BASELINE}" ]; then
     touch "${PYGPLATES_DEPS}/stamps/vcpkg-${VCPKG_BASELINE}"
 fi
 
-# Qwt (must be built against the Qt above - it has no Qt6 binary packages anywhere).
-#
-# Same qwtconfig.pri edits as the Linux image and the macOS build (install prefix, and no
-# designer plugin/examples/playground/tests), plus QwtDll is disabled so Qwt is built as a
-# static library: a Qwt DLL would need every consumer to compile with -DQWT_DLL (Qwt's headers
-# declare no import attributes without it), and Qwt is small enough that linking it into the
-# pyGPlates module is simpler than carrying a DLL for it.
-#
-# qmake's Windows makefiles build both a debug and a release configuration by default, and
-# nothing here builds against a debug Qt, so only the release one is asked for.
-if [ ! -f "${PYGPLATES_DEPS}/stamps/qwt-${QWT_VERSION}" ]; then
-    rm -rf qwt && mkdir qwt && cd qwt
-    curl -sSL -o qwt.tar.bz2 https://sourceforge.net/projects/qwt/files/qwt/${QWT_VERSION}/qwt-${QWT_VERSION}.tar.bz2
-    tar xjf qwt.tar.bz2 --strip-components=1
-    # ('-E' extended regexes, since the basic ones have no alternation; '@' as the substitution
-    # delimiter, since the deps prefix contains '/' and the regexes contain '|'.)
-    sed -i -E \
-        -e "s@^([[:space:]]*QWT_INSTALL_PREFIX[[:space:]]*=).*@\1 ${PYGPLATES_DEPS}@" \
-        -e 's@^QWT_CONFIG[[:space:]]*[+]=[[:space:]]*(QwtDesigner|QwtExamples|QwtPlayground|QwtTests)@# &@' \
-        -e 's@^([[:space:]]*)QWT_CONFIG[[:space:]]*[+]=[[:space:]]*QwtDll@\1# QWT_CONFIG += QwtDll@' \
-        qwtconfig.pri
-    # 'qwtbuild.pri' turns on 'debug_and_release' and 'build_all' for Windows, which overrides
-    # the qmake command line below and builds a debug Qwt as well - against a debug Qt, which
-    # is not installed (its libraries are deleted above). Comment both out. The command line
-    # still says 'CONFIG-=debug_and_release' because that is what clears the same setting where
-    # it also comes from: the compiler's own qmake spec, before any of Qwt's files are read.
-    sed -i -E 's@^([[:space:]]*CONFIG[[:space:]]*[+]=[[:space:]]*(debug_and_release|build_all))@#\1@' qwtbuild.pri
-    "${QT_DIR}/bin/qmake" qwt.pro CONFIG+=release CONFIG-=debug_and_release
-    nmake
-    nmake install
-    cd .. && rm -rf qwt
-    touch "${PYGPLATES_DEPS}/stamps/qwt-${QWT_VERSION}"
-fi
-
 # Boost (only the compiled non-Python libraries pyGPlates needs - Boost.Python is built per
 # Python version by 'build_boost_python.sh', which reuses this source tree, so the tree is NOT
 # deleted after installing).
@@ -352,7 +321,7 @@ require_vcpkg_version() {
         "${PYGPLATES_DEPS}/vcpkg/vcpkg/status")
     if [ "${_got}" != "$2" ]; then
         echo "error: vcpkg installed $1 ${_got:-(nothing)} but 'versions.sh' pins $1 $2. The vcpkg" >&2
-        echo "       baseline in 'vcpkg.json' and the GLEW/PROJ/GDAL pins in 'versions.sh' are meant" >&2
+        echo "       baseline in 'vcpkg.json' and the PROJ/GDAL pins in 'versions.sh' are meant" >&2
         echo "       to move together, as one act, so every platform's wheels ship the same versions" >&2
         echo "       of the libraries a user can feel." >&2
         exit 1
@@ -360,22 +329,18 @@ require_vcpkg_version() {
 }
 #
 # The vcpkg libraries are checked by their headers rather than their import libraries: a port
-# decides for itself what to call the library it installs (glew32.lib, proj_9.lib, ...), whereas
+# decides for itself what to call the library it installs (proj_9.lib, gdal.lib, ...), whereas
 # the header a dependent compiles against is the port's contract. The library directories are
 # listed in the log instead, so that a link failure later can be read against what is actually
 # installed.
 "${QT_DIR}/bin/qmake" -query QT_VERSION
-ls "${QT_DIR}/bin/Qt6Core.dll" "${QT_DIR}/bin/Qt6Gui.dll" "${QT_DIR}/bin/Qt6Widgets.dll" \
-    "${QT_DIR}/bin/Qt6Network.dll" "${QT_DIR}/bin/Qt6Svg.dll" "${QT_DIR}/bin/Qt6OpenGL.dll"
-ls "${PYGPLATES_DEPS}/lib/qwt.lib"
+ls "${QT_DIR}/bin/Qt6Core.dll"
 ls "${PYGPLATES_DEPS}/lib/boost_program_options.lib" "${PYGPLATES_DEPS}/lib/boost_thread.lib"
-require_file "${VCPKG_PREFIX}/include/GL/glew.h" "GLEW"
 require_file "${VCPKG_PREFIX}/include/zlib.h" "zlib"
 require_file "${VCPKG_PREFIX}/include/proj.h" "PROJ"
 require_file "${VCPKG_PREFIX}/include/gdal.h" "GDAL"
 require_file "${VCPKG_PREFIX}/include/gmp.h" "GMP"
 require_file "${VCPKG_PREFIX}/include/mpfr.h" "MPFR"
-require_vcpkg_version glew "${GLEW_VERSION}"
 require_vcpkg_version proj "${PROJ_VERSION}"
 require_vcpkg_version gdal "${GDAL_VERSION}"
 # PROJ and GDAL read these data directories at run time, and the wheel build copies both into

--- a/pygplates/wheel/check_wheel_contents.py
+++ b/pygplates/wheel/check_wheel_contents.py
@@ -1,6 +1,6 @@
 """
-Check that a built pyGPlates wheel carries the data files its dependencies read at run time,
-and the license text.
+Check that a built pyGPlates wheel carries the data files its dependencies read at run time and
+the license text, and that it vendors no GUI, rendering or system libraries.
 
 Run against each repaired wheel by cibuildwheel's 'test-command' (see '[tool.cibuildwheel]' in the
 root 'pyproject.toml'), so it inspects the installed package rather than the build tree.
@@ -17,6 +17,7 @@ survive installation and the wheel repair step to reach the user.
 
 import importlib.metadata
 import pathlib
+import re
 import sys
 
 import pygplates
@@ -34,6 +35,60 @@ REQUIRED_FILES = [
     ("PROJ", pathlib.Path("proj_data") / "proj.db"),
     ("GDAL", pathlib.Path("gdal_data") / "gdalvrt.xsd"),
 ]
+
+# Where the wheel repair step puts the dependency libraries it vendored, relative to the
+# installed package directory. auditwheel (Linux) and delvewheel (Windows) use a sibling
+# 'pygplates.libs' directory; delocate (macOS) uses '.dylibs' inside the package.
+VENDORED_DIRS = [pathlib.Path("..") / "pygplates.libs", pathlib.Path(".dylibs")]
+
+# Libraries that must never be vendored, matched case-insensitively against the file name.
+#
+# This is the transitive complement of 'cmake/check_linkage.py', which lists what the module
+# links *directly*. The repair step walks the whole dependency graph, so a GUI library can be
+# vendored through a dependency's dependency, where the direct check cannot see it - and that
+# is exactly how the two-libGLdispatch-copies segfault at 'import pygplates' arrived.
+#
+# The GLib/ICU/D-Bus entries are a different failure: those are on auditwheel's whitelist, so
+# they are not vendored but *required* from the user's system - which is what kept the Linux
+# wheel from importing on a bare 'python:3.x-slim'. They are listed here because their
+# appearing in this directory would mean the Qt in the image had been built with them after
+# all (see the FEATURE_* flags in 'manylinux_2_28.dockerfile').
+#
+# ('[-.]' after a stem because the vendored names carry a hash: "libQt6Core-598a0482.so.6".)
+FORBIDDEN_VENDORED = re.compile(
+    r"opengl|libGL[-.]|libGLX[-.]|libGLdispatch[-.]|libEGL[-.]"
+    r"|glib|gthread|libicu|libdbus"
+    r"|qt\w*(gui|widgets|svg|network|xml|dbus)|qwt|glew",
+    re.I,
+)
+
+
+def check_vendored_libraries(package_dir):
+    """List the vendored dependency libraries, and return the names that must not be there."""
+    forbidden = []
+    directories = [(package_dir / relative).resolve() for relative in VENDORED_DIRS]
+    directories = [directory for directory in directories if directory.is_dir()]
+    if not directories:
+        # Every platform's repair step vendors at least Qt6Core, so finding nothing means this
+        # is not looking where the libraries went - and a scan of nothing passes silently,
+        # which is the one outcome this whole file exists to prevent.
+        sys.exit(
+            "error: no vendored library directory found next to {} (looked for {}). Either the "
+            "wheel was not repaired, or the repair tool has changed where it puts "
+            "them.".format(package_dir, " and ".join(str(d) for d in VENDORED_DIRS))
+        )
+
+    for directory in directories:
+        # Every file, with its size: the log is also the record of what the wheel actually
+        # ships, which is the only place that is written down.
+        print("Vendored libraries in {}".format(directory))
+        for path in sorted(directory.iterdir()):
+            flag = ""
+            if FORBIDDEN_VENDORED.search(path.name):
+                forbidden.append(path.name)
+                flag = "   <-- FORBIDDEN"
+            print("  {:>9.1f} KB  {}{}".format(path.stat().st_size / 1024, path.name, flag))
+    return forbidden
 
 
 def main():
@@ -67,6 +122,14 @@ def main():
             "which is exactly the failure mode this check exists to catch.".format(
                 ", ".join(missing)
             )
+        )
+
+    forbidden = check_vendored_libraries(package_dir)
+    if forbidden:
+        sys.exit(
+            "error: this wheel vendors {} library/libraries it must not: {}. Something has put "
+            "a GUI, rendering or system library back into the dependency graph - see "
+            "'pygplates/wheel/README.md'.".format(len(forbidden), ", ".join(forbidden))
         )
 
 

--- a/pygplates/wheel/manylinux_2_28.dockerfile
+++ b/pygplates/wheel/manylinux_2_28.dockerfile
@@ -23,6 +23,13 @@
 # Qt 6.7 is the last series supporting macOS 11, which the macOS wheels target - the Linux
 # image uses the same version so all wheels ship the same Qt.
 #
+# Only Qt Core is built. The pyGPlates module links Qt6Core and nothing else - 'cmake/
+# check_linkage.py' fails the build if that ever changes - so a Gui/Widgets/OpenGL Qt would be
+# ~25 minutes of build time, a couple of dozen X11 development packages and a GLEW/Qwt/QtSvg
+# stack, all of it to produce libraries no wheel ever loads. Building Core alone is also what
+# lets the wheel import on a bare 'python:3.x-slim' with no system packages installed (see
+# FEATURE_glib below).
+#
 # The dependency versions come from 'versions.sh' (in this directory), shared with the macOS
 # dependency build so the platforms cannot drift apart.
 #
@@ -39,36 +46,18 @@ ARG ARCH
 #
 # Install the dependencies that EL8 provides as binary packages.
 #
-# - Most '-devel' packages live in the 'powertools' repo on EL8 (and 'xcb-util-cursor-devel' in EPEL).
 # - GMP/MPFR (for CGAL) are new enough in EL8 - the source builds in the old manylinux2014
 #   (CentOS 7) dockerfile are no longer needed.
-# - The X11/xcb/xkbcommon/fontconfig set is what Qt needs to build its xcb platform plugin.
+# - All four are in EL8's base repositories, so no 'powertools'/EPEL enabling is needed. The
+#   X11/xcb/xkbcommon/fontconfig/mesa set that used to be here (and the 'dnf-plugins-core' and
+#   'epel-release' that existed to reach parts of it) went with the Qt Gui build.
 #
-RUN dnf -y install dnf-plugins-core epel-release && \
-    dnf config-manager --set-enabled powertools && \
-    dnf -y update && \
+RUN dnf -y update && \
     dnf -y install \
         bzip2 \
         zlib-devel \
         gmp-devel \
-        mpfr-devel \
-        mesa-libGL-devel \
-        mesa-libGLU-devel \
-        fontconfig-devel \
-        freetype-devel \
-        libX11-devel \
-        libXext-devel \
-        libXrender-devel \
-        libXi-devel \
-        libxkbcommon-devel \
-        libxkbcommon-x11-devel \
-        libxcb-devel \
-        xcb-util-devel \
-        xcb-util-image-devel \
-        xcb-util-keysyms-devel \
-        xcb-util-renderutil-devel \
-        xcb-util-wm-devel \
-        xcb-util-cursor-devel && \
+        mpfr-devel && \
     dnf clean all
 
 # A current Ninja from PyPI, for the Qt builds below - EL8's 'ninja-build' package is
@@ -119,36 +108,25 @@ RUN . /tmp/versions.sh && \
     ldconfig && \
     rm -rf /tmp/build
 
-# GLEW, built against the LEGACY 'libGL' (auditwheel-whitelisted - comes from the end user's
-# system, like the old CentOS 7 'glew-devel' package used to).
+# Qt Core (from qtbase - see the note at the top of this file for why nothing else is built).
 #
-# EL8's 'glew-devel' package must NOT be used instead: it links the GLVND libraries
-# (libGLX/libOpenGL/libGLdispatch), which are not whitelisted by auditwheel and so would be
-# vendored into the wheel - recreating the two-libGLdispatch-copies segmentation fault at
-# 'import pygplates' that OpenGL_GL_PREFERENCE=LEGACY exists to prevent
-# (see 'pygplates/wheel/README.md' for that history).
-WORKDIR /tmp/build
-RUN . /tmp/versions.sh && \
-    curl -sSL https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/glew-${GLEW_VERSION}.tgz | tar xz --strip-components=1 && \
-    make -j $(nproc) GLEW_DEST=/usr/local && \
-    make install GLEW_DEST=/usr/local && \
-    ldconfig && \
-    rm -rf /tmp/build
-
-# Qt (qtbase and qtsvg - pyGPlates needs Core, Gui, Widgets, Xml, OpenGL, OpenGLWidgets and
-# Svg, and Qwt below needs Svg/OpenGL).
+# Each FEATURE_* below is off for a reason, and the whole point of them is what libQt6Core.so.6
+# must NOT end up needing: anything outside auditwheel's whitelist is vendored into the wheel,
+# and anything on it becomes a system library the user has to have installed. The sanity layer
+# at the end of this file asserts the resulting NEEDED list, so a future edit here cannot
+# quietly reintroduce one.
 #
-# FEATURE_xcb=ON is asserted explicitly so that configure *fails* if the xcb dependencies are
-# incomplete (rather than silently building a Qt that cannot connect to an X display).
+# - gui: no Gui means no Widgets, OpenGL, xcb, EGL, fontconfig or freetype either - the whole
+#   X11 stack the image used to install, and most of the build time.
+# - glib: Qt's Core event loop can integrate with GLib's, and configure enables it whenever
+#   glib2-devel is present (EL8's is, as a dependency of the base image's toolchain). GLib is
+#   auditwheel-whitelisted, so it was not vendored - it was simply *required* from the user's
+#   system, which is why 'import pygplates' failed on a bare 'python:3.x-slim' until now.
+# - dbus: Qt6DBus was built and vendored only because Gui pulled it in; nothing links it.
+# - icu: already off today only because 'libicu-devel' is absent from the image. Asserting it
+#   means a base-image change cannot silently vendor ~30 MB of ICU into every wheel.
+# - network/sql/xml/testlib/concurrent: modules nothing links, each costing build time.
 #
-# FEATURE_egl=OFF because a Qt6Gui linking libEGL gets libEGL (and its libGLdispatch
-# dependency) vendored into the wheel by auditwheel - triggering the same
-# two-libGLdispatch-copies segmentation fault described above for GLEW. Desktop OpenGL on X11
-# goes through GLX/libGL and does not need EGL.
-#
-# OpenGL_GL_PREFERENCE=LEGACY for the same reason: Qt's build uses CMake's FindOpenGL, whose
-# default GLVND preference makes libQt6Gui link libGLX/libOpenGL directly (both vendored by
-# auditwheel) instead of the whitelisted legacy libGL.
 # (${QT_VERSION%.*} strips the patch level - the download path groups releases by series.)
 WORKDIR /tmp/build
 RUN . /tmp/versions.sh && \
@@ -159,49 +137,18 @@ RUN . /tmp/versions.sh && \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DQT_BUILD_EXAMPLES=OFF \
         -DQT_BUILD_TESTS=OFF \
-        -DFEATURE_xcb=ON \
-        -DFEATURE_egl=OFF \
-        -DINPUT_opengl=desktop \
-        -DOpenGL_GL_PREFERENCE=LEGACY \
+        -DFEATURE_gui=OFF \
+        -DFEATURE_glib=OFF \
+        -DFEATURE_dbus=OFF \
+        -DFEATURE_icu=OFF \
+        -DFEATURE_network=OFF \
+        -DFEATURE_sql=OFF \
+        -DFEATURE_xml=OFF \
+        -DFEATURE_testlib=OFF \
+        -DFEATURE_concurrent=OFF \
         .. && \
     ninja && \
     ninja install && \
-    ldconfig && \
-    rm -rf /tmp/build
-WORKDIR /tmp/build
-RUN . /tmp/versions.sh && \
-    curl -sSL https://download.qt.io/archive/qt/${QT_VERSION%.*}/${QT_VERSION}/submodules/qtsvg-everywhere-src-${QT_VERSION}.tar.xz | tar xJ --strip-components=1 && \
-    mkdir build && cd build && \
-    cmake -G Ninja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DCMAKE_PREFIX_PATH=/usr/local \
-        -DQT_BUILD_EXAMPLES=OFF \
-        -DQT_BUILD_TESTS=OFF \
-        .. && \
-    ninja && \
-    ninja install && \
-    ldconfig && \
-    rm -rf /tmp/build
-
-# Qwt (must be built against the Qt above - it has no Qt6 binary packages anywhere).
-#
-# The install prefix is changed from the default (a versioned directory like /usr/local/qwt-6.3.0)
-# to /usr/local so that pyGPlates' FindQwt.cmake finds it without any hints.
-# The designer plugin is disabled because it needs Qt Designer headers (from the qttools
-# module, which is not built here); the examples/playground/tests (all on by default) are
-# disabled because they just waste build time.
-WORKDIR /tmp/build
-RUN . /tmp/versions.sh && \
-    curl -sSL -o qwt.tar.bz2 https://sourceforge.net/projects/qwt/files/qwt/${QWT_VERSION}/qwt-${QWT_VERSION}.tar.bz2 && \
-    tar xjf qwt.tar.bz2 --strip-components=1 && \
-    sed -i \
-        -e 's|^\([[:space:]]*QWT_INSTALL_PREFIX[[:space:]]*=\).*|\1 /usr/local|' \
-        -e 's|^QWT_CONFIG[[:space:]]*+=[[:space:]]*\(QwtDesigner\b\|QwtExamples\|QwtPlayground\|QwtTests\)|# &|' \
-        qwtconfig.pri && \
-    qmake qwt.pro && \
-    make -j $(nproc) && \
-    make install && \
     ldconfig && \
     rm -rf /tmp/build
 
@@ -278,19 +225,23 @@ WORKDIR /
 RUN . /tmp/versions.sh && \
     ldconfig && \
     qmake -query QT_VERSION && \
-    test -f /usr/local/lib/libQt6Svg.so -o -f /usr/local/lib64/libQt6Svg.so && \
-    ls /usr/local/lib/libqwt.so && \
+    ls /usr/local/lib*/libQt6Core.so.6 && \
     for python_version in ${PYTHON_VERSIONS}; do \
         ls /usr/local/lib/libboost_python$(echo ${python_version} | tr -d .).so || exit 1; \
     done && \
-    ls /usr/local/lib*/libGLEW.so && \
     ls /usr/local/lib*/libproj.so && \
     ls /usr/local/lib*/libgdal.so && \
     test -d /usr/local/include/CGAL && \
     sccache --version && \
-    # Neither Qt nor GLEW may *directly* link the GLVND family (libEGL/libGLX/libOpenGL) -
-    # auditwheel would vendor those into the wheel, causing the segfault described above.
-    # (Direct DT_NEEDED entries only - transitive GLVND dependencies *of the whitelisted
-    # libGL* are fine, auditwheel does not traverse past whitelisted libraries.)
-    readelf -d /usr/local/lib*/libQt6Gui.so.6 /usr/local/lib*/libGLEW.so | grep -E 'File|NEEDED' && \
-    ! readelf -d /usr/local/lib*/libQt6Gui.so.6 /usr/local/lib*/libGLEW.so | grep NEEDED | grep -E 'libEGL|libGLX|libOpenGL'
+    # Qt Gui, Qwt and GLEW must stay gone: they are what the Qt configure flags above are for,
+    # and an accidental reappearance would be vendored into every wheel unnoticed.
+    ! ls /usr/local/lib*/libQt6Gui.* /usr/local/lib*/libqwt.* /usr/local/lib*/libGLEW.* 2> /dev/null && \
+    # libQt6Core may not need anything beyond the C/C++ runtime: the GLVND family and libX11
+    # would be vendored into the wheel by auditwheel (two copies of libGLdispatch in one
+    # process is the segfault at 'import pygplates' this image's history turns on), while
+    # GLib, ICU and D-Bus are whitelisted and so become system packages the user must install
+    # - which is what stopped the wheel importing on a bare python image.
+    # (Direct DT_NEEDED entries only, printed first so a failure here is diagnosable.)
+    readelf -d /usr/local/lib*/libQt6Core.so.6 | grep -E 'File|NEEDED' && \
+    ! readelf -d /usr/local/lib*/libQt6Core.so.6 | grep NEEDED | \
+        grep -E 'glib|gthread|libGL|libEGL|libicu|libdbus|libX11'

--- a/pygplates/wheel/msvc_env.sh
+++ b/pygplates/wheel/msvc_env.sh
@@ -4,11 +4,11 @@
 #
 #   . "$(dirname "$0")/msvc_env.sh"
 #
-# The Windows dependency builds need it because they are not CMake builds: Boost's b2 and Qwt's
-# qmake/nmake compile with whatever 'cl' the environment provides. The pyGPlates wheel build
-# needs it too, since it moved from the Visual Studio generator (which locates Visual Studio by
-# itself) to Ninja (which does not) - but a cibuildwheel hook cannot set the environment for the
-# CMake build that follows it, so that comes from the shell cibuildwheel is started from: in CI
+# The Windows dependency builds need it because Boost's b2 is not a CMake build: it compiles
+# with whatever 'cl' the environment provides. The pyGPlates wheel build needs it too, since it
+# moved from the Visual Studio generator (which locates Visual Studio by itself) to Ninja
+# (which does not) - but a cibuildwheel hook cannot set the environment for the CMake build
+# that follows it, so that comes from the shell cibuildwheel is started from: in CI
 # the workflow imports this file's results into the whole job (see 'build-wheels.yml'), and a
 # local wheel build starts from an "x64 Native Tools Command Prompt" instead.
 #
@@ -31,7 +31,7 @@
 export MSVC_ENV_VARS="INCLUDE LIB LIBPATH UCRTVersion VCToolsVersion VSINSTALLDIR WindowsSdkDir WindowsSDKVersion VCINSTALLDIR VSCMD_ARG_TGT_ARCH"
 
 # ...but only if that environment targets x64, which is what everything built here is. An "x86
-# Native Tools Command Prompt" also sets VCINSTALLDIR, and taking it would build Boost and Qwt
+# Native Tools Command Prompt" also sets VCINSTALLDIR, and taking it would build Boost
 # 32-bit while 'b2 address-model=64' and the wheel expect 64-bit - which does not fail here, it
 # fails much later at link, saying nothing about the shell it came from. So say it now instead.
 # (An environment set up some other way may not set VSCMD_ARG_TGT_ARCH at all; that is not

--- a/pygplates/wheel/vcpkg.json
+++ b/pygplates/wheel/vcpkg.json
@@ -8,17 +8,17 @@
     "and MPFR are the reason vcpkg is here at all: they have no MSVC build system (vcpkg builds",
     "them through msys2 and installs MSVC-linkable import libraries), and CGAL needs both. PROJ",
     "and GDAL come along because they are a deep stack (SQLite, TIFF, GeoTIFF, JSON-C) that",
-    "vcpkg already knows how to build on Windows. Qt, Qwt, Boost and CGAL are NOT here: they are",
+    "vcpkg already knows how to build on Windows. Qt, Boost and CGAL are NOT here: they are",
     "built by 'build_windows_deps.sh' from the version pins in 'versions.sh', so they stay in",
     "step with the Linux and macOS wheels (and vcpkg's Qt is a multi-hour source build).",
     "",
     "'builtin-baseline' is a commit of https://github.com/microsoft/vcpkg - a vcpkg release tag,",
     "which is what pins these libraries' versions. 'build_windows_deps.sh' reads it from here to",
     "check out the matching vcpkg, and stamps the installed tree with it, so bumping it below",
-    "rebuilds them. For the libraries the other platforms also ship - GLEW, PROJ and GDAL - the",
+    "rebuilds them. For the libraries the other platforms also ship - PROJ and GDAL - the",
     "pins in 'versions.sh' are kept equal to what this baseline supplies, so every platform's",
     "wheels carry the same versions of the libraries a user can feel; bump the baseline and",
-    "those three pins together, as one act ('build_windows_deps.sh' fails if they drift apart)."
+    "those two pins together, as one act ('build_windows_deps.sh' fails if they drift apart)."
   ],
 
   "name": "pygplates-wheel-dependencies",
@@ -26,7 +26,6 @@
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
 
   "dependencies": [
-    "glew",
     "gmp",
     "mpfr",
     "zlib",

--- a/pygplates/wheel/versions.sh
+++ b/pygplates/wheel/versions.sh
@@ -7,9 +7,9 @@
 # '.github/workflows/build-wheels.yml').
 #
 # Not everything is pinned here: the libraries vcpkg supplies to the Windows build are pinned
-# by the vcpkg baseline in 'vcpkg.json' instead. For the libraries both systems pin - GLEW,
-# PROJ and GDAL - the versions here are kept equal to what that baseline supplies, so all three
-# platforms' wheels ship the same geospatial behaviour. Bump the baseline and these three
+# by the vcpkg baseline in 'vcpkg.json' instead. For the libraries both systems pin - PROJ and
+# GDAL - the versions here are kept equal to what that baseline supplies, so all three
+# platforms' wheels ship the same geospatial behaviour. Bump the baseline and these two
 # together, as one act, with vcpkg setting the cadence (it is the one of the two whose available
 # versions cannot be picked freely); 'build_windows_deps.sh' fails if they drift apart.
 #
@@ -25,8 +25,6 @@
 PYTHON_VERSIONS="3.9 3.10 3.11 3.12 3.13 3.14"
 
 QT_VERSION=6.7.3
-GLEW_VERSION=2.3.1
-QWT_VERSION=6.3.0
 BOOST_VERSION=1.91.0
 PROJ_VERSION=9.8.1
 GDAL_VERSION=3.12.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,12 +297,11 @@ before-test = "sccache --show-stats"
 "cmake.define.GPLATES_INSTALL_STANDALONE_SHARED_LIBRARY_DEPENDENCIES" = "FALSE"
 "build-dir" = "build/wheel"
 # No 'OpenGL_GL_PREFERENCE' here any more: the module links only Qt6Core, so nothing on its
-# link line reaches OpenGL and there is no GL family to choose. It was
-# needed while the module linked Qt6Gui (whose imported target propagates Qt's OpenGL
-# dependency) - the history, and the two-libGLdispatch segfault the define prevented, is in
-# 'pygplates/wheel/README.md'. The docker image still sets it when building Qt and GLEW
-# ('pygplates/wheel/manylinux_2_28.dockerfile'); 'cmake/check_linkage.py' fails the build if
-# any GL library reappears on the module.
+# link line reaches OpenGL and there is no GL family to choose. It was needed while the module
+# linked Qt6Gui (whose imported target propagates Qt's OpenGL dependency) - the history, and
+# the two-libGLdispatch segfault the define prevented, is in 'pygplates/wheel/README.md'.
+# Nothing in the Linux image builds against OpenGL any more either; 'cmake/check_linkage.py'
+# and 'pygplates/wheel/check_wheel_contents.py' fail the build if any GL library reappears.
 # Compile through sccache (installed in the images above). The cache only lives for the
 # duration of the cibuildwheel run, but the per-Python-version builds share most of their
 # object files, so the second and later Python versions build many times faster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,11 +235,22 @@ build-verbosity = 1
 #
 # 'check_wheel_contents.py' runs after the suite because it checks the wheel rather than the code:
 # the test suite passes against a wheel whose PROJ and GDAL data never made it in (which is how
-# the Windows wheels came to ship without them), so the packaging needs a check of its own.
-test-sources = ["pygplates/test", "pygplates/wheel/check_wheel_contents.py"]
+# the Windows wheels came to ship without them), so the packaging needs a check of its own. It
+# also lists the libraries the repair step vendored, which is the record of what the wheel ships.
+#
+# 'check_linkage.py' is the CTest of the same name, run here as well because the two check
+# different artifacts: the CTest sees the module in the build tree, this sees the module inside
+# the repaired wheel, whose dependency names the repair step has rewritten. The August 2026
+# segfault at 'import pygplates' was in a wheel whose build-tree module was fine.
+test-sources = [
+    "pygplates/test",
+    "pygplates/wheel/check_wheel_contents.py",
+    "cmake/check_linkage.py",
+]
 test-command = [
     "python -X faulthandler pygplates/test/test.py",
     "python pygplates/wheel/check_wheel_contents.py",
+    "python cmake/check_linkage.py --installed",
 ]
 
 [tool.cibuildwheel.config-settings]


### PR DESCRIPTION
The pyGPlates module links `Qt6Core` and nothing else — `cmake/check_linkage.py` has enforced
that since #59 — but all three dependency builds still built the GUI stack around it: a Qt with
Gui, Widgets, OpenGL and the xcb platform plugin, plus qtsvg, Qwt and GLEW, and on Linux the two
dozen X11/xcb/fontconfig/mesa development packages Qt's configure needs to find them. This is the
"prune Gui" half of §7; #63 already did Core5Compat.

## Wheel contents do not change

Worth saying up front, because a reader will look for a size win that is not there: **nothing
removed here was being vendored.** The wheels never carried Gui, Svg, Network, Xml, Qwt, GLEW,
GL or ICU. The cp313 linux-x86_64 wheel built locally against the new image is 35.8 MB, the same
as the last release run's, and vendors the same 15 libraries:

```
   8717.5 KB  libQt6Core-d68c5b06.so.6.7.3
     31.9 KB  libboost_atomic-…            54.2 KB  libboost_chrono-…
    122.4 KB  libboost_container-…         18.2 KB  libboost_date_time-…
    515.3 KB  libboost_graph-…            621.8 KB  libboost_program_options-…
    444.4 KB  libboost_python313-…        194.8 KB  libboost_thread-…
  77344.5 KB  libgdal-2703d61a.so.38.3.12.4
   2071.5 KB  libgmp-…                   6152.4 KB  libgmpxx-…
   6154.7 KB  libmpfr-…                  6118.7 KB  libproj-…
   8867.1 KB  libsqlite3-49483d4d.so.0.8.6
```

(That listing is new output — see *Checks* below.)

## What does change: the Linux wheel's last system dependency

Qt's Core event loop integrates with GLib's whenever `glib2-devel` is present at configure time,
and EL8's is, as a dependency of the base image's toolchain. GLib is auditwheel-whitelisted, so
it was never vendored — it was simply **required** from the user's machine. That is the
`ImportError: libglib-2.0.so.0: cannot open shared object file` that
`doc-python-api/pygplates_getting_started.rst` has a troubleshooting section for.

`-DFEATURE_glib=OFF` ends it. The vendored `libQt6Core` in the repaired wheel now needs:

```
$ readelf -d pygplates.libs/libQt6Core-d68c5b06.so.6.7.3 | grep NEEDED
  libdl.so.2   libz.so.1   libpthread.so.0   librt.so.1
  libstdc++.so.6   libm.so.6   libgcc_s.so.1   libc.so.6   ld-linux-x86-64.so.2
```

…and the wheel imports on a bare `python:3.13-slim` with **no `apt-get` run at all**:

```
$ docker run --rm -v "$PWD/wheelhouse:/w:ro" python:3.13-slim sh -c \
    'pip install -q /w/pygplates-*cp313*x86_64.whl && python -c "
import pygplates
print(\"pyGPlates\", pygplates.__version__)
rot = pygplates.FiniteRotation(pygplates.PointOnSphere(90, 0), 0.5)
print(\"rotated point:\", (rot * pygplates.PointOnSphere(0, 0)).to_lat_lon())"'
pyGPlates 1.1.0.dev10
rotated point: (4.294837881433197e-16, 28.64788975654117)
```

CI does that on every run now (see *CI* below) — it is the only automated check of the claim,
since every other job runs somewhere GLib exists.

## What stops being built

**Linux image** (`manylinux_2_28.dockerfile`) — GLEW from source; qtsvg; Qwt; the ~20
X11/xcb/fontconfig/mesa `dnf` packages, and the `epel-release`, `dnf-plugins-core` and
`powertools` repo that existed only to reach parts of them (`gmp-devel` and `mpfr-devel` come
from EL8's base repositories, verified); `FEATURE_xcb`, `FEATURE_egl`, `INPUT_opengl` and
`OpenGL_GL_PREFERENCE`.

The qtbase configure is now `FEATURE_gui/glib/dbus/icu/network/sql/xml/testlib/concurrent=OFF`.
Every one of those was honoured — the configure summary reports `no` for each. ICU is the one
worth keeping even though it changes nothing today: it is off now only because `libicu-devel`
happens to be absent from the base image, so a base-image change would otherwise start vendoring
~30 MB of ICU into every wheel with nothing to notice.

**Image build time** (local, 12 cores, `--pull`): **14m52s total**, of which 2m15s was pulling the
base image. The Qt step went from dominating the build to **72 seconds**. Boost.Python across six
Python versions is now the largest step at 7m27s. For comparison the last two CI image builds
(runs 31900393117, 31908916403) took 28 and 39 minutes, so the workflow's `timeout-minutes: 300`
and its "~2 hours" prose were already wrong; they are now 120 and an accurate description.

**macOS** (`build_macos_deps.sh`) — the `qtsvg` archive, GLEW and Qwt from source (with the
`install_name_tool` rpath dance), and their sanity checks. **Windows** (`build_windows_deps.sh`,
`vcpkg.json`) — the `qtsvg` archive, the `glew` vcpkg port and its version-agreement check, and
the static Qwt qmake/nmake build. `GLEW_VERSION` and `QWT_VERSION` leave `versions.sh`.

macOS and Windows still download the whole `qtbase` archive: aqt has nothing smaller, and only
QtCore is ever linked or vendored. `Qt6Gui.dll` and friends still land in the Windows deps
prefix; a comment says so, so nobody reinstates the sanity `ls` for them.

## Checks

The wheel is not the artifact the build produced — the repair step rewrites the module's
dependency names and copies libraries in around it, and none of that exists in the build tree the
`pygplates-linkage-test` CTest inspects. The August 2026 segfault was in a wheel whose build-tree
module was fine. So the wheel `test-command` gains two checks:

- **`check_linkage.py --installed`** — the same script as the CTest, over the module inside the
  installed package. `--installed` rather than a path because the wheel test command runs under
  `cmd` on Windows. Its pattern gains `[-.]` after the `libGL` family, since vendored names carry
  a hash.
- **`check_wheel_contents.py`** grows a scan of the vendored-library directory: every file with
  its size (the table at the top of this description is its output), failing on any GUI,
  rendering or GLib/ICU/D-Bus library. This is the *transitive* complement of the direct check —
  the two-`libGLdispatch` segfault arrived through a dependency's dependency, where a direct
  check cannot see it. Finding no vendored directory at all is also a failure: every platform
  vendors at least Qt6Core, so an empty scan means it is looking in the wrong place, and passing
  silently is the failure mode the whole file exists to prevent.

The image's final layer now prints and asserts `libQt6Core`'s `NEEDED` list, and asserts that
`libQt6Gui`, `libqwt` and `libGLEW` are absent.

## CI: proving a dockerfile change from its branch

A dockerfile change is only really proved by building wheels inside the image it produces, and
that image does not become `:latest` until the change is merged. Rather than a temporary edit
inside the PR that has to be remembered and reverted, two permanent `workflow_dispatch` inputs:

```
gh workflow run build-wheel-images.yml --ref <branch> -f push-latest=false
gh workflow run build-wheels.yml --ref <branch> -f linux-image-tag=<that run's commit sha>
```

`push-latest=false` still tags and pushes `:<sha>`, leaving `:latest` on the merged image.
`linux-image-tag` exports `CIBW_MANYLINUX_{X86_64,AARCH64}_IMAGE`, which cibuildwheel prefers
over `pyproject.toml`, so the file stays authoritative for every other run. The tags are now
pushed by name rather than with `--all-tags`, which would push whatever `:latest` the daemon
holds and undo the point. These serve every future dockerfile PR, not just this one.

`push-latest` is read through a `PUSH_LATEST` job variable rather than compared directly: on a
`push` event the input is the empty string, and GitHub's `==` compares that equal to `false` —
which would have skipped `:latest` on exactly the runs that must move it.

## Expected: the automatic run's `linux-x86_64` leg is red

**That is the check working, not a defect.** A pull request cannot change which dependency image
its wheels are built in — the job pulls `:latest`, which is built from the *merged* dockerfile. So
this PR's automatic run built its Linux wheels in the **old, GLib-enabled** image, and the new
bare-container check correctly refuses them:

```
--- shared libraries this wheel needs that a bare image does not provide:
  pygplates.so: libglib-2.0.so.0 => not found
  pygplates.so: libgthread-2.0.so.0 => not found
  libQt6Core-83f0f135.so.6.7.3: libglib-2.0.so.0 => not found
  libQt6Core-83f0f135.so.6.7.3: libgthread-2.0.so.0 => not found
```

Every other step of that leg passed — the build, the full test suite, the vendored-library scan
and `check_linkage.py --installed`. The step prints the listing above and says why a dockerfile PR
cannot pass it, and `pygplates/wheel/README.md` records the same caveat, so the next person meets
an explanation rather than a bare `ImportError`. (Both paths of that diagnostic were tested
locally against real wheels: the one built in the new image passes, the CI one fails as above.)

The proof is the dispatched pair the two new inputs exist for:

| step | run |
|---|---|
| image, `push-latest=false` | [34023921221](https://github.com/GPlates/GPlates/actions/runs/34023921221) — x86_64 23m36s, aarch64 16m30s. `:<sha>` pushed twice, `latest: digest` appears **0 times** in the log: `:latest` was left alone, as intended. |
| wheels, `linux-image-tag=412a8051db…` | [34025096877](https://github.com/GPlates/GPlates/actions/runs/34025096877) — **all six legs green**, full six-version matrix against the new image |
| wheels again, after a review fix | [34125844350](https://github.com/GPlates/GPlates/actions/runs/34125844350) — **cancelled at ten minutes, having proved what it was dispatched for** (see below) |

That run is the one that matters. Its `linux-x86_64` leg pulled
`pygplates-manylinux_2_28_x86_64:412a8051db…`, built the wheels in it, and the bare-container
step **passed**:

```
Unable to find image 'python:3.13-slim' locally
3.13-slim: Pulling from library/python
Status: Downloaded newer image for python:3.13-slim
1.1.0.dev10
```

Its `check_wheel_contents.py` listing also confirms the wheel is unchanged — the same 15 vendored
libraries at the same sizes as the table at the top of this description (`libQt6Core` 8717.5 KB,
`libgdal` 77344.5 KB, and so on).

(The image carries the pre-amend SHA `412a8051db…`. The dockerfile is byte-identical at the
current head; only the wheel workflow's diagnostic changed after the image was built.)

The `linux-image-tag` step runs only on a dispatch, so a later review fix to it — passing the tag
through `env:` rather than interpolating it into the script body, so a tag containing whitespace
or shell syntax is data — had no CI cover. Rather than spend another six-hour matrix on one line,
it was re-dispatched and cancelled once the Linux legs had shown the whole chain:

```
IMAGE_TAG: 412a8051db168d8874d260d18027d769e25a5bf2
CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/gplates/pygplates-manylinux_2_28_x86_64:412a8051db…
CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/gplates/pygplates-manylinux_2_28_aarch64:412a8051db…
Starting container image ghcr.io/gplates/pygplates-manylinux_2_28_x86_64:412a8051db…
Status: Downloaded newer image for ghcr.io/gplates/pygplates-manylinux_2_28_x86_64:412a8051db…
```

Both legs then compiled the module *inside* the tagged image before the cancel landed (aarch64
reached `[368/369]`), so the image is not merely pullable by that tag. Eleven minutes per leg
instead of two hours; a cancelled job keeps its logs, which is what makes this readable at all.

## Verification

- Local image build, from scratch: green, timings above; the sanity layer's `NEEDED` assertion
  passes.
- Local `cibuildwheel --only cp313-manylinux_x86_64` against that image: green, including the
  full pyGPlates test suite, both new checks, and auditwheel repair. 3 minutes.
- Bare `python:3.13-slim` import + reconstruction: above.
- `ctest --test-dir build-pygplates -C Release`: 4/4 pass (this is where `check_linkage.py`'s
  path mode and the new `--installed` mode were both exercised on Windows/dumpbin).
- `doc-python-api` built from scratch (`-E`, warnings-as-errors): green, 854 index entries. The
  troubleshooting section is scoped to 1.0.x by a note rather than deleted, and keeps its libGL
  half: 1.0.x linked Qt Gui and OpenGL as well as a GLib-enabled Qt Core, so a 1.0.x user on a
  minimal image needs both `libgl1` and `libglib2.0-0` and would otherwise fix one `ImportError`
  only to be met by the other. It is retitled *libGL or glib ImportError on Linux*, which breaks
  no published link: 1.0's docs published `#libgl-importerror-on-linux`, and
  `#glib-importerror-on-linux` has only ever existed on an unreleased branch.
- The macOS and Windows deps scripts rebuilt **cold** in the PR's own run (their cache keys hash
  `versions.sh`, `vcpkg.json` and the scripts) and all three legs passed — windows-x64 1h30m,
  macos-x86_64 1h09m, macos-arm64 29m. Reading those logs rather than the tick: `qwt`, `glew` and
  `qtsvg` appear **zero times** in the whole 137k-line run log; aqt fetched `qtbase` only on all
  three; vcpkg installed gdal, gmp, mpfr, proj, sqlite3, tiff, geotiff, json-c, lzma, jpeg-turbo
  and zlib, with **no glew**.
- The image built in CI on both architectures. On the 4-core runner the qtbase step is 274 s and
  Boost.Python across six Pythons is 367 s — together most of a ~23 minute image build, where Qt
  alone used to be most of 28–39 minutes.
- The aarch64 *wheel* against the new image comes from the dispatched run; the aarch64 image was
  not built locally (a Qt build under QEMU is hours).

## Not in scope

§9 (the conda `meta.yaml`, which still lists `glew` and `qwt`), §11 (`curl --retry`), and a
`smoke` dispatch input to shrink a dispatched wheel matrix. `cmake/modules/FindQwt.cmake` and the
Qwt/GLEW `find_package` calls under `GPLATES_BUILD_GPLATES` stay — GPlates still needs them.

