### PR TITLE
Make the Python console's readline dialog usable

### DIFF
--- a/src/api/AbstractConsole.h
+++ b/src/api/AbstractConsole.h
@@ -73,6 +73,10 @@ namespace GPlatesApi
 		/**
 		 * Prompts the user for a line of input.
 		 *
+		 * The returned line is terminated by a newline. An empty string (with no
+		 * newline) means the user declined to enter a line, and is passed on to
+		 * Python as end-of-file on stdin.
+		 *
 		 * Any implementation of this function must be thread-safe.
 		 */
 		virtual

--- a/src/api/ConsoleReader.cc
+++ b/src/api/ConsoleReader.cc
@@ -30,7 +30,6 @@
 #include "PythonInterpreterUnlocker.h"
 
 #include "api/PythonUtils.h"
-#include "utils/StringUtils.h"
 
 GPlatesApi::ConsoleReader::ConsoleReader(
 		AbstractConsole *console) :
@@ -89,13 +88,23 @@ GPlatesApi::ConsoleReader::readline()
 	result = d_console->read_line();
 
 	// Echo the input out to the console.
-	d_console->append_text(result);
+	//
+	// Note that an empty result means end-of-file (the user cancelled). There is
+	// nothing to echo, but we still terminate the prompt line Python has written.
+	d_console->append_text(result.isEmpty() ? QString("\n") : result);
 	interpreter_unlocker.restore_thread();
 
 	try
 	{
-		object unicode(GPlatesUtils::make_wstring_from_qstring(result));
-		return unicode.attr("encode")("utf-8", "replace"); // FIXME: hard coded codec
+		// Use the registered QString conversion (see PyStrings.cc), which returns a
+		// Python 'str' in both Python 2 (encoded as UTF-8) and Python 3 (Unicode).
+		//
+		// Note that Python 3 must not be given 'bytes' here, because that silently
+		// breaks callers that compare the line against 'str' literals. In particular
+		// the interactive 'help()' utility could then never be exited, since pydoc's
+		// test for "q"/"quit" never matched, and this left its modal readline dialog
+		// reappearing indefinitely.
+		return object(result);
 	}
 	catch (const error_already_set &)
 	{

--- a/src/api/ConsoleReader.cc
+++ b/src/api/ConsoleReader.cc
@@ -108,6 +108,11 @@ GPlatesApi::ConsoleReader::readline()
 	}
 	catch (const error_already_set &)
 	{
+		// Clear the error indicator, otherwise we return a valid object with a Python
+		// exception still set, which CPython later reports as "returned a result with
+		// an error set" at some unrelated call site.
+		PyErr_Clear();
+
 		// This should be a fail-safe conversion.
 		return str(result.toStdString());
 	}

