### PR TITLE
Split the Python find_package() call, and require NumPy for pyGPlates

### DIFF
--- a/pygplates/conda/README.md
+++ b/pygplates/conda/README.md
@@ -160,7 +160,8 @@ These are the reasons behind the non-obvious parts of the recipe, each learned f
 Half the platforms conda-forge publishes are cross builds, and on those the build still has to
 *run* "the host Python": `build.sh` invokes `$PYTHON -m pip install`, and `src/CMakeLists.txt` asks
 that same interpreter for the standard library location, for `sys.prefix`, and for the NumPy include
-directory. Failure of the first two is a `FATAL_ERROR`.
+directory. Each of the three is a `FATAL_ERROR` if it fails - the NumPy one only when building
+pyGPlates, which is all this recipe ever does.
 
 It has to be the host interpreter rather than the one `find_package(Python3)` turns up, because the
 paths taken from it decide where the module is installed. Picking up the build environment's Python
@@ -181,6 +182,16 @@ the same version as the host's because one variant pins both.
 Emulation does appear, but in the test phase rather than the build: that activation script skips
 itself when `CONDA_BUILD_STATE` is `TEST`, which is where conda-forge's `native_and_emulated`
 setting takes over.
+
+One CMake detail belongs here rather than in `src/CMakeLists.txt` alone, because these three
+platforms are the only place it shows: the `Interpreter` and `Development` components of Python are
+searched in two *separate* `find_package()` calls. Policy CMP0190 (CMake 4.1) makes asking for both
+in one call a hard error whenever `CMAKE_CROSSCOMPILING` is true and `CMAKE_CROSSCOMPILING_EMULATOR`
+is not set, which is exactly what conda-forge's compiler activation arranges, so the combined call
+fails to *configure* on every cross build. pyGPlates 1.0.0 shipped only because its
+`cmake_minimum_required` range stopped at 3.31, before the policy existed. It is also why NumPy is
+asked for by running the interpreter rather than as a `find_package()` component: on CMake 4.1 that
+component implies both of the others, and the error comes straight back.
 
 ### Qt Core only - no Qt Gui, GLEW, Qwt, OpenGL or X11
 
@@ -214,9 +225,11 @@ releases.
 
 ### NumPy 2 in `host`, and `numpy` in `run`
 
-pyGPlates uses NumPy only for scalar support, and `src/CMakeLists.txt` treats it as optional: if
-`numpy.get_include()` fails, configure prints a warning and builds a module without it. So `numpy`
-must stay in `host`: without it the build does not fail, it quietly ships a smaller API.
+pyGPlates uses NumPy only for scalar support, but `src/CMakeLists.txt` requires it: if
+`numpy.get_include()` fails, or the directory it names holds no `numpy/arrayobject.h`, configure
+stops with a `FATAL_ERROR`. It used to warn and carry on, which was the worse outcome by far - the
+module built, imported and passed its tests, and only rejected a `numpy.float64` argument later, in
+someone else's script. So `numpy` in `host` is load-bearing, and a build that loses it now says so.
 
 The version matters as much as the presence: see `numpy: 2` above. Building against NumPy 2 gives a
 `>=1.2x,<3` run export, so no `pin_compatible` is needed - but `numpy` is still named explicitly in

--- a/pygplates/conda/README.md
+++ b/pygplates/conda/README.md
@@ -184,14 +184,17 @@ itself when `CONDA_BUILD_STATE` is `TEST`, which is where conda-forge's `native_
 setting takes over.
 
 One CMake detail belongs here rather than in `src/CMakeLists.txt` alone, because these three
