### PR TITLE
Fix the GeoSciML point tests reading freed memory, and the silent (0, 0) behind it

### DIFF
--- a/doc-cpp/design/architecture/dependency-matrix.md
+++ b/doc-cpp/design/architecture/dependency-matrix.md
@@ -13,7 +13,7 @@ in the *column* directory, over every `.h`/`.cc` in the built `src/` subdirector
 | includes -> | (src root) | api | app-logic | canvas-tools | cli | data-mining | feature-visitors | file-io | global | gui | maths | model | opengl | presentation | property-values | qt-widgets | scribe | unit-test | utils | view-operations |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | (src root) |  | 2 | 2 |  | 1 | 1 |  | 1 | 3 | 4 | 3 | 1 | 1 | 2 | 1 | 2 | 6 | 1 | 3 |  |
-| api |  | 275 | 124 |  |  | 8 | 4 | 35 | 156 | 14 | 86 | 75 | 2 | 3 | 112 | 5 | 29 |  | 47 |  |
+| api |  | 275 | 124 |  |  | 8 | 4 | 35 | 156 | 14 | 86 | 75 | 2 | 3 | 112 | 5 | 29 |  | 46 |  |
 | app-logic |  |  | 918 |  |  | 7 | 14 | 20 | 159 |  | 249 | 241 | 12 |  | 263 |  | 25 |  | 123 |  |
 | canvas-tools |  |  | 12 | 42 |  |  | 2 |  | 3 | 37 | 27 | 12 |  | 7 | 2 | 38 |  |  | 8 | 68 |
 | cli |  |  | 17 |  | 42 |  |  | 29 | 6 |  | 5 | 24 |  |  |  |  |  |  |  |  |

--- a/src/app-logic/FeatureCollectionFileIO.cc
+++ b/src/app-logic/FeatureCollectionFileIO.cc
@@ -23,6 +23,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <QDebug>
 #include <QtGlobal>
 
 #include "FeatureCollectionFileIO.h"