--- a/src/api/PythonRunner.cc
+++ b/src/api/PythonRunner.cc
@@ -209,19 +209,21 @@ GPlatesApi::PythonRunner::exec_file(
 		// Python expects the file to end with a newline.
 		file_contents.append("\n");
 
-		// Encode the filename using the given encoding.
 		PythonInterpreterLocker interpreter_locker;
-		str encoded_filename;
+		str script_filename;
+#if PY_MAJOR_VERSION < 3
+		// Encode the filename using the given encoding, since Python 2 'compile()' wants
+		// the file name as a byte string.
 		try
 		{
-			encoded_filename = str(unicode_filename.attr("encode")(
+			script_filename = str(unicode_filename.attr("encode")(
 					filename_encoding.toUtf8().constData()));
 		}
 		catch (const error_already_set &)
 		{
 			try
 			{
-				encoded_filename = str(unicode_filename.attr("encode")("ascii", "replace"));
+				script_filename = str(unicode_filename.attr("encode")("ascii", "replace"));
 			}
 			catch (const error_already_set &)
 			{
@@ -233,10 +235,16 @@ GPlatesApi::PythonRunner::exec_file(
 				return;
 			}
 		}
+#else
+		// Python 3 'compile()' takes the file name as a Unicode 'str', so pass it through
+		// unencoded. Encoding gives 'bytes', and wrapping that in 'str' would name the
+		// script "b'...'" wherever the file name is shown, such as in a traceback.
+		script_filename = str(unicode_filename);
+#endif
 
 		try
 		{
-			object code = d_compile(file_contents.constData(), encoded_filename, "exec");
+			object code = d_compile(file_contents.constData(), script_filename, "exec");
 			d_console.attr("runcode")(code);
 		}
 		catch (const error_already_set &)

--- a/src/gui/EventBlackout.cc
+++ b/src/gui/EventBlackout.cc
@@ -28,6 +28,7 @@
 #include <QEvent>
 #include <QApplication>
 #include <QDebug>
+#include <QWindow>
 
 #include "EventBlackout.h"
 
@@ -85,6 +86,32 @@ namespace
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns the widget on whose behalf @a obj delivers events, if any.
+	 *
+	 * Input, expose and close events are delivered first to a widget's QWindow, and a
+	 * QWindow is not a child of the widget it belongs to, so the ancestry test in
+	 * @a is_exempt never matches for those events. Map such a window back to its widget
+	 * so that an exempt widget's window - and any dialog parented to that widget - is
+	 * exempt too. Without this a dialog opened while the blackout is in force never
+	 * receives an expose event, and so is never painted or able to be closed.
+	 */
+	QObject *
+	resolve_event_target(
+			QObject *obj)
+	{
+		QWindow *window = qobject_cast<QWindow *>(obj);
+		if (window == NULL ||
+			window->handle() == NULL)  // avoid creating a native window just to look it up
+		{
+			return obj;
+		}
+
+		QWidget *widget = QWidget::find(window->winId());
+
+		return (widget != NULL) ? static_cast<QObject *>(widget) : obj;
 	}
 
 	bool
@@ -157,7 +184,7 @@ GPlatesGui::EventBlackout::eventFilter(
 		QEvent *ev)
 {
 	if (::is_control_c(ev) ||
-		::is_exempt(obj, d_exempt_widgets) ||
+		::is_exempt(::resolve_event_target(obj), d_exempt_widgets) ||
 		::is_permitted_while_monitoring(ev->type()))
 	{
 		return QObject::eventFilter(obj, ev);

--- a/src/qt-widgets/PythonReadlineDialog.cc
+++ b/src/qt-widgets/PythonReadlineDialog.cc
@@ -32,7 +32,10 @@
 
 GPlatesQtWidgets::PythonReadlineDialog::PythonReadlineDialog(
 		QWidget *parent_) :
-	QDialog(parent_, Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint)
+	// Note the window close button: closing the window is a valid response
+	// (it means end-of-file).
+	QDialog(parent_, Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
+			Qt::WindowCloseButtonHint)
 {
 	setupUi(this);
 
@@ -55,14 +58,22 @@ GPlatesQtWidgets::PythonReadlineDialog::get_line(
 		move(d_pos);
 	}
 
-	QString line;
-	if (exec() == QDialog::Accepted)
-	{
-		line = input_lineedit->text();
-	}
+	const bool accepted = (exec() == QDialog::Accepted);
 
 	d_pos = pos();
 
-	return line + "\n";
+	if (!accepted)
+	{
+		// The user cancelled (Cancel button, Escape key or window close button).
+		//
+		// Return an empty string - not even a newline - because that is how Python
+		// signals end-of-file on stdin (the equivalent of typing Ctrl-D in a
+		// terminal). Without it there is no way out of Python code that keeps
+		// reading lines, such as the interactive 'help()' utility, and this dialog
+		// just reappears indefinitely.
+		return QString();
+	}
+
+	return input_lineedit->text() + "\n";
 }
 

--- a/src/qt-widgets/PythonReadlineDialog.h
+++ b/src/qt-widgets/PythonReadlineDialog.h
@@ -46,7 +46,12 @@ namespace GPlatesQtWidgets
 				QWidget *parent_ = NULL);
 
 		/**
-		 * Opens this dialog as modal and returns the string that the user enters.
+		 * Opens this dialog as modal and returns the string that the user enters,
+		 * terminated by a newline.
+		 *
+		 * Returns an empty string (with no newline) if the user cancelled. Python
+		 * interprets that as end-of-file on stdin, which is what lets the user out
+		 * of code that keeps reading lines.
 		 */
 		QString
 		get_line(

--- a/src/qt-widgets/PythonReadlineDialogUi.ui
+++ b/src/qt-widgets/PythonReadlineDialogUi.ui
@@ -40,7 +40,7 @@
    <item>
     <widget class="QDialogButtonBox" name="main_buttonbox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -68,6 +68,22 @@
    <signal>accepted()</signal>
    <receiver>PythonReadlineDialog</receiver>
    <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>233</x>
+     <y>78</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>233</x>
+     <y>83</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>main_buttonbox</sender>
+   <signal>rejected()</signal>
+   <receiver>PythonReadlineDialog</receiver>
+   <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>233</x>


### PR DESCRIPTION
Typing `help()` in the GPlates Python console opened the modal "Python Readline" dialog and
then never let go of it. It was reported against GPlates 2.5 on Windows 11: *"this opened an
enigmatic Python Readline window which cannot be closed (ESC, return, ctrl-d/c all don't work).
So the only way was to kill GPlates using the Task manager."*

Three separate bugs, all of which predate 2.5.

### The dialog received no events at all

`EventBlackout` installs an application-wide event filter while Python runs, discarding
everything except a short list of permitted event types, with an exemption for widgets under
the Python console dialog. Since Qt 5 the events that matter most here — expose, close, key
and mouse — are delivered first to a widget's `QWindow`, and a `QWindow` is not a QObject
child of the widget it belongs to, so the exemption never matched any of them.

The readline dialog is created while the blackout is in force, so it never received an expose
event. It appeared as an empty window: no prompt, no line edit, no buttons, and no response to
any attempt to close it. `QEvent::Paint` is on the permitted list, which is why this looks like
it ought to work; `QEvent::Expose` is not, and that is what gates painting.

Fixed by mapping a `QWindow` back to its widget before testing the exemption. Windows whose
widget is not exempt, such as the main window, are unaffected.

This also repairs the "Running Python code…" cancel button, which is blackout-exempt but lives
inside the console dialog's window, so its clicks were being dropped for the same reason.

### `help()` could not be exited even once the dialog worked

`ConsoleReader::readline()` encoded the entered line to UTF-8 before returning it. In Python 2
that gives a `str`, which is what callers expect, but in Python 3 it gives `bytes`, so pydoc's
test for `"q"`/`"quit"` compared bytes against str and never matched. It now uses the
registered QString conversion (`PyStrings.cc`), which already returns `str` for both Python
versions, so the encoding decision lives in one place.

The dialog also had no way to signal end-of-file — only an OK button, no Cancel, no window
close button, and it always appended a newline — so `readline()` could never return the empty
string that Python reads as EOF, leaving `except EOFError` unreachable in any code that keeps
reading lines. It now has a Cancel button and a close button, and returns an empty string when
rejected.

### Scripts were compiled under the wrong name

`exec_file()` encoded the script's file name and wrapped the result in `boost::python::str`.
Under Python 3 that is `str(bytes)`, i.e. the repr, so every script was compiled as
`b'C:\...'` and appeared that way in tracebacks and `co_filename`. The name is now passed
through unencoded under Python 3; Python 2 keeps its encoding.

## Verification

Both products build clean and pass their suites: `gplates-unit-test` 39/39, pyGPlates ctest
2/2 (Windows, Qt6, Ninja/Release, conda).

The dialog behaviour was checked by driving the built GPlates — F12, `help()`, screenshot:

- Before: blank dialog, close button inert.
- After: `help>` prompt, line edit, OK and Cancel, working close button.
- Close/Alt+F4 → *"You are now leaving help and returning to the Python interpreter."* → `>>>`.
- Typing `quit` → same, which is the end-to-end check on the bytes/str fix.

The cancel button was checked the same way, A/B against a build with only `EventBlackout.cc`
reverted, running `sum(1 for _ in range(10000000000))` and clicking the cancel button:

- Before: six seconds after the click, still running, no interrupt.
- After: `KeyboardInterrupt` raised in the generator expression, back to `>>>`.

Note that `time.sleep()` still cannot be cancelled promptly, and this is not something the
patch can change: cancelling raises an asynchronous exception with
`PyThreadState_SetAsyncExc`, which only takes effect when the target thread next executes a
bytecode, and `sleep()` blocks with the GIL released. Clicking cancel three seconds into
`time.sleep(15)` leaves the console running for the remaining twelve seconds and then reports
`KeyboardInterrupt` — the click is delivered, the interrupt is simply queued.

The script name was checked with a startup script recording `sys._getframe().f_code.co_filename`;
it comes back as the real path rather than `b'...'`, which also confirms `compile()` accepts the
unencoded name.

Note that `help()` behaves differently across the Python versions involved: 2.5 ships Python
3.12, where pydoc exits on a blank line, while this build embeds 3.14, where a blank line
re-prompts and the exit words are `q`/`quit`/`exit`. On 3.14 there was no accidental way out at
all.