-platforms are the only place it shows: the `Interpreter` and `Development` components of Python are
-searched in two *separate* `find_package()` calls. Policy CMP0190 (CMake 4.1) makes asking for both
-in one call a hard error whenever `CMAKE_CROSSCOMPILING` is true and `CMAKE_CROSSCOMPILING_EMULATOR`
-is not set, which is exactly what conda-forge's compiler activation arranges, so the combined call
-fails to *configure* on every cross build. pyGPlates 1.0.0 shipped only because its
-`cmake_minimum_required` range stopped at 3.31, before the policy existed. It is also why NumPy is
-asked for by running the interpreter rather than as a `find_package()` component: on CMake 4.1 that
-component implies both of the others, and the error comes straight back.
+platforms are the only place it applies: on them, and only on them, the `Interpreter` and
+`Development` components of Python are searched in two *separate* `find_package()` calls. Policy
+CMP0190 (CMake 4.1) makes asking for both in one call a hard error whenever `CMAKE_CROSSCOMPILING`
+is true and `CMAKE_CROSSCOMPILING_EMULATOR` is not set - which is exactly what conda-forge's
+compiler activation arranges - so a combined call fails to *configure* on every cross build.
+pyGPlates 1.0.0 shipped only because its `cmake_minimum_required` range stopped at 3.31, before the
+policy existed. Every other platform keeps the combined call, because that is what makes CMake look
+the headers and library up *from* the interpreter and so keeps the two consistent - a guarantee a
+cross build cannot have anyway. CMP0190 is also why NumPy is asked for by running the interpreter
+rather than as a `find_package()` component: on CMake 4.1 that component implies both of the others,
+and the error comes straight back.
 
 ### Qt Core only - no Qt Gui, GLEW, Qwt, OpenGL or X11
 
@@ -229,7 +232,13 @@ pyGPlates uses NumPy only for scalar support, but `src/CMakeLists.txt` requires 
 `numpy.get_include()` fails, or the directory it names holds no `numpy/arrayobject.h`, configure
 stops with a `FATAL_ERROR`. It used to warn and carry on, which was the worse outcome by far - the
 module built, imported and passed its tests, and only rejected a `numpy.float64` argument later, in
-someone else's script. So `numpy` in `host` is load-bearing, and a build that loses it now says so.
+someone else's script.
+
+`numpy` therefore stays in `host`: it is the copy a native build compiles against, and the one whose
+run export pins the runtime bound. Be clear about how far the new error reaches, though - on the
+cross builds the probe is answered by the *build* prefix's numpy (see [Cross builds run the host
+interpreter](#cross-builds-run-the-host-interpreter)), so dropping `numpy` from `host` would still
+configure and build there. On those three platforms `host` is about the pin, not the probe.
 
 The version matters as much as the presence: see `numpy: 2` above. Building against NumPy 2 gives a
 `>=1.2x,<3` run export, so no `pin_compatible` is needed - but `numpy` is still named explicitly in

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,9 +77,30 @@ else()  # CMake < 3.18
 	set(GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME Development)
 endif()
 
-# Note that we don't really need to specify the 'Interpreter' component but we do in case it makes 'Development' more robust.
-# We also specify the optional component NumPy to get access to the numpy C-API header include directories.
-find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME} OPTIONAL_COMPONENTS NumPy)
+# The 'Development' component provides the Python headers and library, and the 'Interpreter' component
+# provides Python${_PYTHON_MAJOR_VER}_EXECUTABLE, which we use below (except under conda, which tells us
+# which interpreter to use).
+#
+# Note: The 'Development' and 'Interpreter' components are searched in *separate* find_package() calls.
+#       CMake policy CMP0190 (CMake 4.1) makes it a hard error to request 'Interpreter' (or 'Compiler') together
+#       with any 'Development' component while cross-compiling, unless CMAKE_CROSSCOMPILING_EMULATOR is set
+#       (an interpreter for the target platform generally cannot be run on the build platform):
+#         https://github.com/Kitware/CMake/blob/bda0b36155a63134811c8ec754fba4fa85dfcd65/Modules/FindPython/Support.cmake#L1601
+#       And conda-forge's cross builds ('linux-aarch64', 'linux-ppc64le' and 'osx-arm64') are exactly that
+#       situation: the compiler activation passes '-DCMAKE_SYSTEM_NAME' (so CMAKE_CROSSCOMPILING is TRUE) and sets
+#       no emulator anywhere, while the policy range in the top-level 'cmake_minimum_required(VERSION 3.22...4.4)'
+#       opts us into CMP0190. So a single combined call fails to *configure* there. pyGPlates 1.0.0 escaped this
+#       only because its policy range stopped at 3.31, before CMP0190 existed.
+#
+#       The policy only inspects the components of a single find_package() call, so splitting the call satisfies
+#       it. We search 'Development' first because that is the component describing the *target*: when
+#       cross-compiling its artifacts come from the conda 'host' prefix, whereas the interpreter found by the
+#       second call comes from the 'build' prefix (and is not the interpreter we end up running anyway - see
+#       GPLATES_PYTHON_EXECUTABLE below).
+#
+#       NumPy is deliberately not requested as a component here - see the NumPy section further below for why.
+find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME})
+find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter)
 
 # Get the Python major/minor versions.
 set(GPLATES_PYTHON_VERSION_MAJOR ${Python${_PYTHON_MAJOR_VER}_VERSION_MAJOR})