@@ -247,9 +248,14 @@ GPlatesAppLogic::FeatureCollectionFileIO::load_xml_data(
 	using namespace GPlatesFileIO;
 	ReadErrorAccumulation read_errors;
 
-	//create temp file
+	// The features come from 'data'; the file is created only so that the loaded feature
+	// collection has a real path to be named by, and is never read back. So failing to
+	// create it costs the collection its name, not its contents.
 	QFile tmp_file(filename);
-	tmp_file.open(QIODevice::ReadWrite | QIODevice::Text);
+	if (!tmp_file.open(QIODevice::ReadWrite | QIODevice::Text))
+	{
+		qWarning() << "Could not create" << filename << ":" << tmp_file.errorString();
+	}
 	tmp_file.close();
 
 	const FileInfo file_info(filename);

--- a/src/file-io/GeoscimlProfile.cc
+++ b/src/file-io/GeoscimlProfile.cc
@@ -47,8 +47,7 @@ GPlatesFileIO::GeoscimlProfile::populate(
 {
 	QString filename = file_ref.get_file_info().get_display_name(true);
 	QFile source(filename);
-	source.open(QFile::ReadOnly | QFile::Text);
-	if(!source.isOpen())
+	if(!source.open(QFile::ReadOnly | QFile::Text))
 	{
 		qWarning() << QString("Cannot open xml file: %1.").arg(filename);
 		return;

--- a/src/file-io/GpmlStructuralTypeReaderUtils.cc
+++ b/src/file-io/GpmlStructuralTypeReaderUtils.cc
@@ -1247,7 +1247,6 @@ GPlatesFileIO::GpmlStructuralTypeReaderUtils::create_lon_lat_pos(
 	// NOTE: We are assuming GPML is using (lat,lon) ordering.
 	// See http://trac.gplates.org/wiki/CoordinateReferenceSystem for details.
 	const double lat = pos_2d.first;
-	// FIXME: Check is.status() here!
 	const double lon = pos_2d.second;
 
 	if ( ! (GPlatesMaths::LatLonPoint::is_valid_latitude(lat) &&
@@ -1278,6 +1277,16 @@ GPlatesFileIO::GpmlStructuralTypeReaderUtils::create_pos_2d(
 
 	is >> x;
 	is >> y;
+
+	// A failed extraction leaves its target untouched, so without this check a gml:pos that
+	// is not two numbers becomes the point (0, 0) - a plausible wrong answer rather than an
+	// error.
+	if (is.status() != QTextStream::Ok)
+	{
+		throw GpmlReaderException(GPLATES_EXCEPTION_SOURCE,
+				elem, GPlatesFileIO::ReadErrors::InvalidDouble,
+				EXCEPTION_SOURCE);
+	}
 
 	return std::make_pair(x, y);
 }

--- a/src/file-io/GpmlStructuralTypeReaderUtils.cc
+++ b/src/file-io/GpmlStructuralTypeReaderUtils.cc
@@ -1321,7 +1321,6 @@ GPlatesFileIO::GpmlStructuralTypeReaderUtils::create_lon_lat_coordinates(
 	// NOTE: We are assuming GPML is using (lat,lon) ordering.
 	// See http://trac.gplates.org/wiki/CoordinateReferenceSystem for details.
 	const double lat = coordinates_2d.first;
-	// FIXME: Check is.status() here!
 	const double lon = coordinates_2d.second;
 
 	if ( ! (GPlatesMaths::LatLonPoint::is_valid_latitude(lat) &&
@@ -1345,23 +1344,32 @@ GPlatesFileIO::GpmlStructuralTypeReaderUtils::create_coordinates_2d(
 
 	// XXX: Currently assuming srsDimension is 2!!
 
-	QStringList tokens = str.split(",");
+	const QStringList tokens = str.split(",");
+
+	// Falling through with the coordinates untouched, as this used to, turns a gml:coordinates
+	// that is not two numbers into the point (0, 0) - a plausible wrong answer rather than an
+	// error. (This is the gml:pos check in 'create_pos_2d()', for the other spelling.)
+	if (tokens.count() != 2)
+	{
+		throw GpmlReaderException(GPLATES_EXCEPTION_SOURCE,
+				elem, GPlatesFileIO::ReadErrors::InvalidDouble,
+				EXCEPTION_SOURCE);
+	}
 
 	double x = 0.0;
 	double y = 0.0;
 
-	if (tokens.count() == 2)
+	try
 	{
-		try
-		{
-			GPlatesUtils::Parse<double> parse;
-			x = parse(tokens.at(0));
-			y = parse(tokens.at(1));
-		}
-		catch (...)
-		{
-			// Do nothing, fall through.
-		}
+		GPlatesUtils::Parse<double> parse;
+		x = parse(tokens.at(0));
+		y = parse(tokens.at(1));
+	}
+	catch (const GPlatesUtils::ParseError &)
+	{
+		throw GpmlReaderException(GPLATES_EXCEPTION_SOURCE,
+				elem, GPlatesFileIO::ReadErrors::InvalidDouble,
+				EXCEPTION_SOURCE);
 	}
 
 	return std::make_pair(x, y);

--- a/src/qt-widgets/ConnectWFSDialog.cc
+++ b/src/qt-widgets/ConnectWFSDialog.cc
@@ -375,12 +375,34 @@ GPlatesQtWidgets::ConnectWFSDialog::httpFinished()
 				tr("Redirect to %1 ?").arg(newUrl.toString()),
 				QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) 
 		{
-             d_url = newUrl;
-             d_reply->deleteLater();
-             d_xml_file->open(QIODevice::WriteOnly);
-             d_xml_file->resize(0);
-             startRequest(d_url);
-             return;
+			d_url = newUrl;
+			d_reply->deleteLater();
+			// Reopened to receive the redirected download. If it cannot be, there is
+			// nowhere to put the response - every write in 'httpReadyRead()' would fail
+			// silently, with the progress dialog already hidden - so abandon the transfer
+			// instead of issuing the request. This is the cleanup below the if/else chain,
+			// which returning here skips, less the 'deleteLater()' just done.
+			if (!d_xml_file->open(QIODevice::WriteOnly))
+			{
+				QMessageBox::information(
+					this, tr("HTTP"),
+					tr("Could not reopen the download file: %1.")
+							.arg(d_xml_file->errorString()));
+				d_reply = 0;
+				d_xml_file->remove();
+				delete d_xml_file;
+				d_xml_file = 0;
+				d_xml_data.clear();
+				return;
+			}
+			// The bytes received before the redirect are dropped from the file; drop them
+			// from the buffer too, or 'process_xml()' sees them in front of the payload
+			// that follows and neither the "<?xml" check nor the feature count means
+			// anything.
+			d_xml_file->resize(0);
+			d_xml_data.clear();
+			startRequest(d_url);
+			return;
 		}
 	} 
 	else 
@@ -449,6 +471,9 @@ GPlatesQtWidgets::ConnectWFSDialog::process_xml()
 	{
 		QErrorMessage *e = new QErrorMessage( this );
 		e->showMessage("Error with query or returned XML; Please Cancel;");
+		// Discard it, as the path below does on the way out: left in the buffer it would
+		// sit in front of the next query's response.
+		d_xml_data.clear();
 		return;
 	}
 	

--- a/src/qt-widgets/KinematicGraphsDialog.cc
+++ b/src/qt-widgets/KinematicGraphsDialog.cc
@@ -542,21 +542,27 @@ GPlatesQtWidgets::KinematicGraphsDialog::handle_use_feature()
 
 		std::vector<double> times = property_finder.get_times();
 
-		// Motion path times are stored in increasing order, i.e. youngest (end-time) to oldest (begin-time)
-		d_begin_time = times.back();
-		d_end_time = times.front();
-		int steps = static_cast<int>(times.size());
-
-		// If we're not able to get a sensible time step for some reason, d_step_time
-		// will not be updated.
-		if (steps > 1)
+		// A motion path carrying no times has no range to take, and 'front()' and 'back()'
+		// on an empty vector are undefined - which is what GCC's -Warray-bounds sees. Leave
+		// the dialog's own range in that case.
+		if (!times.empty())
 		{
-			d_step_time = (d_begin_time - d_end_time)/(steps-1);
-		}
+			// Motion path times are stored in increasing order, i.e. youngest (end-time) to oldest (begin-time)
+			d_begin_time = times.back();
+			d_end_time = times.front();
+			int steps = static_cast<int>(times.size());
 
-		spinbox_begin_time->setValue(d_begin_time);
-		spinbox_end_time->setValue(d_end_time);
-		spinbox_dt->setValue(d_step_time);
+			// If we're not able to get a sensible time step for some reason, d_step_time
+			// will not be updated.
+			if (steps > 1)
+			{
+				d_step_time = (d_begin_time - d_end_time)/(steps-1);
+			}
+
+			spinbox_begin_time->setValue(d_begin_time);
+			spinbox_end_time->setValue(d_end_time);
+			spinbox_dt->setValue(d_step_time);
+		}
 	}
 
 	// And we might as well do the whole calculation thing here as well.

--- a/src/unit-test/GeoscimlReaderTest.cc
+++ b/src/unit-test/GeoscimlReaderTest.cc
@@ -330,6 +330,30 @@ TEST_F(GeoscimlReaderTest, malformed_point_is_not_read_as_the_origin)
 }
 
 
+TEST_F(GeoscimlReaderTest, point_by_coordinates_and_the_malformed_case)
+{
+	// gml:coordinates is the other spelling of a gml:Point's position, and it read the same
+	// way: coordinates that are not two numbers used to become (0, 0) rather than an error.
+	const feature_seq_type features = read("point_coordinates.gsml");
+	ASSERT_EQ(2u, features.size());
+
+	// Read as GPML's latitude longitude, like a gml:pos.
+	EXPECT_EQ("Point by coordinates", name(features[0]));
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(features[0]);
+	const GPlatesMaths::PointGeometryOnSphere *point =
+			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(geometry.get());
+	ASSERT_TRUE(point);
+	expect_lat_lon(45, -30, point->position());
+
+	// The member with one coordinate where two were needed is abandoned part-built, carrying
+	// no geometry.
+	GPlatesFeatureVisitors::GeometryFinder finder;
+	finder.visit_feature(features[1]);
+	EXPECT_EQ(0, std::distance(finder.found_geometries_begin(), finder.found_geometries_end()));
+}
+
+
 TEST_F(GeoscimlReaderTest, feature_without_a_feature_member_wrapper)
 {
 	const feature_seq_type features = read("unwrapped_feature.gsml");

--- a/src/unit-test/GeoscimlReaderTest.cc
+++ b/src/unit-test/GeoscimlReaderTest.cc
@@ -142,6 +142,14 @@ namespace
 		return string_property(feature, GPlatesModel::PropertyName::create_gml("name"));
 	}
 
+	/**
+	 * The feature's one geometry.
+	 *
+	 * The caller must keep the returned pointer alive for as long as it uses the geometry:
+	 * a gml:Point is stored as a coordinate pair and synthesises its PointGeometryOnSphere
+	 * on demand, so - unlike a gml:LineString or a gml:Polygon - the feature itself holds
+	 * no reference to it.
+	 */
 	GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type
 	only_geometry(
 			const GPlatesModel::FeatureHandle::weak_ref &feature)
@@ -198,8 +206,10 @@ TEST_F(GeoscimlReaderTest, line_string_swaps_pos_list_to_lat_lon)
 			string_property(line, GPlatesModel::PropertyName::create_gml("description")));
 
 	// gml:posList is longitude latitude; GPlates stores latitude longitude.
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type line_geometry =
+			only_geometry(line);
 	const GPlatesMaths::PolylineOnSphere *polyline =
-			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(only_geometry(line).get());
+			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(line_geometry.get());
 	ASSERT_TRUE(polyline);
 	ASSERT_EQ(3u, polyline->number_of_vertices());
 	expect_lat_lon(20, 10, *polyline->vertex_begin());
@@ -220,9 +230,10 @@ TEST_F(GeoscimlReaderTest, point_is_read_in_gpml_order)
 	ASSERT_LE(2u, features.size());
 
 	// Unlike a gml:posList, a gml:pos is not swapped: it is read as GPML's latitude longitude.
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(features[1]);
 	const GPlatesMaths::PointGeometryOnSphere *point =
-			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(
-					only_geometry(features[1]).get());
+			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(geometry.get());
 	ASSERT_TRUE(point);
 	expect_lat_lon(45, -30, point->position());
 }
@@ -234,9 +245,10 @@ TEST_F(GeoscimlReaderTest, polygon_and_repeated_properties)
 	ASSERT_LE(3u, features.size());
 	const GPlatesModel::FeatureHandle::weak_ref &polygon_feature = features[2];
 
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type polygon_geometry =
+			only_geometry(polygon_feature);
 	const GPlatesMaths::PolygonOnSphere *polygon =
-			dynamic_cast<const GPlatesMaths::PolygonOnSphere *>(
-					only_geometry(polygon_feature).get());
+			dynamic_cast<const GPlatesMaths::PolygonOnSphere *>(polygon_geometry.get());
 	ASSERT_TRUE(polygon);
 	EXPECT_EQ(4, std::distance(
 			polygon->exterior_ring_vertex_begin(), polygon->exterior_ring_vertex_end()));
@@ -265,9 +277,10 @@ TEST_F(GeoscimlReaderTest, macrostrat_properties)
 	EXPECT_EQ(3.0, double_property(rock_unit, gpml_property("rock_min_thick")).get_value_or(-1));
 
 	EXPECT_EQ(7.0, double_property(fossils, gpml_property("fossil_diversity")).get_value_or(-1));
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(fossils);
 	const GPlatesMaths::PointGeometryOnSphere *point =
-			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(
-					only_geometry(fossils).get());
+			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(geometry.get());
 	ASSERT_TRUE(point);
 	expect_lat_lon(-33, 151, point->position());
 }
@@ -281,8 +294,10 @@ TEST_F(GeoscimlReaderTest, three_dimensional_pos_list_in_another_srs)
 	// srsDimension="3" is read off the bare gml:posList start tag, so the coordinates are
 	// consumed in triples and the height dropped. (The SRS itself is not transformed - that
 	// code has been disabled since GDAL 3 - so the values pass through, and are swapped.)
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(features[5]);
 	const GPlatesMaths::PolylineOnSphere *polyline =
-			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(only_geometry(features[5]).get());
+			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(geometry.get());
 	ASSERT_TRUE(polyline);
 	ASSERT_EQ(3u, polyline->number_of_vertices());
 	expect_lat_lon(20, 10, *polyline->vertex_begin());
@@ -297,8 +312,10 @@ TEST_F(GeoscimlReaderTest, feature_without_a_feature_member_wrapper)
 	ASSERT_EQ(1u, features.size());
 	EXPECT_EQ("Unwrapped feature", name(features[0]));
 
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(features[0]);
 	const GPlatesMaths::PolylineOnSphere *polyline =
-			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(only_geometry(features[0]).get());
+			dynamic_cast<const GPlatesMaths::PolylineOnSphere *>(geometry.get());
 	ASSERT_TRUE(polyline);
 	EXPECT_EQ(2u, polyline->number_of_vertices());
 	expect_lat_lon(-10, 100, *polyline->vertex_begin());

--- a/src/unit-test/GeoscimlReaderTest.cc
+++ b/src/unit-test/GeoscimlReaderTest.cc
@@ -305,6 +305,31 @@ TEST_F(GeoscimlReaderTest, three_dimensional_pos_list_in_another_srs)
 }
 
 
+TEST_F(GeoscimlReaderTest, malformed_point_is_not_read_as_the_origin)
+{
+	// A gml:pos that does not begin with two numbers used to be extracted as (0, 0) - a point
+	// in the Gulf of Guinea, indistinguishable from a real one. It is now a read error, which
+	// the GeoSciML reader reports by skipping the member it came from.
+	const feature_seq_type features = read("malformed_point.gsml");
+
+	// The member is abandoned part-built rather than removed, so it still counts - but it
+	// carries no geometry, which is the point.
+	ASSERT_EQ(2u, features.size());
+	GPlatesFeatureVisitors::GeometryFinder finder;
+	finder.visit_feature(features[0]);
+	EXPECT_EQ(0, std::distance(finder.found_geometries_begin(), finder.found_geometries_end()));
+
+	// The member after it still reads.
+	EXPECT_EQ("Good point", name(features[1]));
+	const GPlatesMaths::GeometryOnSphere::non_null_ptr_to_const_type geometry =
+			only_geometry(features[1]);
+	const GPlatesMaths::PointGeometryOnSphere *point =
+			dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(geometry.get());
+	ASSERT_TRUE(point);
+	expect_lat_lon(-33, 151, point->position());
+}
+
+
 TEST_F(GeoscimlReaderTest, feature_without_a_feature_member_wrapper)
 {
 	const feature_seq_type features = read("unwrapped_feature.gsml");

--- a/src/unit-test/data/gsml/malformed_point.gsml
+++ b/src/unit-test/data/gsml/malformed_point.gsml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A gml:pos that is not two numbers, followed by a member that reads cleanly. The bad
+  coordinates used to be extracted as the point (0, 0); they are now a read error, and the
+  member carrying them is skipped without costing the file the members after it.
+  Used by GeoscimlReaderTest.cc.
+-->
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0">
+  <gml:featureMember>
+    <gsml:UnclassifiedFeature gml:id="malformed-point">
+      <gml:name>Malformed point</gml:name>
+      <gsml:shape>
+        <gml:Point srsName="EPSG:4326">
+          <gml:pos>somewhere in particular</gml:pos>
+        </gml:Point>
+      </gsml:shape>
+    </gsml:UnclassifiedFeature>
+  </gml:featureMember>
+  <gml:featureMember>
+    <gsml:UnclassifiedFeature gml:id="good-point">
+      <gml:name>Good point</gml:name>
+      <gsml:shape>
+        <gml:Point srsName="EPSG:4326">
+          <gml:pos>-33 151</gml:pos>
+        </gml:Point>
+      </gsml:shape>
+    </gsml:UnclassifiedFeature>
+  </gml:featureMember>
+</wfs:FeatureCollection>

--- a/src/unit-test/data/gsml/point_coordinates.gsml
+++ b/src/unit-test/data/gsml/point_coordinates.gsml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  gml:coordinates, the other spelling of a gml:Point's position: one member that reads, and
+  one whose coordinates are not two numbers. The bad one used to be extracted as the point
+  (0, 0); it is now a read error, and the member carrying it is skipped.
+  Used by GeoscimlReaderTest.cc.
+-->
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0">
+  <gml:featureMember>
+    <gsml:UnclassifiedFeature gml:id="coordinates">
+      <gml:name>Point by coordinates</gml:name>
+      <gsml:shape>
+        <gml:Point srsName="EPSG:4326">
+          <gml:coordinates>45,-30</gml:coordinates>
+        </gml:Point>
+      </gsml:shape>
+    </gsml:UnclassifiedFeature>
+  </gml:featureMember>
+  <gml:featureMember>
+    <gsml:UnclassifiedFeature gml:id="malformed-coordinates">
+      <gml:name>Malformed coordinates</gml:name>
+      <gsml:shape>
+        <gml:Point srsName="EPSG:4326">
+          <gml:coordinates>45</gml:coordinates>
+        </gml:Point>
+      </gsml:shape>
+    </gsml:UnclassifiedFeature>
+  </gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
`GeoscimlReaderTest.point_is_read_in_gpml_order` and `GeoscimlReaderTest.macrostrat_properties`
failed on macOS CI at 86cebd62f (run 34529722913) while Linux and Windows passed: every
`gml:pos` point came back as exactly (0, 0).

### The failure

Not the reader. The `gml:pos` string reaching `create_pos_2d()` is `"45 -30"` on macOS too; the
geometry is parsed correctly and the corruption happens afterwards, in the test:

```cpp
const GPlatesMaths::PointGeometryOnSphere *point =
        dynamic_cast<const GPlatesMaths::PointGeometryOnSphere *>(
                only_geometry(features[1]).get());   // temporary released here
expect_lat_lon(45, -30, point->position());          // reads freed memory
```

`only_geometry()` returns a `non_null_ptr_to_const_type` by value and every test kept only the
raw pointer from `.get()`. Whether that pointer stayed valid depended on who else owned the
object: a `gml:LineString` and a `gml:Polygon` are stored as geometries on their property value,
so the feature held one alive, but a `gml:Point` is stored as a coordinate pair and
`PointOnSphere::get_geometry_on_sphere()` builds a fresh `PointGeometryOnSphere` on each call,
owned by nothing but the temporary. So only the two point tests read freed memory, and they
passed wherever the allocator happened to leave the bytes intact. On the macOS runner the freed
position vector read back as zeros, which `make_lat_lon_point()` turned into (0, 0).

`MallocScribble=1` reproduces it on any machine, with a wilder value:

```
MallocScribble=1 ./build-gplates/bin/gplates-unit-test --gtest_filter='GeoscimlReaderTest.*'
```

### What is in here

1. **Keep the geometry alive while the GeoSciML tests read it** - the fix. Each test binds the
   returned pointer to a local, and `only_geometry()` says why the caller has to.
2. **Make a `gml:pos` that is not two numbers a read error** - what turned a parse failure into a
   plausible wrong answer in the first place. `create_pos_2d()` never checked `is.status()`, as
   the FIXME in `create_lon_lat_pos()` noted, so bad coordinates became a point in the Gulf of
   Guinea that passes the lat/lon range check below it.
3. **Make a `gml:coordinates` that is not two numbers a read error too** - the same defect in
   `create_coordinates_2d()`, whose entire error handling was a `catch (...)` saying "Do nothing,
   fall through". Nothing covered `gml:coordinates` at all, so the test reads a good one too.
4. **Regenerate the stale dependency matrix** - `pygplates-source-closure-test` has been failing
   on `gplates` since the sync merge: one cell, api -> utils, reads 47 where the tree computes 46.
   cc0f096b0 on `pygplates` dropped an include from `src/api/ConsoleReader.cc` without
   regenerating the doc. Nothing on `gplates` could have caught it - the closure test is a
   pyGPlates CTest and this workflow only builds GPlates - so it would have surfaced at the next
   sync merge into `pygplates`, looking like the merge's fault.

### Behaviour change worth noting

2 and 3 change what happens to real files. A GPML file with a malformed `gml:pos` or
`gml:coordinates` that used to load silently with a point at the origin now reports a read error
and drops that property; in a GeoSciML file it reaches `GeoscimlProfile`'s per-member `catch`,
which skips that feature member and carries on. An error beats a wrong point, but it is a change.

Only the two extractions are checked, so a three-dimensional `gml:pos` still reads its first two
values and ignores the third, as before.

### Verification

Both products built locally (shared `file-io` source), Qt6:

- GPlates: 65/65 ctest pass, and the whole suite passes again under
  `MallocScribble=1 MallocPreScribble=1 MallocGuardEdges=1`.
- pyGPlates: 4/4 pass, including `pygplates-source-closure-test`, which was the pre-existing
  failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