@@ -104,24 +125,9 @@ if (GPLATES_CONDA_BUILD)
 	#       "Cross builds run the host interpreter"). Dropping that build dependency from the recipe would
 	#       break the execute_process() calls below.
 	#
-	# UPDATE: CMake policy CMP0190 (CMake 4.1) makes this a hard error when cross-compiling, and it is not
-	#         hypothetical - it will break the next conda-forge release unless the find_package() call above
-	#         is changed. FindPython refuses to search for 'Interpreter' together with any 'Development'
-	#         component while CMAKE_CROSSCOMPILING is true, unless CMAKE_CROSSCOMPILING_EMULATOR is set:
-	#           https://github.com/Kitware/CMake/blob/bda0b36155a63134811c8ec754fba4fa85dfcd65/Modules/FindPython/Support.cmake#L1601
-	#         All three conditions hold on conda-forge's cross builds ('linux-aarch64', 'linux-ppc64le' and
-	#         'osx-arm64'): the policy range in the top-level 'cmake_minimum_required(VERSION 3.22...4.4)'
-	#         opts us into CMP0190, conda-forge's compiler activation passes '-DCMAKE_SYSTEM_NAME' and
-	#         '-DCMAKE_SYSTEM_PROCESSOR' (so CMAKE_CROSSCOMPILING is TRUE) and sets no emulator anywhere, and
-	#         conda-forge now ships CMake 4.4. Reproduced with CMake 4.3.4 by configuring this same call with
-	#         '-DCMAKE_SYSTEM_NAME=Linux'. pyGPlates 1.0.0 escaped it only because its policy range stopped at
-	#         3.31, before CMP0190 existed.
-	#
-	#         The fix is to split the call above into two - one for 'Development.Module' and one for
-	#         'Interpreter' - since the policy only inspects the components of a single find_package() call.
-	#         Verified to configure cleanly under the same faked cross-compile, with Python3_EXECUTABLE still
-	#         set. Not done here: it is a change to shared sources that needs both products built (see
-	#         AGENTS.md), so it belongs with the NumPy change below rather than in the conda recipe update.
+	# Note: CMake policy CMP0190 (CMake 4.1) makes it a hard error to search for the 'Interpreter' component together with
+	#       a 'Development' component while cross-compiling, which is why the find_package() calls above are split in
+	#       two. See the comment there.
 	#
 	# When not cross-compiling there's only a 'host' prefix (conda only installs Python into the 'host' prefix, not also the 'build' prefix).
 	# In this situation the PYTHON environment variable should be the same as that found with 'find_package(Python2/3)'.
@@ -205,30 +211,61 @@ if (GPLATES_BUILD_GPLATES)
 	endif()
 endif()
 
-# Find the Python NumPy include directories (and store in GPLATES_PYTHON_NUMPY_INCLUDE_DIRS if found).
-if (GPLATES_CONDA_BUILD)
-	# Get the 'host' prefix Python to import numpy and then print out the numpy include directory.
-	execute_process(COMMAND "${GPLATES_PYTHON_EXECUTABLE}" "-c" "from __future__ import print_function; import numpy as np; print(np.get_include());"
-		RESULT_VARIABLE _NUMPY_RESULT
-		OUTPUT_VARIABLE _NUMPY_OUTPUT
-		ERROR_QUIET
-		OUTPUT_STRIP_TRAILING_WHITESPACE)
-	if (NOT _NUMPY_RESULT)  # success
-		file(TO_CMAKE_PATH ${_NUMPY_OUTPUT} GPLATES_PYTHON_NUMPY_INCLUDE_DIRS)  # Convert '\' to '/' in paths.
-	endif()
-else()
-	# We called find_package(Python2) or find_package(Python3) with optional NumPy component.
-	if (Python${GPLATES_PYTHON_VERSION_MAJOR}_NumPy_FOUND)
-		set(GPLATES_PYTHON_NUMPY_INCLUDE_DIRS ${Python${GPLATES_PYTHON_VERSION_MAJOR}_NumPy_INCLUDE_DIRS})
+# Find the Python NumPy C-API include directories (and store in GPLATES_PYTHON_NUMPY_INCLUDE_DIRS if found).
+#
+# Note: We ask the Python interpreter for its NumPy include directory rather than using the 'NumPy' component of
+#       find_package(Python2/3), for two reasons:
+#       - GPLATES_PYTHON_EXECUTABLE is the interpreter we are actually building against (under conda that is the
+#         'host' prefix Python, whereas the component would report the 'build' prefix when cross-compiling), and
+#       - requesting the 'NumPy' component implicitly adds 'Interpreter' to that find_package() call, and on
+#         CMake 4.1 'Development.Module' along with it, which re-triggers CMP0190 when cross-compiling no matter
+#         how the calls above are split. CMake >= 4.2 drops that second implication (policy CMP0201), but there
+#         is no reason to depend on the CMake version here when the interpreter can just be asked directly.
+execute_process(COMMAND "${GPLATES_PYTHON_EXECUTABLE}" "-c" "from __future__ import print_function; import numpy as np; print(np.get_include());"
+	RESULT_VARIABLE _NUMPY_RESULT
+	OUTPUT_VARIABLE _NUMPY_OUTPUT
+	ERROR_VARIABLE _NUMPY_ERROR
+	OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+if (NOT _NUMPY_RESULT)  # success
+	file(TO_CMAKE_PATH ${_NUMPY_OUTPUT} GPLATES_PYTHON_NUMPY_INCLUDE_DIRS)  # Convert '\' to '/' in paths.
+
+	# Make sure the NumPy C-API header is actually in there.
+	#
+	# Note: 'Config_h.cmake' only defines GPLATES_HAVE_NUMPY_C_API when it finds this header, so an include
+	#       directory without it leaves us just as badly off as not finding NumPy at all.
+	if (NOT EXISTS "${GPLATES_PYTHON_NUMPY_INCLUDE_DIRS}/numpy/arrayobject.h")
+		set(_NUMPY_ERROR "There is no 'numpy/arrayobject.h' in '${GPLATES_PYTHON_NUMPY_INCLUDE_DIRS}'.")
+		unset(GPLATES_PYTHON_NUMPY_INCLUDE_DIRS)
 	endif()
 endif()
-# If NumPy was not found then numpy hasn't been installed into Python.
+
+# NumPy is required when building pyGPlates, but only recommended when building GPlates.
+#
+# Without the NumPy C-API everything still builds, but silently loses the ability to accept NumPy int/float
+# scalars as arguments to Python functions (see GPLATES_HAVE_NUMPY_C_API in the source). For pyGPlates that is a
+# broken package rather than a reduced one: 'pyproject.toml' declares numpy as an unconditional *runtime*
+# dependency, so every pyGPlates user has NumPy and can hand us its scalars. And the failure is invisible until
+# one of them does, which is far too late - hence a fatal error here.
+#
+# GPlates merely embeds Python, where NumPy is genuinely optional, so there it stays a warning (which also keeps
+# a from-source build working in a minimal Python installation).
 if (NOT GPLATES_PYTHON_NUMPY_INCLUDE_DIRS)
-	# Warn that numpy was not found.
-	message(WARNING [[
-	Unable to 'import numpy':
-		You will not be able to pass NumPy int/float scalars as arguments to pyGPlates functions.
-		To enable this functionality please install NumPy and then re-run CMake (to enable use of NumPy C-API).]])
+	set(_NUMPY_FAILURE
+		"Unable to get the NumPy C-API include directory from the Python interpreter:\n"
+		"    ${GPLATES_PYTHON_EXECUTABLE}\n"
+		"${_NUMPY_ERROR}\n")
+	if (GPLATES_BUILD_GPLATES)
+		message(WARNING ${_NUMPY_FAILURE}
+			"You will not be able to pass NumPy int/float scalars as arguments to Python functions. "
+			"To enable this functionality please install NumPy into the above Python installation and then "
+			"re-run CMake (to enable use of the NumPy C-API).")
+	else()
+		message(FATAL_ERROR ${_NUMPY_FAILURE}
+			"NumPy is required when building pyGPlates: it is an unconditional runtime dependency of the "
+			"pyGPlates package (see 'dependencies' in 'pyproject.toml') and its C-API is what lets pyGPlates "
+			"accept NumPy int/float scalars as arguments. Please install NumPy into the above Python "
+			"installation and then re-run CMake.")
+	endif()
 endif()
 
 # Set the Python executable in the parent scope (parent directory).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,26 +81,41 @@ endif()
 # provides Python${_PYTHON_MAJOR_VER}_EXECUTABLE, which we use below (except under conda, which tells us
 # which interpreter to use).
 #
-# Note: The 'Development' and 'Interpreter' components are searched in *separate* find_package() calls.
-#       CMake policy CMP0190 (CMake 4.1) makes it a hard error to request 'Interpreter' (or 'Compiler') together
-#       with any 'Development' component while cross-compiling, unless CMAKE_CROSSCOMPILING_EMULATOR is set
-#       (an interpreter for the target platform generally cannot be run on the build platform):
+# Note: Both components are requested in a *single* find_package() call, because that is what makes
+#       find_package() look up the development artifacts *from the interpreter*, and so keeps the two
+#       consistent. From 'Support.cmake' in CMake's FindPython module: "if python interpreter is found, use
+#       it to look-up for artifacts to ensure consistency between interpreter and development environments".
+#       Ask for them in two calls instead and each search stands alone (every call also resets all the
+#       Python${_PYTHON_MAJOR_VER}_<component>_FOUND flags first), so on a machine with more than one Python
+#       - and especially with a '-DPython${_PYTHON_MAJOR_VER}_EXECUTABLE=...' pointing at one of them, which
+#       the error message further below tells users to pass - you can silently end up with one Python's
+#       headers and library and another Python's version and interpreter. Together in one call that same
+#       mismatch is instead a hard "Could NOT find Python${_PYTHON_MAJOR_VER} (missing: Development.Module)".
+#
+#       Cross-compiling is the one exception, and there the call *must* be split: CMake policy CMP0190
+#       (CMake 4.1) makes requesting 'Interpreter' (or 'Compiler') together with any 'Development' component
+#       a hard error while cross-compiling, unless CMAKE_CROSSCOMPILING_EMULATOR is set:
 #         https://github.com/Kitware/CMake/blob/bda0b36155a63134811c8ec754fba4fa85dfcd65/Modules/FindPython/Support.cmake#L1601
 #       And conda-forge's cross builds ('linux-aarch64', 'linux-ppc64le' and 'osx-arm64') are exactly that
-#       situation: the compiler activation passes '-DCMAKE_SYSTEM_NAME' (so CMAKE_CROSSCOMPILING is TRUE) and sets
-#       no emulator anywhere, while the policy range in the top-level 'cmake_minimum_required(VERSION 3.22...4.4)'
-#       opts us into CMP0190. So a single combined call fails to *configure* there. pyGPlates 1.0.0 escaped this
-#       only because its policy range stopped at 3.31, before CMP0190 existed.
+#       situation: the compiler activation passes '-DCMAKE_SYSTEM_NAME' (so CMAKE_CROSSCOMPILING is TRUE) and
+#       sets no emulator anywhere, while the policy range in the top-level
+#       'cmake_minimum_required(VERSION 3.22...4.4)' opts us into CMP0190. So a combined call fails to
+#       *configure* there. pyGPlates 1.0.0 escaped this only because its policy range stopped at 3.31, before
+#       CMP0190 existed.
 #
-#       The policy only inspects the components of a single find_package() call, so splitting the call satisfies
-#       it. We search 'Development' first because that is the component describing the *target*: when
-#       cross-compiling its artifacts come from the conda 'host' prefix, whereas the interpreter found by the
-#       second call comes from the 'build' prefix (and is not the interpreter we end up running anyway - see
-#       GPLATES_PYTHON_EXECUTABLE below).
+#       Splitting the call gives up nothing on that path, because find_package() declines to use the
+#       interpreter for the artifact lookup in precisely that situation anyway (an interpreter built for the
+#       build platform cannot describe the target). We ask for 'Interpreter' first and 'Development' second
+#       so that it is the *target* artifacts that determine Python${_PYTHON_MAJOR_VER}_VERSION.
 #
-#       NumPy is deliberately not requested as a component here - see the NumPy section further below for why.
-find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME})
-find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter)
+#       NumPy is deliberately not requested as a component in either form - see the NumPy section further
+#       below for why.
+if (CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
+	find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter)
+	find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME})
+else()
+	find_package(Python${_PYTHON_MAJOR_VER} REQUIRED COMPONENTS Interpreter ${GPLATES_PYTHON_DEVELOPMENT_COMPONENT_NAME})
+endif()
 
 # Get the Python major/minor versions.
 set(GPLATES_PYTHON_VERSION_MAJOR ${Python${_PYTHON_MAJOR_VER}_VERSION_MAJOR})
@@ -125,9 +140,8 @@ if (GPLATES_CONDA_BUILD)
 	#       "Cross builds run the host interpreter"). Dropping that build dependency from the recipe would
 	#       break the execute_process() calls below.
 	#
-	# Note: CMake policy CMP0190 (CMake 4.1) makes it a hard error to search for the 'Interpreter' component together with
-	#       a 'Development' component while cross-compiling, which is why the find_package() calls above are split in
-	#       two. See the comment there.
+	# Note: Cross-compiling is also why the find_package() call above is split in two when CMAKE_CROSSCOMPILING is set
+	#       (CMake policy CMP0190). See the comment there.
 	#
 	# When not cross-compiling there's only a 'host' prefix (conda only installs Python into the 'host' prefix, not also the 'build' prefix).
 	# In this situation the PYTHON environment variable should be the same as that found with 'find_package(Python2/3)'.


### PR DESCRIPTION
Two changes to the Python discovery in `src/CMakeLists.txt`, plus the paragraphs of `pygplates/conda/README.md` they make out of date. **The first one blocks the 1.1.0 release**: without it the conda-forge feedstock cannot configure on three of its six platforms.

### CMP0190 - the release blocker

CMake policy CMP0190 (CMake 4.1) makes it a hard error to request the `Interpreter` component together with any `Development` component while cross-compiling, unless `CMAKE_CROSSCOMPILING_EMULATOR` is set. conda-forge's cross builds - `linux-aarch64`, `linux-ppc64le` and `osx-arm64` - are exactly that situation: the compiler activation passes `-DCMAKE_SYSTEM_NAME` and sets no emulator anywhere, while `cmake_minimum_required(VERSION 3.22...4.4)` opts us into the policy. pyGPlates 1.0.0 escaped only because its policy range stopped at 3.31, before CMP0190 existed.

The fix is to search the two components in separate `find_package()` calls - the policy only inspects the components of a single call - **but only when cross-compiling without an emulator**. Everywhere else the combined call stays, because requesting both components together is what makes CMake look the headers and library up *from* the interpreter and so keeps the two consistent. Splitting it unconditionally trades a loud failure for a silent one; measured with CMake 4.3.4, passing `-DPython3_EXECUTABLE=<conda 3.11>` with the 3.14 environment on `CMAKE_PREFIX_PATH`:

| form | `Python3_VERSION` | `Python3_LIBRARIES` | outcome |
|---|---|---|---|
| combined | 3.11.15 | `miniconda3/libs/python311.lib` | `Could NOT find Python3 (missing: Development.Module)` - `REQUIRED` stops configure |
| split | 3.11.15 | `envs/gplates/libs/python314.lib` | silent: `Boost::python311` against 3.14 headers and `python314.lib` |

Nothing is given up on the cross path, because `find_package()` declines to use the interpreter for the artifact lookup in precisely that situation anyway. There `Interpreter` is searched first and `Development` second, so the *target's* artifacts determine `Python3_VERSION`.

The `NumPy` component is dropped in both forms: requesting it implicitly adds `Interpreter` to whichever call carries it, and on CMake 4.1 `Development.Module` too, which re-triggers CMP0190 however the other calls are split. The include directory is now always obtained by asking `GPLATES_PYTHON_EXECUTABLE` - which is what the conda path already did, and is the interpreter we actually build against - so the conda and non-conda branches collapse into one. The probe additionally checks that `numpy/arrayobject.h` is really in the directory it names (that is what `Config_h.cmake` gates `GPLATES_HAVE_NUMPY_C_API` on) and keeps stderr instead of discarding it, so a failure is diagnosable.

### NumPy is now required for pyGPlates

It had only ever warned. `pyproject.toml` declares numpy an unconditional runtime dependency, so a pyGPlates built without the NumPy C-API is broken rather than reduced: it builds, imports, passes its tests, and then rejects a `numpy.float64` argument in someone's script. It is now a `FATAL_ERROR` when `GPLATES_BUILD_GPLATES` is false. GPlates merely embeds Python, where NumPy is genuinely optional, so there it stays a warning - which also keeps a from-source build working in a minimal Python installation.

Note how far that reaches: on the conda cross builds the probe is answered by the *build* prefix's numpy, so it does not police `numpy` in the recipe's `host` section on those three platforms. The README says so.

### Verification

- CMP0190 reproduced with CMake 4.3.4 by configuring the old call under `-DCMAKE_SYSTEM_NAME=Linux`, and the conditional form confirmed to configure cleanly there. Also confirmed that keeping the `NumPy` component re-triggers the error once `CMP0201` is `OLD` - ie, how CMake 4.1 behaves - and that the combined call still fails loudly on a mismatched `-DPython3_EXECUTABLE`.
- Both products configured **from scratch** and built under Qt6 (conda-forge, Ninja/MSVC): `pygplates` and `gplates` + `gplates-unit-test`. Both find `Interpreter Development.Module`/`Development.Embed` in one call and define `GPLATES_HAVE_NUMPY_C_API` as before.
- Both failure paths exercised by breaking the probe: pyGPlates stops with the traceback quoted in the error; GPlates warns and configures on.
- `ctest -C Release`: pyGPlates 4/4, GPlates 63/63.

Qt5 was not built - nothing here is Qt-version-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
