### PR TITLE
Leave gitflow: one development branch and permanent release series branches

### DIFF
--- a/.claude/skills/release-wheel/SKILL.md
+++ b/.claude/skills/release-wheel/SKILL.md
@@ -47,6 +47,17 @@ committing, tagging, or pushing. Do not push a tag without explicit approval.
    deployment (repository page → the run → "Review deployments"). This is the moment to eyeball
    the TestPyPI project page. Approval waits expire after 30 days.
 5. **Publish.** On approval the whole matrix uploads to PyPI with PEP 740 attestations.
+6. **Move the targets on.** A tag changes what the next version on each branch is called, and
+   the resolver refuses to configure until `VersionRelease.cmake` says so:
+   - on the series branch, after the *release*, set the target to the next patch (`1.1.1` after
+     `1.1.0`) so later fixes there configure. After a candidate, nothing: the next commit on the
+     branch prepares the next candidate or the release, and nothing else is accepted there until
+     the release is final.
+   - on `gplates`, if this was the *first* tag in the series (the first candidate, or the
+     release when there was none), set the target to the next minor (`1.2.0`). The development
+     branch's count restarts at that moment, so left on `1.1.0` it would re-issue versions it
+     has already used. Later tags in the series need nothing on `gplates`.
+   Commit each on its own branch. The rules are in `doc-cpp/design/versioning/README.md` (7.2).
 
 ## Recovery
 

--- a/.claude/skills/release-wheel/SKILL.md
+++ b/.claude/skills/release-wheel/SKILL.md
@@ -19,11 +19,11 @@ committing, tagging, or pushing. Do not push a tag without explicit approval.
 
 - Confirm the working tree is clean and up to date with the GitHub remote. Name that remote
   explicitly rather than assuming `origin` — not every checkout has one.
-- Know which branch the release is being cut on. A release is prepared on a
-  `release/pygplates-<version>` branch taken from `pygplates`, merged into `release-pygplates`,
-  and tagged **there** — release tags belong on the main release branches, and nowhere else
-  (the root `README.md` has the branching model). A release *candidate* is tagged on the
-  `release/pygplates-<version>` branch itself, since it is not a release.
+- Know which branch the release is being cut on. A release is prepared on the permanent release
+  series branch `release/pygplates-<major>.<minor>`, cut from `gplates` when the first release in
+  that series is prepared, and tagged **there** — release tags belong on the series branches and
+  nowhere else (the root `README.md` has the branching model). Candidates and later patch
+  releases are tagged on the same branch, each a further commit on it.
 - If this is a first pass at a release, suggest an `rc` version (e.g. `1.1.0rc1`). pip ignores
   release candidates by default, so it exercises the whole pipeline — tag check, TestPyPI
   rehearsal, approval gate, real PyPI upload — at low stakes.
@@ -34,9 +34,9 @@ committing, tagging, or pushing. Do not push a tag without explicit approval.
    `cmake/modules/VersionRelease.cmake` to the target version, and commit. Development versions
    are counted from git and cannot be released — the run rejects a `.dev` version. Check what
    the commit resolves to with `cmake -P cmake/modules/VersionFromGit.cmake pygplates`.
-2. **Tag exactly `PyGPlates-<version>`, on the release commit.** For a release that is the
-   merge commit on `release-pygplates`; for a release candidate it is the commit on the
-   `release/pygplates-<version>` branch. The tag's version string must match
+2. **Tag exactly `PyGPlates-<version>`, on the release commit.** That is the commit on the
+   `release/pygplates-<major>.<minor>` branch that sets the target, whether it is a candidate, the
+   release itself or a later patch. The tag's version string must match
    `PYGPLATES_RELEASE_VERSION` character for character; the run fails in its first minute if they
    disagree, and so does any local build standing on the tag. Push the tag to the GitHub remote.
    Ask which remote if there is more than one.

--- a/.github/workflows/build-test-pygplates.yml
+++ b/.github/workflows/build-test-pygplates.yml
@@ -16,7 +16,7 @@ name: pygplates build and test
 
 on:
   push:
-    branches: [ "pygplates" ]
+    branches: [ "gplates" ]
     paths-ignore:
       # Documentation and repository metadata cannot affect the build or the tests.
       # Note '.gitattributes' is deliberately NOT listed: it controls line endings, and
@@ -28,7 +28,7 @@ on:
       - 'CREDITS'
       - 'CHANGELOG'
   pull_request:
-    branches: [ "pygplates" ]
+    branches: [ "gplates" ]
     paths-ignore:
       # Documentation and repository metadata cannot affect the build or the tests.
       # Note '.gitattributes' is deliberately NOT listed: it controls line endings, and
@@ -113,7 +113,7 @@ jobs:
         # 'restore-keys' is what makes this useful: the primary key includes the commit SHA and so
         # never hits, and the prefix fallback restores the most recent cache for this platform.
         # A pull request can read caches written on its base branch, so PRs start warm from the
-        # last push to 'pygplates'.
+        # last push to 'gplates'.
         #
         # The keys are namespaced 'sccache-pygplates-*', and the GPlates workflow's
         # 'sccache-gplates-*': the two builds share no cache entries at all (every shared
@@ -177,7 +177,7 @@ jobs:
         # branch and every other pull request cannot see it. Later runs of that same pull request can,
         # but they gain little, because the base-branch cache already covers everything the pull
         # request did not change - a re-run only recompiles the PR's own modified files either way.
-        # Pushes to 'pygplates' warm the cache; pull requests restore from it.
+        # Pushes to 'gplates' warm the cache; pull requests restore from it.
         # 'always()' rather than 'success()', so that a failed build still saves the objects it
         # did compile - and so does one that hits 'timeout-minutes', which the runner delivers as
         # a cancellation. The restore-outcome guard is what a bare 'always()' would be missing:

--- a/.github/workflows/build-wheel-images.yml
+++ b/.github/workflows/build-wheel-images.yml
@@ -30,7 +30,7 @@ name: pygplates wheel images
 
 on:
   push:
-    branches: [ "pygplates" ]
+    branches: [ "gplates" ]
     paths:
       - pygplates/wheel/manylinux_2_28.dockerfile
       - pygplates/wheel/versions.sh

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -30,7 +30,7 @@ on:
     # sdist job rejects one anyway, but not before the matrix has been queued.
     tags: [ "PyGPlates-*", "!PyGPlates-*.dev*" ]
   pull_request:
-    branches: [ "pygplates" ]
+    branches: [ "gplates" ]
     paths:
       - pygplates/wheel/**
       - pyproject.toml

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -182,8 +182,8 @@ jobs:
           # reachable too, and whoever adds one has no reason to know this file exists.
           #
           # Grouping by ref as well as prefix is not optional: caches are ref-scoped, and dropping
-          # the newest 'refs/heads/pygplates' entry because a newer 'refs/heads/gplates' one
-          # happened to share its prefix would cost that branch a cold build.
+          # the newest 'refs/pull/<n>/merge' entry because a newer 'refs/heads/gplates' one
+          # happened to share its prefix would cost that pull request a cold build.
           #
           # Keeping exactly one per group is not a heuristic - it is the reachable set. It also
           # needs no special case for a partial cache saved by a failed build: that partial is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,10 @@ and argued for in `doc-cpp/design/versioning/README.md`.
   `hotfix/` concept and no permanent 'production' branch.
 - **short-lived** branches: `feature/<name>` and `fix/<name>` off `gplates` (a fix rather than a
   feature, but otherwise identical), and patch branches off a release series branch.
+- **fixes move between `gplates` and a series branch by `git cherry-pick -x`**, in either
+  direction — never by merging a series branch into `gplates`. Such a merge conflicts on
+  `VersionRelease.cmake` every time (each side has moved its release target), and when it does
+  not conflict it silently hands `gplates` the series branch's target.
 
 **Base pull requests on `gplates`, never on a release series branch.** CI enforces this: both
 `build-test-gplates.yml` and `build-test-pygplates.yml` run only on `gplates`. Building **both**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,8 +224,8 @@ Where this guidance and a specific file disagree, match the file you are editing
 
 ## Branches and pull requests
 
-This is **not** gitflow — it is the trunk-plus-release-series model, described in `README.md` and
-argued for in `doc-cpp/design/versioning/README.md`.
+This is **no longer** gitflow — it is the trunk-plus-release-series model, described in `README.md`
+and argued for in `doc-cpp/design/versioning/README.md`.
 
 - **`gplates`** is the single development branch and the repository's default. Both products are
   developed on it; there is no per-product branch. (It will be renamed `main` in a later change.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,9 @@ same sources, selected by the CMake option `GPLATES_BUILD_GPLATES`. It is declar
 `cmake/modules/Version.cmake` (not `ConfigDefault.cmake`) and **defaults to `TRUE`**, so a
 pyGPlates build that omits `-DGPLATES_BUILD_GPLATES=FALSE` silently builds GPlates instead.
 
-Either product can be built from either develop branch. Default to the product matching the
-checked-out branch — `pygplates` branch to `build-pygplates/`, `gplates` branch to
-`build-gplates/` — but building the other product from the same worktree is normal and fine.
+There is one development branch, `gplates`, and both products are developed on it. Building
+either one from the same worktree is normal; keep them in separate build trees
+(`build-pygplates/`, `build-gplates/`) so neither reconfigure invalidates the other.
 
 Versions are **derived, not written**. `cmake/modules/VersionRelease.cmake` holds the release
 each line is heading towards (`GPLATES_RELEASE_VERSION`, `PYGPLATES_RELEASE_VERSION`), and
@@ -126,20 +126,18 @@ built module must have no direct dependency on GPlates' GUI/rendering libraries)
 either fails after adding a file or an `#include`, the failure message says which CMake list
 to fix — do that rather than weakening the tracer.
 
-CI coverage gap: each develop branch's workflow builds only its own product
-(`build-test-pygplates.yml` → pyGPlates, `build-test-gplates.yml` → GPlates), so CI will not
-catch a change to the shared sources or the CMake source lists breaking the *other* product.
-Build both **locally** before pushing such a change: pyGPlates and GPlates under Qt6, plus
-GPlates under Qt5 when the change could plausibly be Qt-version-sensitive (any `QT_VERSION`
-conditional, `qt-widgets`, or a Qt include whose header moved between Qt5 and Qt6). The Qt5
-build needs a second conda environment (see *Build* above); if it is not set up, say what you
-could not verify rather than skipping it silently. The nastiest case: a change landing on
-`gplates` (the default branch, which the downstream fork tracks) that breaks pyGPlates surfaces
-only at the next sync merge into `pygplates`, where it looks like the merge's fault.
+**CI builds both products on every push**, which is what makes the boundary enforceable: the
+two CTests above are pyGPlates tests, so only a pyGPlates build can run them. Until the develop
+branches were unified each workflow ran on its own branch and built only its own product, and a
+change to the shared sources or the CMake source lists could break the other product undetected
+— discovered at the next sync merge, where it looked like the merge's fault. Both defects PR #70
+fixed had been hiding in exactly that gap.
 
-The gap could be closed by adding the other product's configure+build to each workflow, at the
-cost of roughly doubling CI compute per push. That is a maintainer decision, recorded here so
-it can be made deliberately — not a change to make in passing (see *Working agreements*).
+What CI still does **not** cover is Qt5. Build GPlates under Qt5 locally before pushing a change
+that could plausibly be Qt-version-sensitive (any `QT_VERSION` conditional, `qt-widgets`, or a Qt
+include whose header moved between Qt5 and Qt6). That needs a second conda environment (see
+*Build* above); if it is not set up, say what you could not verify rather than skipping it
+silently.
 
 ## Python API docstrings and the `.pyi` stub
 
@@ -226,29 +224,28 @@ Where this guidance and a specific file disagree, match the file you are editing
 
 ## Branches and pull requests
 
-The branching model is a gitflow variant, described in `README.md`. Four **main** branches are
-permanent; everything else is a short-lived **support** branch merged back into one of them.
+This is **not** gitflow — it is the trunk-plus-release-series model, described in `README.md` and
+argued for in `doc-cpp/design/versioning/README.md`.
 
-- **main develop** branches: `gplates` (the repository's default branch) and `pygplates`. These
-  are kept closely in sync — GPlates-related work is done on `gplates` and pyGPlates-related
-  work on `pygplates`, but they are otherwise near-identical.
-- **main release** branches: `release-gplates` and `release-pygplates` track release history.
-  **Release tags live only here** — on the merge commit of the `release/…` or `hotfix/…` branch
-  that prepared the release, never on that temporary branch and never on a develop branch. (A
-  release *candidate* is tagged on the `release/…` branch preparing it, not being a release.)
-- **support** branches: `feature/<name>`, `fix/<name>` (a fix rather than a feature, but
-  otherwise identical — branched from and merged back into a main develop branch),
-  `release/{gplates,pygplates}-<version>` (cut from a main develop branch), and
-  `hotfix/{gplates,pygplates}-<version>` (cut from a main release branch).
+- **`gplates`** is the single development branch and the repository's default. Both products are
+  developed on it; there is no per-product branch. (It will be renamed `main` in a later change.)
+- **release series** branches — `release/gplates-<X.Y>`, `release/pygplates-<X.Y>` — are
+  permanent, cut from `gplates` when the first release in the series is prepared. **Release tags
+  live only here**, never on `gplates`: candidates, the release, and each later patch release are
+  successive commits on the one branch, so the tip is always the newest X.Y.z. There is no
+  `hotfix/` concept and no permanent 'production' branch.
+- **short-lived** branches: `feature/<name>` and `fix/<name>` off `gplates` (a fix rather than a
+  feature, but otherwise identical), and patch branches off a release series branch.
 
-**Base pull requests on the main develop branch you are working from — `pygplates` or `gplates`
-— never on a `release-*` branch.** CI enforces this: `build-test-pygplates.yml` only runs on
-`pygplates` and `build-test-gplates.yml` only on `gplates`.
+**Base pull requests on `gplates`, never on a release series branch.** CI enforces this: both
+`build-test-gplates.yml` and `build-test-pygplates.yml` run only on `gplates`. Building **both**
+products on every push is deliberate — it is what closes the coverage gap that two develop
+branches used to leave open (see *The pyGPlates module boundary*).
 
 Pull requests are merged with a merge commit (`Merge pull request #N from …`), so a branch's
 commits become the permanent record. **Whether to tidy a branch before merging is a judgement
-about that branch, not a convention** — neither develop branch has a squash policy, and they do
-not differ in this any more than in anything else. Ask what a reader hitting the commit in
+about that branch, not a convention** — there is no squash policy. Ask what a reader hitting the
+commit in
 `git log` or `git bisect` a year from now gets from it:
 
 - **Squash** commits that exist only because of iteration — "fix the CI", "try again", a typo
@@ -270,8 +267,8 @@ push and fetch commands rather than assuming. There is an active downstream fork
 ## Releases (pyGPlates wheels)
 
 Set `PYGPLATES_RELEASE_VERSION` in `cmake/modules/VersionRelease.cmake` to the release version,
-commit, then tag **exactly** `PyGPlates-<version>` on `release-pygplates` (release tags belong on
-the main release branches — see *Branches and pull requests*); the workflow fails in its first
+commit, then tag **exactly** `PyGPlates-<version>` on the release series branch
+`release/pygplates-<X.Y>` (release tags belong only there — see *Branches and pull requests*); the workflow fails in its first
 minute on a mismatch or a `.dev` version. Standing on the tag, the derived version *is* the
 release target (no development number), which is what makes the two agree. Afterwards set the
 target to the next release, or the following commit resolves to a version sorting below the one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,10 @@ commit, then tag **exactly** `PyGPlates-<version>` on the release series branch
 minute on a mismatch or a `.dev` version. Standing on the tag, the derived version *is* the
 release target (no development number), which is what makes the two agree. Afterwards set the
 target to the next release, or the following commit resolves to a version sorting below the one
-just released — a hard error rather than a bad package.
+just released — a hard error rather than a bad package. The resolver also refuses a target that
+sorts below the nearest release or skips a version, so the next target has to be the next patch,
+minor or major (or a candidate of one); `cmake -P cmake/modules/VersionFromGitTest.cmake` runs
+those rules as tests.
 Publishing uses PyPI Trusted Publishing (OIDC, no tokens) and pauses for manual approval on the
 `pypi` deployment environment. **Renaming `.github/workflows/build-wheels.yml` silently breaks
 publishing** — the trusted-publisher registration binds to the filename. Adding a Python version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,16 +92,18 @@ in Debug instead of throwing, which kills every test that exercises an error pat
 products enforce that differently, and the difference decides how you fix an empty run:
 
 - **pyGPlates** tests are registered `CONFIGURATIONS Release MinSizeRel`. Omitting `-C Release`
-  matches nothing and CTest still **exits 0**, so the run looks like a pass.
+  matches none of them and CTest still **exits 0**, so the run looks like a pass.
 - **GPlates** tests are registered by `gtest_discover_tests()`, which cannot attach
   `CONFIGURATIONS`, so they are instead skipped at *configure* time by
   `if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")` (`src/CMakeLists.txt`). A Debug build tree contains
-  no registered tests at all and **no `-C` value will reveal any** — reconfigure as Release. On a
+  no GPlates tests at all and **no `-C` value will reveal any** — reconfigure as Release. On a
   single-config Release tree a bare `ctest` does work; `-C Release` matters for the multi-config
   generators (Visual Studio, Xcode).
 
-So: zero tests from `build-pygplates` usually means a missing `-C Release`; zero tests from
-`build-gplates` usually means the tree was configured Debug.
+So: only `version-resolver-test` from `build-pygplates` usually means a missing `-C Release`, and
+only it from `build-gplates` usually means the tree was configured Debug. That one test carries
+no configuration restriction, deliberately — it runs a CMake script and builds nothing — so it
+runs, and passes, in exactly those mis-run cases. One passing test is not a green suite.
 
 The GPlates unit-test binary is `EXCLUDE_FROM_ALL`, so build it explicitly:
 
@@ -270,12 +272,14 @@ Set `PYGPLATES_RELEASE_VERSION` in `cmake/modules/VersionRelease.cmake` to the r
 commit, then tag **exactly** `PyGPlates-<version>` on the release series branch
 `release/pygplates-<X.Y>` (release tags belong only there — see *Branches and pull requests*); the workflow fails in its first
 minute on a mismatch or a `.dev` version. Standing on the tag, the derived version *is* the
-release target (no development number), which is what makes the two agree. Afterwards set the
-target to the next release, or the following commit resolves to a version sorting below the one
-just released — a hard error rather than a bad package. The resolver also refuses a target that
-sorts below the nearest release or skips a version, so the next target has to be the next patch,
-minor or major (or a candidate of one); `cmake -P cmake/modules/VersionFromGitTest.cmake` runs
-those rules as tests.
+release target (no development number), which is what makes the two agree. Afterwards move the
+targets on, on both branches: the series branch to the next patch after a release (nothing after
+a candidate — the next commit there prepares the next candidate or the release, and nothing else
+is accepted until the release is final), and `gplates` to the next minor when the series gets its
+*first* tag. Left behind, the following commit resolves to a version sorting below the one just
+released, or re-issues numbers the development branch has already used — a hard error rather
+than a bad package. The resolver also refuses a target that sorts below the nearest release or
+skips a version; `cmake -P cmake/modules/VersionFromGitTest.cmake` runs those rules as tests.
 Publishing uses PyPI Trusted Publishing (OIDC, no tokens) and pauses for manual approval on the
 `pypi` deployment environment. **Renaming `.github/workflows/build-wheels.yml` silently breaks
 publishing** — the trusted-publisher registration binds to the filename. Adding a Python version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,17 @@ enable_testing()
 # Print test output when test fails - when running tests with 'make test' or building 'RUN_TESTS' (in Visual Studio).
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")  # Ignored if CMake < 3.17
 
+# Test the version resolver's pure helper functions - splitting and ordering versions, and
+# checking the hand-edited release target against the nearest release ('VersionFromGit.cmake').
+#
+# Registered here rather than under 'pygplates/test/' because it belongs to neither product: it
+# runs a CMake script, needs nothing built, and both products resolve both versions. For the same
+# reason it carries no CONFIGURATIONS restriction - the Debug caveat on the other tests is about
+# 'GPlatesGlobal::Assert' aborting instead of throwing, which nothing here goes near.
+add_test(
+    NAME version-resolver-test
+    COMMAND ${CMAKE_COMMAND} -P "${PROJECT_SOURCE_DIR}/cmake/modules/VersionFromGitTest.cmake")
+
 #
 # Include configuration options (default options and options overridden by user).
 #

--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ Please see the [installation instructions](https://www.gplates.org/docs/pygplate
 
 ### Source code
 
+> __Note:__ The rest of this document is only for those wishing to compile GPlates or pyGPlates
+> from source. Most users will not need to, since GPlates is available as ready-to-use binary
+> packages and pyGPlates can be installed using conda or pip (see [above](#binary-packages)).
+
 The source code can be compiled on Windows, macOS and Linux.
 
-The source code is obtained by checking out a [primary branch in this repository](#primary-branches).
-
-> Both the GPlates and pyGPlates source code are in this repository (on different [branches](#primary-branches)).
+> Both GPlates and pyGPlates are compiled from this one repository (and from the same
+> [branch](#branches)) - which of the two is selected when configuring the build.
 
 Instructions for installing the [dependencies](#dependencies) and compiling GPlates/pyGPlates can be found in the source code, in the files:
 
@@ -98,126 +101,52 @@ GPlates and pyGPlates are [free software](https://www.gnu.org/philosophy/free-sw
 * [Qt](https://www.qt.io/) 6.x recommended (5.15 also supported)
 * [Qwt](https://qwt.sourceforge.io/) 6.0.1 or above (preferably 6.1 or above)
 
-#### Repository
+#### Branches
 
-Public releases and development snapshots can be compiled from the __primary branches__ in this repository.
+There is one permanent __development__ branch, plus one permanent branch per __release series__:
 
-##### Primary branches
+- `gplates` is the __development__ branch (and the _default_ branch). Both GPlates and pyGPlates
+  are developed here. Check it out to compile the latest __development snapshot__ of either
+  product.
+- `release/gplates-<major>.<minor>` and `release/pygplates-<major>.<minor>` (eg,
+  `release/gplates-2.6` and `release/pygplates-1.1`) are the __release series__ branches. Each is
+  created from the development branch when the first release in that series is prepared, and
+  every release in the series is then tagged on it - the release candidates, the release itself
+  and any later patch releases - so its tip is always the newest release in that series.
 
-There is one permanent __development__ branch, `gplates` (_the default branch_), plus one
-permanent branch per __release series__.
+To compile a __public release__, check out its tag (eg, `GPlates-2.5` or `PyGPlates-1.0.0`) - the
+releases are listed on the [Releases page](https://github.com/GPlates/GPlates/releases) - or, for
+the newest release in a series, check out the series branch.
 
-To compile the latest __development snapshot__ of either product, use `gplates`.
+All other branches are short-lived, created from one of the permanent branches and deleted once
+merged back:
 
-To compile a __public release__, check out its tag - or, for the newest release in a series that is
-still maintained, the series branch, whose tip is always the latest release in that line. The
-releases are listed on the [Releases page](https://github.com/GPlates/GPlates/releases), and on the
-command-line by:
+- `feature/<name>` and `fix/<name>` branches, for developing a new feature or fixing a bug, are
+  created from (and merged back into) the __development__ branch,
+- __patch__ branches, for a fix to a version that has already been released, are created from
+  (and merged back into) a __release series__ branch.
 
-```
-git -c versionsort.suffix=a -c versionsort.suffix=b -c versionsort.suffix=rc tag --list 'GPlates-*' --sort=version:refname
-```
-
-(`PyGPlates-*` for pyGPlates. The `versionsort.suffix` settings are what sort a release candidate
-_before_ its release instead of after it.)
-
-> __Note:__ Not every tag in that list is a release. __A tag carrying a development number is
-> not one__: `GPlates-2.6.0-47` and `PyGPlates-1.1.0.dev20` are _anchor_ tags, which exist to move
-> the version counter (see __Versioning__ below), and a few very old tags are neither. A release
-> tag is `GPlates-<version>` or `PyGPlates-<version>` with no development number on it.
-
-> __Note:__ A release series branch is created when the first release in that series is prepared,
-> so there is not one for every past release. The tags are the complete record.
-
-##### Branching model
-
-This is __not__ [gitflow](https://nvie.com/posts/a-successful-git-branching-model/). There is a
-single permanent development branch and one permanent branch per release series - the model that
-QGIS, GDAL, CGAL, LLVM and CPython use. Every other branch is short-lived: created from one of the
-permanent branches and deleted once it has been merged back.
-
-- the __development__ branch named:
-  - `gplates`
-  > __Note:__ The _default_ branch, and the only branch where development happens. Both products
-  > are built from it - which one is selected by the `GPLATES_BUILD_GPLATES` CMake option - so
-  > there is no separate branch per product.
-- __release series__ branches named:
-  - `release/gplates-<major>.<minor>` (eg, `release/gplates-2.6`)
-  - `release/pygplates-<major>.<minor>` (eg, `release/pygplates-1.1`)
-  > __Note:__ These are permanent, and are created from the __development__ branch when the first
-  > release in the series is prepared. Every release in that line is tagged here - the candidates,
-  > the release itself, and each later patch release, which is simply a further commit on the same
-  > branch. So `release/pygplates-1.1` carries `PyGPlates-1.1.0rc1`, `PyGPlates-1.1.0`,
-  > `PyGPlates-1.1.1` and so on, and its tip is always the newest 1.1.x. Any commits made while
-  > preparing a release are also merged back into the __development__ branch.
-  >
-  > __Release tags belong only on these branches__, never on the __development__ branch.
-- __feature__ branches named:
-  - `feature/<name>` for developing a new feature
-- __fix__ branches named:
-  - `fix/<name>` for fixing a bug, typically one reported as a GitHub issue
-  > __Note:__ A __fix__ branch is a __feature__ branch in every respect but intent. Both are
-  > created from the __development__ branch and merged back into it, and ship whenever the next
-  > release happens.
-- __patch__ branches, created from a __release series__ branch, for a fix that has to reach a
-  version that has already been released.
-  > __Note:__ These are merged back into the series branch, where the patch release is tagged,
-  > and also into the __development__ branch when the fix applies there too.
-
-> __Note:__ There is no permanent 'production' branch and no `hotfix` branch: a patch release is a
-> commit on the release series branch. Why the repository is arranged this way, and what was
-> considered instead, is written up in
+> __Note:__ This is no longer [gitflow](https://nvie.com/posts/a-successful-git-branching-model/).
+> It is the branching model that QGIS, GDAL, CGAL, LLVM and CPython use: development happens on
+> the default branch, and releases are tagged on permanent per-series branches. There is no
+> separate 'production' branch and no `hotfix` branch (a patch release is simply a further commit
+> on the release series branch). The reasoning, and what was considered instead, is in
 > [doc-cpp/design/versioning/README.md](doc-cpp/design/versioning/README.md).
 
-##### Versioning
+> __Note:__ The development branch will be renamed `main` in a later change.
 
-Versions follow from the branching model above rather than being written out by hand:
+#### Versioning
 
-- `cmake/modules/VersionRelease.cmake` names the release each line is heading towards
-  (`GPLATES_RELEASE_VERSION`, `PYGPLATES_RELEASE_VERSION`). This is the only part anyone edits,
-  and it changes twice per release: once when a __release__ branch names the candidate being
-  prepared, and once afterwards to name the next release.
-- `cmake/modules/VersionFromGit.cmake` adds a development number - the number of first-parent
-  commits since the nearest release tag, which is how many times the branch tip has advanced.
-  So a GPlates development build is `2.6.0-47` and a pyGPlates one is `1.1.0.dev46`, while a
-  build standing on a release tag is exactly the release version.
+Versions are derived from git rather than written by hand. `cmake/modules/VersionRelease.cmake`
+names the release each product is heading towards (eg, `2.6.0` for GPlates and `1.1.0` for
+pyGPlates), and the build appends a development number counted from the git history. So a
+development build of GPlates has a version like `2.6.0-47` and of pyGPlates `1.1.0.dev46`, while
+a build standing on a release tag has exactly the release version.
 
-To see what a checkout resolves to, without configuring a build:
+> __Note:__ Counting needs the whole git history, so a shallow clone (`git clone --depth ...`) is
+> refused. And a source archive with no git repository at all needs the version supplied, as
+> described at the top of `cmake/modules/VersionFromGit.cmake`.
 
-```
-cmake -P cmake/modules/VersionFromGit.cmake gplates
-cmake -P cmake/modules/VersionFromGit.cmake pygplates
-```
-
-> __Note:__ Counting needs the whole history, so a shallow clone is refused rather than allowed
-> to produce a smaller number that still looks plausible. Building from a source archive with no
-> repository at all needs the version supplied, either as `-DGPLATES_SEMANTIC_VERSION=<version>`
-> (or `-DPYGPLATES_PEP440_VERSION=<version>`) or as an environment variable of the same name.
-
-> __Note for forks:__ commits on a fork advance its own first-parent line, so a fork will
-> otherwise mint the same development numbers as upstream for different code. Tagging the fork
-> branch - say `GPlates-2.6.0-2000` - makes that tag the nearest one, and the fork counts on from
-> there.
-
-To go the other way, from a version string back to the commit it was built from: the development
-number counts first-parent commits on from the nearest tag, so subtract that tag's own development
-number and count that far along the branch.
-
-```
-# pyGPlates 1.1.0.dev48, counting from PyGPlates-1.0.0 (development number 0)
-git rev-list --first-parent --reverse PyGPlates-1.0.0..gplates | sed -n '48p'
-
-# GPlates 2.6.0-56, counting from the anchor GPlates-2.6.0-47 (development number 47)
-git rev-list --first-parent --reverse GPlates-2.6.0-47..gplates | sed -n '9p'
-```
-
-> __Note:__ Count along the branch the build came from - the development branch, or a release
-> series branch. A development number is unique along one first-parent line but not across lines,
-> so the same version string can name different commits on different branches, and a version minted
-> before the two development branches were unified cannot be found this way at all.
->
-> So __tag any development build that goes to someone__, and the commit is findable by name
-> instead. It costs nothing: a tag whose development number matches the count already in force
-> leaves every version before and after it exactly as it was, deleting it again restores the same
-> numbers, and `build-wheels.yml` ignores `PyGPlates-*.dev*` tags so one cannot start a release
-> run.
+How the version is derived, how to see what a checkout resolves to, how to find the commit that a
+version was built from, and how a fork can keep its own version numbers, are all described in
+[doc-cpp/design/versioning/README.md](doc-cpp/design/versioning/README.md).

--- a/README.md
+++ b/README.md
@@ -109,14 +109,22 @@ permanent branch per __release series__.
 
 To compile the latest __development snapshot__ of either product, use `gplates`.
 
-To compile a __public release__, check out its tag - or, for the newest release in a series that
-is still maintained, the series branch, whose tip is always the latest release in that line. To
-list the releases on the command-line, type:
+To compile a __public release__, check out its tag - or, for the newest release in a series that is
+still maintained, the series branch, whose tip is always the latest release in that line. The
+releases are listed on the [Releases page](https://github.com/GPlates/GPlates/releases), and on the
+command-line by:
 
 ```
-git tag --list 'GPlates-*'   --sort=version:refname
-git tag --list 'PyGPlates-*' --sort=version:refname
+git -c versionsort.suffix=a -c versionsort.suffix=b -c versionsort.suffix=rc tag --list 'GPlates-*' --sort=version:refname
 ```
+
+(`PyGPlates-*` for pyGPlates. The `versionsort.suffix` settings are what sort a release candidate
+_before_ its release instead of after it.)
+
+> __Note:__ Not every tag in that list is a release. __A tag carrying a development number is
+> not one__: `GPlates-2.6.0-47` and `PyGPlates-1.1.0.dev20` are _anchor_ tags, which exist to move
+> the version counter (see __Versioning__ below), and a few very old tags are neither. A release
+> tag is `GPlates-<version>` or `PyGPlates-<version>` with no development number on it.
 
 > __Note:__ A release series branch is created when the first release in that series is prepared,
 > so there is not one for every past release. The tags are the complete record.
@@ -190,3 +198,26 @@ cmake -P cmake/modules/VersionFromGit.cmake pygplates
 > otherwise mint the same development numbers as upstream for different code. Tagging the fork
 > branch - say `GPlates-2.6.0-2000` - makes that tag the nearest one, and the fork counts on from
 > there.
+
+To go the other way, from a version string back to the commit it was built from: the development
+number counts first-parent commits on from the nearest tag, so subtract that tag's own development
+number and count that far along the branch.
+
+```
+# pyGPlates 1.1.0.dev48, counting from PyGPlates-1.0.0 (development number 0)
+git rev-list --first-parent --reverse PyGPlates-1.0.0..gplates | sed -n '48p'
+
+# GPlates 2.6.0-56, counting from the anchor GPlates-2.6.0-47 (development number 47)
+git rev-list --first-parent --reverse GPlates-2.6.0-47..gplates | sed -n '9p'
+```
+
+> __Note:__ Count along the branch the build came from - the development branch, or a release
+> series branch. A development number is unique along one first-parent line but not across lines,
+> so the same version string can name different commits on different branches, and a version minted
+> before the two development branches were unified cannot be found this way at all.
+>
+> So __tag any development build that goes to someone__, and the commit is findable by name
+> instead. It costs nothing: a tag whose development number matches the count already in force
+> leaves every version before and after it exactly as it was, deleting it again restores the same
+> numbers, and `build-wheels.yml` ignores `PyGPlates-*.dev*` tags so one cannot start a release
+> run.

--- a/README.md
+++ b/README.md
@@ -104,61 +104,62 @@ Public releases and development snapshots can be compiled from the __primary bra
 
 ##### Primary branches
 
-To compile the latest official __public release__:
-- For GPlates, use the `release-gplates` branch.
-- For PyGPlates, use the `release-pygplates` branch.
+There is one permanent __development__ branch, `gplates` (_the default branch_), plus one
+permanent branch per __release series__.
 
-To compile the latest __development snapshot__:
-- For GPlates, use the `gplates` branch (_the default branch_).
-- For PyGPlates, use the `pygplates` branch.
+To compile the latest __development snapshot__ of either product, use `gplates`.
 
-##### Development branching model
+To compile a __public release__, check out its tag - or, for the newest release in a series that
+is still maintained, the series branch, whose tip is always the latest release in that line. To
+list the releases on the command-line, type:
 
-The branching model used in this repository is based on [gitflow](https://nvie.com/posts/a-successful-git-branching-model/).
-Four __main__ branches are permanent - two tracking releases and two tracking development - and
-every other branch is a short-lived __support__ branch, created from a main branch and deleted
-once it has been merged back.
+```
+git tag --list 'GPlates-*'   --sort=version:refname
+git tag --list 'PyGPlates-*' --sort=version:refname
+```
 
-- __main release__ branches named:
-  - `release-gplates` to track the history of __GPlates__ releases
-  - `release-pygplates` to track the history of __pyGPlates__ releases
-  > __Note:__ Release tags (eg, `GPlates-2.6.0`, `PyGPlates-1.1.0`) belong __only__ on these
-  > two branches, on the merge commit of the `release/...` or `hotfix/...` branch that prepared
-  > the release - never on that temporary branch itself, and never on a __main develop__ branch.
-  > A release _candidate_ is not a release, so its tag stays where the candidate was prepared:
-  > `PyGPlates-1.0.0rc1` is tagged on the `release/pygplates-1.0.0` branch.
+> __Note:__ A release series branch is created when the first release in that series is prepared,
+> so there is not one for every past release. The tags are the complete record.
+
+##### Branching model
+
+This is __not__ [gitflow](https://nvie.com/posts/a-successful-git-branching-model/). There is a
+single permanent development branch and one permanent branch per release series - the model that
+QGIS, GDAL, CGAL, LLVM and CPython use. Every other branch is short-lived: created from one of the
+permanent branches and deleted once it has been merged back.
+
+- the __development__ branch named:
+  - `gplates`
+  > __Note:__ The _default_ branch, and the only branch where development happens. Both products
+  > are built from it - which one is selected by the `GPLATES_BUILD_GPLATES` CMake option - so
+  > there is no separate branch per product.
+- __release series__ branches named:
+  - `release/gplates-<major>.<minor>` (eg, `release/gplates-2.6`)
+  - `release/pygplates-<major>.<minor>` (eg, `release/pygplates-1.1`)
+  > __Note:__ These are permanent, and are created from the __development__ branch when the first
+  > release in the series is prepared. Every release in that line is tagged here - the candidates,
+  > the release itself, and each later patch release, which is simply a further commit on the same
+  > branch. So `release/pygplates-1.1` carries `PyGPlates-1.1.0rc1`, `PyGPlates-1.1.0`,
+  > `PyGPlates-1.1.1` and so on, and its tip is always the newest 1.1.x. Any commits made while
+  > preparing a release are also merged back into the __development__ branch.
   >
-  > To see the list of all public releases on the command-line, type:  
-  > `git log --first-parent release-gplates release-pygplates`
-- __main develop__ branches named:
-  - `gplates` for development of __GPlates__
-  - `pygplates` for development of __pyGPlates__
-  > __Note:__ The _default_ branch is `gplates`
-  > (synonymous with the typical 'main' or 'master' branch in other repositories).
+  > __Release tags belong only on these branches__, never on the __development__ branch.
 - __feature__ branches named:
   - `feature/<name>` for developing a new feature
-  > __Note:__ These short-lived branches are merged back into their parent __main develop__
-  > branch (`gplates` or `pygplates`).
 - __fix__ branches named:
   - `fix/<name>` for fixing a bug, typically one reported as a GitHub issue
-  > __Note:__ Not part of gitflow, but used here. A __fix__ branch is a __feature__ branch in
-  > every respect but intent - branched from a __main develop__ branch, merged back into it,
-  > and shipped whenever the next release happens. It is __not__ a __hotfix__ branch, which
-  > exists to repair a version that has already been released.
-- __release__ branches named:
-  - `release/gplates-<gplates_version>` for preparing a GPlates release
-  - `release/pygplates-<pygplates_version>` for preparing a pyGPlates release
-  > __Note:__ These short-lived branches are created from a __main develop__ branch, and are
-  > merged into `release-gplates` or `release-pygplates` (the __main release__ branch containing
-  > __all__ GPlates or pyGPlates releases), where the release is tagged. Any commits made while
-  > preparing the release are also merged back into `gplates` or `pygplates`.
-- __hotfix__ branches named:
-  - `hotfix/gplates-<gplates_version>` for preparing a GPlates _bug fix_ release
-  - `hotfix/pygplates-<pygplates_version>` for preparing a pyGPlates _bug fix_ release
-  > __Note:__ These short-lived branches are created from a __main release__ branch - that is
-  > what distinguishes them from __fix__ branches - and are merged back into `release-gplates`
-  > or `release-pygplates`, where the bug fix release is tagged, and also into `gplates` or
-  > `pygplates`.
+  > __Note:__ A __fix__ branch is a __feature__ branch in every respect but intent. Both are
+  > created from the __development__ branch and merged back into it, and ship whenever the next
+  > release happens.
+- __patch__ branches, created from a __release series__ branch, for a fix that has to reach a
+  version that has already been released.
+  > __Note:__ These are merged back into the series branch, where the patch release is tagged,
+  > and also into the __development__ branch when the fix applies there too.
+
+> __Note:__ There is no permanent 'production' branch and no `hotfix` branch: a patch release is a
+> commit on the release series branch. Why the repository is arranged this way, and what was
+> considered instead, is written up in
+> [doc-cpp/design/versioning/README.md](doc-cpp/design/versioning/README.md).
 
 ##### Versioning
 

--- a/cmake/modules/VersionFromGit.cmake
+++ b/cmake/modules/VersionFromGit.cmake
@@ -165,6 +165,238 @@ function(gplates_join_version product base dev out_var)
 endfunction()
 
 
+#
+# Split a base version - one with no development number - into a numeric head and a comparable
+# pre-release rank, so that two bases can be ordered.
+#
+# The rank orders the suffixes each product allows, later being greater:
+#
+#   GPlates      2.6.0-alpha.N  <  2.6.0-beta.N  <  2.6.0-rc.N  <  2.6.0
+#   pyGPlates    1.1.0aN        <  1.1.0bN       <  1.1.0rcN    <  1.1.0  <  1.1.0.postN
+#
+# Neither ordering is invented here: both are what Semantic Versioning and PEP 440 respectively
+# already require, and 'Version.cmake' relies on them.
+#
+# Sets <ok_var> FALSE if the base does not parse. That is not an error in itself - an unparseable
+# tag is skipped everywhere else too - it only means the base cannot be compared.
+#
+function(_gplates_version_base_rank product base ok_var head_var rank_var n_var post_var)
+	set(${ok_var} FALSE PARENT_SCOPE)
+	set(${head_var} "" PARENT_SCOPE)
+	set(${rank_var} 0 PARENT_SCOPE)
+	set(${n_var} 0 PARENT_SCOPE)
+	set(${post_var} 0 PARENT_SCOPE)
+
+	set(_n 0)
+	set(_post 0)
+
+	if (product STREQUAL "gplates")
+		if (base MATCHES [[^([0-9]+\.[0-9]+\.[0-9]+)-(alpha|beta|rc)\.([0-9]+)$]])
+			set(_head "${CMAKE_MATCH_1}")
+			set(_kind "${CMAKE_MATCH_2}")
+			set(_n "${CMAKE_MATCH_3}")
+		elseif (base MATCHES [[^([0-9]+\.[0-9]+\.[0-9]+)$]])
+			set(_head "${CMAKE_MATCH_1}")
+			set(_kind "")
+		else()
+			return()
+		endif()
+	elseif (product STREQUAL "pygplates")
+		if (NOT base MATCHES [[^([0-9]+\.[0-9]+\.[0-9]+)((a|b|rc)([0-9]+))?(\.post([0-9]+))?$]])
+			return()
+		endif()
+		set(_head "${CMAKE_MATCH_1}")
+		set(_kind "${CMAKE_MATCH_3}")
+		if (NOT _kind STREQUAL "")
+			set(_n "${CMAKE_MATCH_4}")
+		endif()
+		if (NOT "${CMAKE_MATCH_6}" STREQUAL "")
+			set(_post "${CMAKE_MATCH_6}")
+		endif()
+	else()
+		message(FATAL_ERROR "Unknown product '${product}' - expected 'gplates' or 'pygplates'.")
+	endif()
+
+	# 4 is "no pre-release suffix", so a plain release outranks every candidate of it. A
+	# post-release sorts above that again, and is ranked by <post_var>; only pyGPlates can
+	# express one.
+	if (_kind STREQUAL "alpha" OR _kind STREQUAL "a")
+		set(_rank 1)
+	elseif (_kind STREQUAL "beta" OR _kind STREQUAL "b")
+		set(_rank 2)
+	elseif (_kind STREQUAL "rc")
+		set(_rank 3)
+	else()
+		set(_rank 4)
+	endif()
+
+	set(${ok_var} TRUE PARENT_SCOPE)
+	set(${head_var} "${_head}" PARENT_SCOPE)
+	set(${rank_var} ${_rank} PARENT_SCOPE)
+	set(${n_var} ${_n} PARENT_SCOPE)
+	set(${post_var} ${_post} PARENT_SCOPE)
+endfunction()
+
+
+#
+# Order two base versions of the same product: sets <out_var> to -1, 0 or 1 as 'a' sorts below,
+# equal to, or above 'b' - or to the empty string if either of them does not parse.
+#
+# CMake's own VERSION_LESS cannot do this alone: it compares dotted numbers and ignores the rest,
+# so it reads '1.1.0rc1' and '1.1.0' as equal - the one comparison that matters most here.
+#
+function(gplates_compare_versions product a b out_var)
+	_gplates_version_base_rank(${product} "${a}" _ok_a _head_a _rank_a _n_a _post_a)
+	_gplates_version_base_rank(${product} "${b}" _ok_b _head_b _rank_b _n_b _post_b)
+	if (NOT _ok_a OR NOT _ok_b)
+		set(${out_var} "" PARENT_SCOPE)
+		return()
+	endif()
+
+	if (_head_a VERSION_GREATER _head_b)
+		set(${out_var} 1 PARENT_SCOPE)
+		return()
+	elseif (_head_a VERSION_LESS _head_b)
+		set(${out_var} -1 PARENT_SCOPE)
+		return()
+	endif()
+
+	# Equal heads: the pre-release rank decides, then its number, then the post-release number.
+	set(_a_parts "${_rank_a}" "${_n_a}" "${_post_a}")
+	set(_b_parts "${_rank_b}" "${_n_b}" "${_post_b}")
+	foreach (_i RANGE 2)
+		list(GET _a_parts ${_i} _x)
+		list(GET _b_parts ${_i} _y)
+		if (_x GREATER _y)
+			set(${out_var} 1 PARENT_SCOPE)
+			return()
+		elseif (_x LESS _y)
+			set(${out_var} -1 PARENT_SCOPE)
+			return()
+		endif()
+	endforeach()
+
+	set(${out_var} 0 PARENT_SCOPE)
+endfunction()
+
+
+#
+# Check the hand-edited release target against the nearest release, setting <error_var> to a
+# message to abort with, or to the empty string if the target is acceptable.
+#
+# 'reference' is the base version of the nearest tag that is a *release* rather than an anchor,
+# and 'reference_tag' names it. Anchor tags are deliberately excluded: an anchor says nothing
+# about what has been released, and a fork standing on 'GPlates-2.6.0-2000' with the target
+# '2.6.0' is the normal configuration, not an error.
+#
+# CHECK 1 (correctness): the target must sort strictly above the reference. Without it, a target
+# left behind - or set backwards by a typo - silently mints versions sorting below a release that
+# is already published: '1.1.0.dev3' after '1.1.0', or '0.9.0.dev49' after '1.0.0'. Equality is
+# the common case and gets its own message.
+#
+# CHECK 2 (policy): the target must not skip a version. Check 1 accepts '1.2.0' after a released
+# '1.0.0', which is what an accidentally skipped '1.1' looks like. The GPlates release line has no
+# skips - the one apparent gap, 0.9.5 to 0.9.7.1, is a release whose tag went missing, and the big
+# early pyGPlates jumps are from an era that used the SVN revision as the minor version - so this
+# matches the project's actual practice. It is policy rather than correctness, and a future
+# maintainer wanting a deliberate jump can loosen it without breaking anything.
+#
+# A candidate is treated more strictly than a release: only the same numeric head may follow one,
+# so '1.1.0rc1' can be followed by '1.1.0rc2' or '1.1.0' but not by '1.1.1'. There is no such
+# thing as skipping past a release that never happened.
+#
+# Honest limit: neither check catches a typo landing one step *forwards*. '1.10' normalises to
+# '1.10.0', which is a legitimate next minor from '1.9.0'.
+#
+function(gplates_check_release_target product target reference reference_tag distance error_var)
+	set(${error_var} "" PARENT_SCOPE)
+
+	# 'Version.cmake' is what validates the target's grammar; an unparseable one is its error to
+	# report, and there is nothing to compare here.
+	gplates_split_version(${product} "${target}" _ok _target_base _target_dev)
+	if (NOT _ok)
+		return()
+	endif()
+
+	gplates_compare_versions(${product} "${_target_base}" "${reference}" _cmp)
+	if (_cmp STREQUAL "")
+		return()
+	endif()
+
+	set(_where "'cmake/modules/VersionRelease.cmake'")
+
+	if (_cmp EQUAL 0)
+		string(CONCAT _msg
+				"The ${product} release target is '${target}', but '${reference_tag}' has already "
+				"been released ${distance} commit(s) back. Every commit from here would carry a "
+				"development version of something already published, sorting below it. Set the "
+				"next target in ${_where}."
+		)
+		set(${error_var} "${_msg}" PARENT_SCOPE)
+		return()
+	endif()
+
+	if (_cmp LESS 0)
+		string(CONCAT _msg
+				"The ${product} release target is '${target}', which sorts below '${reference}' - "
+				"released ${distance} commit(s) back as '${reference_tag}'. Every version derived "
+				"from here would sort below a release that is already published. Set the target in "
+				"${_where} to a version above '${reference}'."
+		)
+		set(${error_var} "${_msg}" PARENT_SCOPE)
+		return()
+	endif()
+
+	# Check 2. The heads are what the no-skip rule is about; the suffixes were settled by check 1.
+	_gplates_version_base_rank(${product} "${_target_base}" _ok_t _target_head _target_rank _t_n _t_post)
+	_gplates_version_base_rank(${product} "${reference}" _ok_r _ref_head _ref_rank _r_n _r_post)
+	if (NOT _ok_t OR NOT _ok_r)
+		return()
+	endif()
+
+	if (_target_head VERSION_EQUAL _ref_head)
+		return()
+	endif()
+
+	if (_ref_rank LESS 4)
+		string(CONCAT _msg
+				"The ${product} release target is '${target}', but the release line it follows has "
+				"not been finished: '${reference_tag}' is a candidate for '${_ref_head}', "
+				"${distance} commit(s) back. Set the target in ${_where} to another candidate for "
+				"'${_ref_head}', or to '${_ref_head}' itself."
+		)
+		set(${error_var} "${_msg}" PARENT_SCOPE)
+		return()
+	endif()
+
+	if (NOT _ref_head MATCHES [[^([0-9]+)\.([0-9]+)\.([0-9]+)$]])
+		return()
+	endif()
+	set(_major "${CMAKE_MATCH_1}")
+	set(_minor "${CMAKE_MATCH_2}")
+	set(_patch "${CMAKE_MATCH_3}")
+	math(EXPR _next_major "${_major} + 1")
+	math(EXPR _next_minor "${_minor} + 1")
+	math(EXPR _next_patch "${_patch} + 1")
+	set(_allowed
+			"${_major}.${_minor}.${_next_patch}"
+			"${_major}.${_next_minor}.0"
+			"${_next_major}.0.0")
+
+	if (NOT _target_head IN_LIST _allowed)
+		string(REPLACE ";" "', '" _allowed_text "${_allowed}")
+		string(CONCAT _msg
+				"The ${product} release target is '${target}', which skips past '${reference}' - "
+				"released ${distance} commit(s) back as '${reference_tag}'. The next release after "
+				"it is '${_allowed_text}', optionally as a candidate of one of those. Set the "
+				"target in ${_where} - or, if the jump is deliberate, loosen this check in "
+				"'gplates_check_release_target' (it is policy, not correctness)."
+		)
+		set(${error_var} "${_msg}" PARENT_SCOPE)
+	endif()
+endfunction()
+
+
 # Run git in the source tree, returning its exit code and stripped standard output.
 function(_gplates_version_git result_var output_var)
 	execute_process(
@@ -279,10 +511,15 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 	set(_best_distance -1)
 	set(_best_offset 0)
 	set(_best_tag "")
-	# Set only if one of the *nearest* tags is a plain release of the version being worked
-	# towards - tracked apart from the tag that supplies the number, because a tied anchor tag
-	# can supply the number while a release tag is what makes the situation an error.
-	set(_released_target_tag "")
+	# The nearest tag that is a *release* rather than an anchor, tracked apart from the tag that
+	# supplies the development number: an anchor tag can be nearer, and supply the number, while
+	# it is a release the target has to be checked against. Among releases tied at the same
+	# distance the highest base wins - seen from the develop branch 'GPlates-2.6.0' and
+	# 'GPlates-2.6.1' tie, both being off its first-parent line, and comparing against the older
+	# one would make a legitimate '2.6.2' look like a skipped release.
+	set(_ref_base "")
+	set(_ref_tag "")
+	set(_ref_distance 0)
 	set(_at_tag_base "")
 	set(_at_tag_name "")
 	set(_at_tag_dev 0)
@@ -327,10 +564,22 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 			continue()
 		endif()
 
-		# Is this a plain release of exactly the version being worked towards?
-		set(_is_released_target FALSE)
-		if (_dev EQUAL 0 AND _base STREQUAL target AND _base MATCHES [[^[0-9]+\.[0-9]+\.[0-9]+$]])
-			set(_is_released_target TRUE)
+		# Track the nearest release, which the release-target checks below compare against.
+		if (_dev EQUAL 0)
+			set(_is_nearer FALSE)
+			if (_ref_base STREQUAL "" OR _distance LESS _ref_distance)
+				set(_is_nearer TRUE)
+			elseif (_distance EQUAL _ref_distance)
+				gplates_compare_versions(${product} "${_base}" "${_ref_base}" _ref_cmp)
+				if (NOT _ref_cmp STREQUAL "" AND _ref_cmp GREATER 0)
+					set(_is_nearer TRUE)
+				endif()
+			endif()
+			if (_is_nearer)
+				set(_ref_base "${_base}")
+				set(_ref_tag "${_tag}")
+				set(_ref_distance ${_distance})
+			endif()
 		endif()
 
 		# Nearest wins; among equally near tags the largest development number wins, so the
@@ -339,17 +588,10 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 			set(_best_distance ${_distance})
 			set(_best_offset ${_dev})
 			set(_best_tag "${_tag}")
-			set(_released_target_tag "")
-			if (_is_released_target)
-				set(_released_target_tag "${_tag}")
-			endif()
 		elseif (_distance EQUAL _best_distance)
 			if (_dev GREATER _best_offset)
 				set(_best_offset ${_dev})
 				set(_best_tag "${_tag}")
-			endif()
-			if (_is_released_target)
-				set(_released_target_tag "${_tag}")
 			endif()
 		endif()
 	endforeach()
@@ -362,6 +604,24 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 	endif()
 	if (_best_distance LESS 0)
 		return()
+	endif()
+
+	# Check the hand-edited release target against the nearest release.
+	#
+	# Skipped when HEAD is standing on a release tag: there the target must *equal* that tag's
+	# base, which the block below enforces, and check 1 rejects exactly that equality. An anchor
+	# tag at HEAD is not skipped - the reference excludes anchors, so there is still a real
+	# release behind it to check against, and a fork's target has to clear it like anyone else's.
+	set(_at_release_tag FALSE)
+	if (NOT _at_tag_base STREQUAL "" AND _at_tag_dev EQUAL 0)
+		set(_at_release_tag TRUE)
+	endif()
+	if (NOT _at_release_tag AND NOT _ref_base STREQUAL "")
+		gplates_check_release_target(${product} "${target}" "${_ref_base}" "${_ref_tag}"
+				${_ref_distance} _target_error)
+		if (NOT _target_error STREQUAL "")
+			message(FATAL_ERROR "${_target_error}")
+		endif()
 	endif()
 
 	# Standing on a tag.
@@ -383,15 +643,6 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 		endif()
 		set(${out_var} "${target}" PARENT_SCOPE)
 		return()
-	endif()
-
-	# Heading towards a version that has already been released - the derived version would sort
-	# *below* the release it follows (eg, '1.1.0' released, then '1.1.0.dev3').
-	if (NOT _released_target_tag STREQUAL "")
-		message(FATAL_ERROR
-				"The ${product} release target is '${target}', but '${_released_target_tag}' has "
-				"already been released ${_best_distance} commit(s) back. Set the next target in "
-				"'cmake/modules/VersionRelease.cmake'.")
 	endif()
 
 	math(EXPR _dev_number "${_best_offset} + ${_best_distance}")

--- a/cmake/modules/VersionFromGit.cmake
+++ b/cmake/modules/VersionFromGit.cmake
@@ -301,14 +301,30 @@ endfunction()
 # matches the project's actual practice. It is policy rather than correctness, and a future
 # maintainer wanting a deliberate jump can loosen it without breaking anything.
 #
-# A candidate is treated more strictly than a release: only the same numeric head may follow one,
-# so '1.1.0rc1' can be followed by '1.1.0rc2' or '1.1.0' but not by '1.1.1'. There is no such
-# thing as skipping past a release that never happened.
+# A candidate binds the line it is on, and only that line. 'on_line' says whether the reference
+# tag sits on HEAD's first-parent line:
+#
+#   - On the line (a release series branch, or a patch branch off one): only the same numeric
+#     head may follow a candidate, so '1.1.0rc1' can be followed by '1.1.0rc2' or '1.1.0' but
+#     not by '1.1.1'. There is no such thing as skipping past a release that never happened.
+#   - Off the line (the development branch, once the series branch cut from it has its first
+#     candidate; or a feature branch cut before then): the candidate's head counts as released
+#     for the no-skip rule, and *staying* on that head is refused. The 1.1.0 line has moved to
+#     the series branch, which is minting '1.1.0rc1.devN' there, and this line's nearest tag is
+#     now that candidate at the branch point - so its own count has restarted, and left on
+#     '1.1.0' it would re-issue numbers it has already used. The target has to move on to
+#     '1.2.0' (or '1.1.1', or '2.0.0') at that moment: the same bump that check 1 forces after
+#     a final release, brought forward to the first candidate.
+#
+# Without that distinction, the first candidate on any series branch stopped every configure on
+# the development branch until the release was final - and, since both products' versions are
+# always resolved, a GPlates candidate stopped every pyGPlates build.
 #
 # Honest limit: neither check catches a typo landing one step *forwards*. '1.10' normalises to
 # '1.10.0', which is a legitimate next minor from '1.9.0'.
 #
-function(gplates_check_release_target product target reference reference_tag distance error_var)
+function(gplates_check_release_target product target reference reference_tag distance on_line
+		error_var)
 	set(${error_var} "" PARENT_SCOPE)
 
 	# 'Version.cmake' is what validates the target's grammar; an unparseable one is its error to
@@ -354,18 +370,37 @@ function(gplates_check_release_target product target reference reference_tag dis
 		return()
 	endif()
 
-	if (_target_head VERSION_EQUAL _ref_head)
-		return()
-	endif()
-
 	if (_ref_rank LESS 4)
-		string(CONCAT _msg
-				"The ${product} release target is '${target}', but the release line it follows has "
-				"not been finished: '${reference_tag}' is a candidate for '${_ref_head}', "
-				"${distance} commit(s) back. Set the target in ${_where} to another candidate for "
-				"'${_ref_head}', or to '${_ref_head}' itself."
-		)
-		set(${error_var} "${_msg}" PARENT_SCOPE)
+		# The reference is a candidate.
+		if (on_line)
+			if (_target_head VERSION_EQUAL _ref_head)
+				return()
+			endif()
+			string(CONCAT _msg
+					"The ${product} release target is '${target}', but the release line it follows has "
+					"not been finished: '${reference_tag}' is a candidate for '${_ref_head}', "
+					"${distance} commit(s) back. Set the target in ${_where} to another candidate for "
+					"'${_ref_head}', or to '${_ref_head}' itself."
+			)
+			set(${error_var} "${_msg}" PARENT_SCOPE)
+			return()
+		endif()
+		if (_target_head VERSION_EQUAL _ref_head)
+			string(CONCAT _msg
+					"The ${product} release target is '${target}', but '${_ref_head}' is being released "
+					"on another branch: '${reference_tag}' is a candidate for it, on a release series "
+					"branch cut from this line ${distance} commit(s) back. This line's development "
+					"number now counts from that branch point, so a target of '${_ref_head}' would "
+					"re-issue versions it has already used. Set the target in ${_where} to the release "
+					"after '${_ref_head}' - or, on a branch cut before the series branch was, merge the "
+					"development branch in, where the target has already moved on."
+			)
+			set(${error_var} "${_msg}" PARENT_SCOPE)
+			return()
+		endif()
+		# Any other head: the candidate's head counts as released, and the no-skip rule applies.
+	elseif (_target_head VERSION_EQUAL _ref_head)
+		# A post-release republishes the same version, so it keeps the head it follows.
 		return()
 	endif()
 
@@ -386,11 +421,14 @@ function(gplates_check_release_target product target reference reference_tag dis
 	if (NOT _target_head IN_LIST _allowed)
 		string(REPLACE ";" "', '" _allowed_text "${_allowed}")
 		string(CONCAT _msg
-				"The ${product} release target is '${target}', which skips past '${reference}' - "
-				"released ${distance} commit(s) back as '${reference_tag}'. The next release after "
-				"it is '${_allowed_text}', optionally as a candidate of one of those. Set the "
-				"target in ${_where} - or, if the jump is deliberate, loosen this check in "
-				"'gplates_check_release_target' (it is policy, not correctness)."
+				"The ${product} release target is '${target}', which skips past '${reference}' "
+				"('${reference_tag}', ${distance} commit(s) back). The next release after it is "
+				"'${_allowed_text}', optionally as a candidate of one of those. If this checkout "
+				"may be missing tags - a fork, or a clone that fetched one branch, since release "
+				"tags live on the release series branches - run 'git fetch --tags <upstream>' "
+				"first. Otherwise set the target in ${_where} - or, if the jump is deliberate, "
+				"loosen this check in 'gplates_check_release_target' (it is policy, not "
+				"correctness)."
 		)
 		set(${error_var} "${_msg}" PARENT_SCOPE)
 	endif()
@@ -519,6 +557,7 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 	# one would make a legitimate '2.6.2' look like a skipped release.
 	set(_ref_base "")
 	set(_ref_tag "")
+	set(_ref_commit "")
 	set(_ref_distance 0)
 	set(_at_tag_base "")
 	set(_at_tag_name "")
@@ -578,6 +617,7 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 			if (_is_nearer)
 				set(_ref_base "${_base}")
 				set(_ref_tag "${_tag}")
+				set(_ref_commit "${_tag_commit}")
 				set(_ref_distance ${_distance})
 			endif()
 		endif()
@@ -617,8 +657,17 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 		set(_at_release_tag TRUE)
 	endif()
 	if (NOT _at_release_tag AND NOT _ref_base STREQUAL "")
+		# Whether the reference is on HEAD's first-parent line, which decides how a candidate is
+		# treated. 'HEAD~n' follows first parents, so the commit that many steps back is the
+		# reference's own commit if it is on the line, and otherwise the commit where the two
+		# histories part - the one the release series branch was cut from.
+		set(_ref_on_line FALSE)
+		_gplates_version_git(_result _line_commit rev-parse --verify "HEAD~${_ref_distance}")
+		if (_result EQUAL 0 AND _line_commit STREQUAL _ref_commit)
+			set(_ref_on_line TRUE)
+		endif()
 		gplates_check_release_target(${product} "${target}" "${_ref_base}" "${_ref_tag}"
-				${_ref_distance} _target_error)
+				${_ref_distance} ${_ref_on_line} _target_error)
 		if (NOT _target_error STREQUAL "")
 			message(FATAL_ERROR "${_target_error}")
 		endif()

--- a/cmake/modules/VersionFromGit.cmake
+++ b/cmake/modules/VersionFromGit.cmake
@@ -25,13 +25,14 @@
 # does not require that every commit be a merge; both forms advance the tip exactly once.
 #
 # WHY 'rev-list --count' AND NOT 'git describe': 'git describe --first-parent' requires the tag
-# to sit *on* the first-parent line and fails outright here ("No tags can describe"). Under the
-# gitflow variant this repository uses, release tags live on the product main branches
-# ('release-gplates', 'release-pygplates'), on the merge commit of a temporary
-# 'release/<product>-<version>' branch, and those main branches are not merged back into the
-# develop branches. 'rev-list --count --first-parent <tag>..HEAD' needs no such ancestry - it
-# counts the first-parent commits of HEAD that are not reachable from the tag - so the existing
-# tags work unchanged.
+# to sit *on* the first-parent line and fails outright here ("No tags can describe"). Release tags
+# live on the release series branches ('release/<product>-<major>.<minor>'), never on the develop
+# branch, so no release tag is ever on the develop branch's first-parent line - and it stays off
+# it even when the series branch is merged back, since such a merge takes the series branch as its
+# *second* parent. 'rev-list --count --first-parent <tag>..HEAD' needs no such ancestry - it counts
+# the first-parent commits of HEAD that are not reachable from the tag - so the tags work
+# unchanged. Counting from a tag on a series branch gives the number of commits since that series
+# was cut, which is the more meaningful quantity anyway.
 #
 # ANCHOR TAGS: because the *nearest* tag wins, a tag placed on a branch takes over the numbering
 # from that point. That is how a downstream fork keeps its own development numbers without

--- a/cmake/modules/VersionFromGit.cmake
+++ b/cmake/modules/VersionFromGit.cmake
@@ -27,12 +27,15 @@
 # WHY 'rev-list --count' AND NOT 'git describe': 'git describe --first-parent' requires the tag
 # to sit *on* the first-parent line and fails outright here ("No tags can describe"). Release tags
 # live on the release series branches ('release/<product>-<major>.<minor>'), never on the develop
-# branch, so no release tag is ever on the develop branch's first-parent line - and it stays off
-# it even when the series branch is merged back, since such a merge takes the series branch as its
-# *second* parent. 'rev-list --count --first-parent <tag>..HEAD' needs no such ancestry - it counts
-# the first-parent commits of HEAD that are not reachable from the tag - so the tags work
-# unchanged. Counting from a tag on a series branch gives the number of commits since that series
-# was cut, which is the more meaningful quantity anyway.
+# branch, so no release tag is ever on the develop branch's first-parent line. (Series branches
+# are not merged back: a fix wanted on both lines goes to the develop branch and is cherry-picked
+# to the series, and a merge would carry the series branch's release target with it. Were one
+# ever merged, it would have to be with '--no-ff' - a fast-forward puts the tags on the line and
+# hands the develop branch the series' target, with no guard firing.)
+# 'rev-list --count --first-parent <tag>..HEAD' needs no such ancestry - it counts the
+# first-parent commits of HEAD that are not reachable from the tag - so the tags work unchanged.
+# Counting from a tag on a series branch gives the number of commits since that series was cut,
+# which is the more meaningful quantity anyway.
 #
 # ANCHOR TAGS: because the *nearest* tag wins, a tag placed on a branch takes over the numbering
 # from that point. That is how a downstream fork keeps its own development numbers without
@@ -44,8 +47,11 @@
 # runs back through the 2013 'python-api' branch, and no ancestor of any GPlates release tag
 # newer than that sits on it - so without the anchor the count runs from 2013 and gives
 # 2.6.0-1206 instead of 2.6.0-47. Deleting the tag would silently restore the larger number.
-# It stops being load-bearing at the next release, when release/gplates-2.6.0 is cut from the
-# develop tip and the branch point lands back on the first-parent line.
+# Once 'release/gplates-2.6' is cut and 'GPlates-2.6.0' tagged on it, the tip counts from that
+# tag instead - but every commit between the anchor and the branch point still counts from the
+# anchor (a release tag scores 0 there and is skipped, see below), and those are the commits
+# 'git bisect' walks. So the anchor stays load-bearing for its stretch of history: never delete
+# it.
 #
 
 if (CMAKE_SCRIPT_MODE_FILE)

--- a/cmake/modules/VersionFromGit.cmake
+++ b/cmake/modules/VersionFromGit.cmake
@@ -541,8 +541,26 @@ function(_gplates_version_from_git product tag_prefix target out_var)
 	endif()
 
 	_gplates_version_git(_result _tags tag --list "${tag_prefix}*")
-	if (NOT _result EQUAL 0 OR _tags STREQUAL "")
+	if (NOT _result EQUAL 0)
 		return()
+	endif()
+	if (_tags STREQUAL "")
+		# A working repository with none of the tags is almost always a fork: GitHub copies no
+		# tags into a fork, and fetching a single branch brings only the tags on it, while release
+		# tags live on the release series branches. Falling through to the file fallbacks would
+		# end in a message blaming the missing repository, which is the wrong diagnosis.
+		message(FATAL_ERROR
+				"Cannot derive the ${product} version: this repository has no '${tag_prefix}*' tags "
+				"to count from. A fork made on GitHub carries none of the upstream tags, and a fetch "
+				"of a single branch brings only the tags on it. Fetch them from the upstream "
+				"repository:\n"
+				"    git fetch --tags <upstream>\n"
+				"or just the release tags:\n"
+				"    git fetch <upstream> 'refs/tags/GPlates-*:refs/tags/GPlates-*' "
+				"'refs/tags/PyGPlates-*:refs/tags/PyGPlates-*'\n"
+				"and push them to the fork ('git push <fork> --tags') so that its clones and its CI "
+				"have them too. Or set the version explicitly (see the message at the end of "
+				"VersionFromGit.cmake).")
 	endif()
 	string(REGEX REPLACE "\r?\n" ";" _tags "${_tags}")
 

--- a/cmake/modules/VersionFromGitTest.cmake
+++ b/cmake/modules/VersionFromGitTest.cmake
@@ -12,8 +12,9 @@
 # This covers only the parts of 'VersionFromGit.cmake' that are pure functions of their
 # arguments - splitting and joining a version, ordering two of them, and checking the
 # hand-edited release target against the nearest release. The parts that consult git are not
-# covered here: they would need a synthetic repository per case, and what they compute is a
-# commit count rather than a decision.
+# covered case by case: they would need a synthetic repository per case, and what they compute
+# is a commit count rather than a decision. The whole resolver is run once, at the end, against
+# the repository this file is in.
 #
 # That split is deliberate rather than a shortcut. The decisions this file tests are the ones
 # that abort a configure, and each is a rule somebody has to be able to change with confidence
@@ -94,26 +95,51 @@ function(expect_incomparable product a b)
 endfunction()
 
 # The release target is acceptable against this reference release.
-function(expect_target_ok product target reference)
-	gplates_check_release_target(${product} "${target}" "${reference}" "tag-${reference}" 3 _error)
-	if (NOT _error STREQUAL "")
-		_fail("${product} target '${target}' after release '${reference}': expected it to be "
-				"accepted, but got:\n  ${_error}")
+# 'on_line' is whether the reference tag is on HEAD's first-parent line (a release series
+# branch) or off it (the development branch, seen from which every series tag is off the line).
+# An empty 'expected_phrase' means the target is expected to be accepted; otherwise it is
+# expected to be rejected, with a message mentioning the phrase, so that the right one of the
+# refusals is doing the rejecting.
+function(_expect_target product target reference on_line expected_phrase)
+	gplates_check_release_target(${product} "${target}" "${reference}" "tag-${reference}" 3
+			${on_line} _error)
+	if (on_line)
+		set(_seen "after release '${reference}'")
+	else()
+		set(_seen "with '${reference}' released on another branch")
+	endif()
+	if (expected_phrase STREQUAL "")
+		if (NOT _error STREQUAL "")
+			_fail("${product} target '${target}' ${_seen}: expected it to be accepted, but got:"
+					"\n  ${_error}")
+		endif()
+	elseif (_error STREQUAL "")
+		_fail("${product} target '${target}' ${_seen}: expected it to be rejected, but it was "
+				"accepted.")
+	elseif (NOT _error MATCHES "${expected_phrase}")
+		_fail("${product} target '${target}' ${_seen}: rejected, but for the wrong reason - "
+				"expected a message matching '${expected_phrase}', got:\n  ${_error}")
 	endif()
 	set(_failures ${_failures} PARENT_SCOPE)
 endfunction()
 
-# The release target is rejected, and the message mentions 'expected_phrase' so that the right
-# one of the three refusals is doing the rejecting.
+function(expect_target_ok product target reference)
+	_expect_target(${product} "${target}" "${reference}" TRUE "")
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
 function(expect_target_rejected product target reference expected_phrase)
-	gplates_check_release_target(${product} "${target}" "${reference}" "tag-${reference}" 3 _error)
-	if (_error STREQUAL "")
-		_fail("${product} target '${target}' after release '${reference}': expected it to be "
-				"rejected, but it was accepted.")
-	elseif (NOT _error MATCHES "${expected_phrase}")
-		_fail("${product} target '${target}' after release '${reference}': rejected, but for the "
-				"wrong reason - expected a message matching '${expected_phrase}', got:\n  ${_error}")
-	endif()
+	_expect_target(${product} "${target}" "${reference}" TRUE "${expected_phrase}")
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+function(expect_target_ok_off_line product target reference)
+	_expect_target(${product} "${target}" "${reference}" FALSE "")
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+function(expect_target_rejected_off_line product target reference expected_phrase)
+	_expect_target(${product} "${target}" "${reference}" FALSE "${expected_phrase}")
 	set(_failures ${_failures} PARENT_SCOPE)
 endfunction()
 
@@ -193,14 +219,40 @@ expect_target_rejected(pygplates "1.0.2" "1.0.0" "skips past")
 expect_target_rejected(pygplates "1.2.0" "1.0.0" "skips past")
 expect_target_rejected(pygplates "3.0.0" "1.0.0" "skips past")
 
-# After a candidate, only the same release line may follow: another candidate, or the release
-# it was a candidate for. This is the step that must not fire during a real release.
+# After a candidate on this line - the release series branch - only the same release line may
+# follow: another candidate, or the release it was a candidate for. This is the step that must
+# not fire during a real release.
 expect_target_ok(pygplates "1.1.0rc2" "1.1.0rc1")
 expect_target_ok(pygplates "1.1.0" "1.1.0rc1")
 expect_target_rejected(pygplates "1.1.0rc1" "1.1.0rc1" "already been released")
 expect_target_rejected(pygplates "1.1.0a1" "1.1.0rc1" "sorts below")
 expect_target_rejected(pygplates "1.1.1" "1.1.0rc1" "not been finished")
 expect_target_rejected(pygplates "1.2.0" "1.1.0rc1" "not been finished")
+
+# A candidate on another branch - what the development branch sees once the series branch cut
+# from it has its first candidate - binds nothing about its own line. Its head counts as
+# released for the no-skip rule, and staying on that head is refused, because the numbers are
+# being minted over there and this line's count has restarted. The first cut of the candidate
+# rule made no such distinction, and would have stopped every configure on the development
+# branch until the release was final.
+expect_target_ok_off_line(pygplates "1.1.1" "1.1.0rc1")
+expect_target_ok_off_line(pygplates "1.2.0" "1.1.0rc1")
+expect_target_ok_off_line(pygplates "2.0.0" "1.1.0rc1")
+expect_target_ok_off_line(pygplates "1.2.0rc1" "1.1.0rc1")
+expect_target_rejected_off_line(pygplates "1.1.0" "1.1.0rc1" "another branch")
+expect_target_rejected_off_line(pygplates "1.1.0rc2" "1.1.0rc1" "another branch")
+expect_target_rejected_off_line(pygplates "1.1.0rc1" "1.1.0rc1" "already been released")
+expect_target_rejected_off_line(pygplates "1.0.0" "1.1.0rc1" "sorts below")
+expect_target_rejected_off_line(pygplates "1.3.0" "1.1.0rc1" "skips past")
+# A patch candidate on a maintenance series, seen from the development branch, which has long
+# since moved on to the next minor.
+expect_target_ok_off_line(pygplates "1.2.0" "1.1.1rc1")
+expect_target_ok_off_line(gplates "2.7.0" "2.6.1-rc.1")
+# A final release on another branch is treated exactly as one on this line.
+expect_target_ok_off_line(pygplates "1.2.0" "1.1.0")
+expect_target_ok_off_line(pygplates "1.1.1" "1.1.0")
+expect_target_rejected_off_line(pygplates "1.1.0" "1.1.0" "already been released")
+expect_target_rejected_off_line(pygplates "1.3.0" "1.1.0" "skips past")
 
 expect_target_ok(gplates "2.6.0" "2.5.0")
 expect_target_ok(gplates "2.5.1" "2.5.0")
@@ -213,15 +265,22 @@ expect_target_ok(gplates "2.6.0-rc.2" "2.6.0-rc.1")
 expect_target_ok(gplates "2.6.0" "2.6.0-rc.1")
 expect_target_rejected(gplates "2.6.1" "2.6.0-rc.1" "not been finished")
 
-# The state this repository is actually in, so that a mistake here fails the test rather than
-# every configure. Both targets come from 'VersionRelease.cmake'; the nearest releases are
-# 'GPlates-2.5' and 'PyGPlates-1.0.0', which normalise to these.
-expect_target_ok(gplates "${GPLATES_RELEASE_VERSION}" "2.5.0")
-expect_target_ok(pygplates "${PYGPLATES_RELEASE_VERSION}" "1.0.0")
-
 # The hole this check was added to close: verified by hand before it existed, a target of
 # '0.9.0' with 'PyGPlates-1.0.0' long released resolved to '0.9.0.dev49' and exited 0.
 expect_target_rejected(pygplates "0.9.0" "1.0.0" "sorts below")
+
+#
+# The whole resolver, once, against the repository this file is in: the targets in
+# 'VersionRelease.cmake' checked against the real tags, and the git path exercised end to end.
+# A failure aborts with the resolver's own message. (An earlier version of this test wrote the
+# expected nearest releases down as literals, which would have gone red at the first release
+# after it was written; the resolver finds them itself.) In a tree with no usable repository
+# the resolver falls back to the recorded version, so this still passes.
+#
+gplates_resolve_version(gplates _resolved)
+message(STATUS "gplates resolves to ${_resolved}")
+gplates_resolve_version(pygplates _resolved)
+message(STATUS "pygplates resolves to ${_resolved}")
 
 
 if (_failures GREATER 0)

--- a/cmake/modules/VersionFromGitTest.cmake
+++ b/cmake/modules/VersionFromGitTest.cmake
@@ -1,0 +1,230 @@
+##########################################################
+# Tests for the version resolver's pure helper functions #
+##########################################################
+
+#
+# Run with:
+#
+#     cmake -P cmake/modules/VersionFromGitTest.cmake
+#
+# or as the CTest test 'version-resolver-test', which the root 'CMakeLists.txt' registers.
+#
+# This covers only the parts of 'VersionFromGit.cmake' that are pure functions of their
+# arguments - splitting and joining a version, ordering two of them, and checking the
+# hand-edited release target against the nearest release. The parts that consult git are not
+# covered here: they would need a synthetic repository per case, and what they compute is a
+# commit count rather than a decision.
+#
+# That split is deliberate rather than a shortcut. The decisions this file tests are the ones
+# that abort a configure, and each is a rule somebody has to be able to change with confidence
+# - particularly the no-skip policy, which is a convention rather than a correctness
+# requirement, and is meant to be loosenable.
+#
+
+cmake_minimum_required(VERSION 3.22)
+
+include("${CMAKE_CURRENT_LIST_DIR}/VersionFromGit.cmake")
+
+set(_failures 0)
+
+function(_fail message)
+	math(EXPR _n "${_failures} + 1")
+	set(_failures ${_n} PARENT_SCOPE)
+	message(SEND_ERROR "${message}")
+endfunction()
+
+# The version splits into the expected base and development number.
+function(expect_split product version expected_base expected_dev)
+	gplates_split_version(${product} "${version}" _ok _base _dev)
+	if (NOT _ok)
+		_fail("${product} '${version}': expected it to parse, but it did not.")
+	elseif (NOT _base STREQUAL expected_base OR NOT _dev EQUAL expected_dev)
+		_fail("${product} '${version}': split to base '${_base}' dev ${_dev}, "
+				"expected base '${expected_base}' dev ${expected_dev}.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+# The version does not parse, so it is skipped rather than counted from.
+function(expect_no_split product version)
+	gplates_split_version(${product} "${version}" _ok _base _dev)
+	if (_ok)
+		_fail("${product} '${version}': expected it not to parse, but it gave base '${_base}'.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+function(expect_join product base dev expected)
+	gplates_join_version(${product} "${base}" ${dev} _version)
+	if (NOT _version STREQUAL expected)
+		_fail("${product} base '${base}' + dev ${dev}: joined to '${_version}', expected '${expected}'.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+# 'a' sorts strictly below 'b', and 'b' strictly above 'a'.
+function(expect_below product a b)
+	gplates_compare_versions(${product} "${a}" "${b}" _cmp)
+	if (NOT _cmp STREQUAL "-1")
+		_fail("${product}: expected '${a}' to sort below '${b}', got '${_cmp}'.")
+	endif()
+	gplates_compare_versions(${product} "${b}" "${a}" _reverse)
+	if (NOT _reverse STREQUAL "1")
+		_fail("${product}: expected '${b}' to sort above '${a}', got '${_reverse}' - the "
+				"comparison is not antisymmetric.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+function(expect_equal_versions product a b)
+	gplates_compare_versions(${product} "${a}" "${b}" _cmp)
+	if (NOT _cmp STREQUAL "0")
+		_fail("${product}: expected '${a}' and '${b}' to compare equal, got '${_cmp}'.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+# Neither side can be ranked, so the caller is told so rather than given a wrong order.
+function(expect_incomparable product a b)
+	gplates_compare_versions(${product} "${a}" "${b}" _cmp)
+	if (NOT _cmp STREQUAL "")
+		_fail("${product}: expected '${a}' vs '${b}' to be incomparable, got '${_cmp}'.")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+# The release target is acceptable against this reference release.
+function(expect_target_ok product target reference)
+	gplates_check_release_target(${product} "${target}" "${reference}" "tag-${reference}" 3 _error)
+	if (NOT _error STREQUAL "")
+		_fail("${product} target '${target}' after release '${reference}': expected it to be "
+				"accepted, but got:\n  ${_error}")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+# The release target is rejected, and the message mentions 'expected_phrase' so that the right
+# one of the three refusals is doing the rejecting.
+function(expect_target_rejected product target reference expected_phrase)
+	gplates_check_release_target(${product} "${target}" "${reference}" "tag-${reference}" 3 _error)
+	if (_error STREQUAL "")
+		_fail("${product} target '${target}' after release '${reference}': expected it to be "
+				"rejected, but it was accepted.")
+	elseif (NOT _error MATCHES "${expected_phrase}")
+		_fail("${product} target '${target}' after release '${reference}': rejected, but for the "
+				"wrong reason - expected a message matching '${expected_phrase}', got:\n  ${_error}")
+	endif()
+	set(_failures ${_failures} PARENT_SCOPE)
+endfunction()
+
+
+#
+# Splitting.
+#
+expect_split(gplates "2.6.0" "2.6.0" 0)
+expect_split(gplates "2.6.0-8" "2.6.0" 8)
+expect_split(gplates "2.6.0-rc.1" "2.6.0-rc.1" 0)
+expect_split(gplates "2.6.0-rc.1.8" "2.6.0-rc.1" 8)
+# Two-component release tags are normalised, which is what lets 'GPlates-2.5' be counted from.
+expect_split(gplates "2.5" "2.5.0" 0)
+expect_split(pygplates "1.1.0" "1.1.0" 0)
+expect_split(pygplates "1.1.0.dev10" "1.1.0" 10)
+expect_split(pygplates "1.1.0rc1" "1.1.0rc1" 0)
+expect_split(pygplates "1.1.0rc1.dev5" "1.1.0rc1" 5)
+expect_split(pygplates "0.36" "0.36.0" 0)
+
+# The tags in this repository that must be skipped rather than counted from.
+expect_no_split(gplates "1.5+hellinger-testing")
+expect_no_split(gplates "0.9.10.1")
+
+#
+# Joining. A development number is appended with '-' to a plain GPlates version and with '.' to
+# one that already carries a pre-release suffix, which keeps both the SemVer and the Debian
+# orderings intact.
+#
+expect_join(gplates "2.6.0" 0 "2.6.0")
+expect_join(gplates "2.6.0" 8 "2.6.0-8")
+expect_join(gplates "2.6.0-rc.1" 8 "2.6.0-rc.1.8")
+expect_join(pygplates "1.1.0" 0 "1.1.0")
+expect_join(pygplates "1.1.0" 10 "1.1.0.dev10")
+expect_join(pygplates "1.1.0rc1" 5 "1.1.0rc1.dev5")
+
+#
+# Ordering. The case that matters most is a candidate against its release: CMake's own
+# VERSION_LESS reads '1.1.0rc1' and '1.1.0' as equal, so the resolver cannot use it.
+#
+expect_below(pygplates "1.1.0rc1" "1.1.0")
+expect_below(pygplates "1.1.0a1" "1.1.0b1")
+expect_below(pygplates "1.1.0b1" "1.1.0rc1")
+expect_below(pygplates "1.1.0rc1" "1.1.0rc2")
+expect_below(pygplates "1.1.0" "1.1.0.post1")
+expect_below(pygplates "1.0.0" "1.1.0")
+expect_below(pygplates "1.9.0" "1.10.0")
+expect_equal_versions(pygplates "1.1.0" "1.1.0")
+
+expect_below(gplates "2.6.0-alpha.1" "2.6.0-beta.1")
+expect_below(gplates "2.6.0-beta.1" "2.6.0-rc.1")
+expect_below(gplates "2.6.0-rc.1" "2.6.0")
+expect_below(gplates "2.5.0" "2.6.0")
+
+# An unrankable base is reported as such, so that a tag nobody anticipated cannot silently
+# order itself first.
+expect_incomparable(gplates "2.6.0" "not-a-version")
+
+#
+# The release target, checked against the nearest release. The table below is the one in
+# 'gplates_check_release_target'.
+#
+# After a plain release, the next patch, minor or major is allowed - and a candidate of any of
+# them - while anything further ahead is a skipped release.
+#
+expect_target_ok(pygplates "1.0.1" "1.0.0")
+expect_target_ok(pygplates "1.1.0" "1.0.0")
+expect_target_ok(pygplates "2.0.0" "1.0.0")
+expect_target_ok(pygplates "1.0.1rc1" "1.0.0")
+expect_target_ok(pygplates "1.1.0rc1" "1.0.0")
+# A post-release republishes the same version, so it keeps the head it follows.
+expect_target_ok(pygplates "1.0.0.post1" "1.0.0")
+
+expect_target_rejected(pygplates "1.0.0" "1.0.0" "already been released")
+expect_target_rejected(pygplates "0.9.0" "1.0.0" "sorts below")
+expect_target_rejected(pygplates "1.0.0rc2" "1.0.0" "sorts below")
+expect_target_rejected(pygplates "1.0.2" "1.0.0" "skips past")
+expect_target_rejected(pygplates "1.2.0" "1.0.0" "skips past")
+expect_target_rejected(pygplates "3.0.0" "1.0.0" "skips past")
+
+# After a candidate, only the same release line may follow: another candidate, or the release
+# it was a candidate for. This is the step that must not fire during a real release.
+expect_target_ok(pygplates "1.1.0rc2" "1.1.0rc1")
+expect_target_ok(pygplates "1.1.0" "1.1.0rc1")
+expect_target_rejected(pygplates "1.1.0rc1" "1.1.0rc1" "already been released")
+expect_target_rejected(pygplates "1.1.0a1" "1.1.0rc1" "sorts below")
+expect_target_rejected(pygplates "1.1.1" "1.1.0rc1" "not been finished")
+expect_target_rejected(pygplates "1.2.0" "1.1.0rc1" "not been finished")
+
+expect_target_ok(gplates "2.6.0" "2.5.0")
+expect_target_ok(gplates "2.5.1" "2.5.0")
+expect_target_ok(gplates "3.0.0" "2.5.0")
+expect_target_ok(gplates "2.6.0-rc.1" "2.5.0")
+expect_target_rejected(gplates "2.5.0" "2.5.0" "already been released")
+expect_target_rejected(gplates "2.4.0" "2.5.0" "sorts below")
+expect_target_rejected(gplates "2.7.0" "2.5.0" "skips past")
+expect_target_ok(gplates "2.6.0-rc.2" "2.6.0-rc.1")
+expect_target_ok(gplates "2.6.0" "2.6.0-rc.1")
+expect_target_rejected(gplates "2.6.1" "2.6.0-rc.1" "not been finished")
+
+# The state this repository is actually in, so that a mistake here fails the test rather than
+# every configure. Both targets come from 'VersionRelease.cmake'; the nearest releases are
+# 'GPlates-2.5' and 'PyGPlates-1.0.0', which normalise to these.
+expect_target_ok(gplates "${GPLATES_RELEASE_VERSION}" "2.5.0")
+expect_target_ok(pygplates "${PYGPLATES_RELEASE_VERSION}" "1.0.0")
+
+# The hole this check was added to close: verified by hand before it existed, a target of
+# '0.9.0' with 'PyGPlates-1.0.0' long released resolved to '0.9.0.dev49' and exited 0.
+expect_target_rejected(pygplates "0.9.0" "1.0.0" "sorts below")
+
+
+if (_failures GREATER 0)
+	message(FATAL_ERROR "${_failures} version-resolver test(s) failed.")
+endif()
+message(STATUS "All version-resolver tests passed.")

--- a/cmake/modules/VersionRelease.cmake
+++ b/cmake/modules/VersionRelease.cmake
@@ -27,7 +27,7 @@
 #          version only if that release turns out to contain no new API. Waiting until the API
 #          actually changes only risks nobody remembering to do it.
 #
-# 2. On a release branch ('release/pygplates-<version>' etc), to name the candidate being
+# 2. On a release series branch ('release/pygplates-<major>.<minor>' etc), to name the release being
 #    prepared - eg, set the target to '1.1.0rc1' on cutting the branch, to '1.1.0rc2' if a
 #    second candidate is needed, and to '1.1.0' for the release itself. Development commits on
 #    the release branch then carry '1.1.0rc1.dev3' and so on.

--- a/cmake/modules/VersionRelease.cmake
+++ b/cmake/modules/VersionRelease.cmake
@@ -39,6 +39,12 @@
 # A target must NOT carry a development suffix ('2.6.0-8', '1.1.0.dev10') - that part is what
 # gets counted. The resolver rejects one that does.
 #
+# The resolver also checks the target against the nearest release, and aborts the configure if it
+# does not sort above it or if it skips a version - so a target left behind, set backwards, or
+# mistyped one release too far ahead is a loud failure rather than a package nobody can install
+# over. 'gplates_check_release_target' in 'VersionFromGit.cmake' has the rules and the reasoning;
+# 'VersionFromGitTest.cmake' has them as tests.
+#
 
 # The GPlates release target - a restricted Semantic Version 'X.Y.Z' or 'X.Y.Z-{alpha|beta|rc}.N'.
 set(GPLATES_RELEASE_VERSION 2.6.0)

--- a/cmake/modules/VersionRelease.cmake
+++ b/cmake/modules/VersionRelease.cmake
@@ -11,10 +11,12 @@
 #
 # There are exactly two times to edit this file:
 #
-# 1. When a release changes what the *next* release will be called. Immediately after tagging
-#    'PyGPlates-1.1.0', for instance, the pyGPlates target becomes '1.2.0' - otherwise the next
-#    development version would be '1.1.0.dev1', which sorts *below* the 1.1.0 just released
-#    (the resolver refuses to produce that, rather than letting it reach a package).
+# 1. On the development branch, the moment a release series branch cut from it gets its first
+#    tag - a candidate ('PyGPlates-1.1.0rc1') or the release itself. The pyGPlates target then
+#    becomes '1.2.0'. The 1.1.0 line now lives on the series branch, and the development
+#    branch's count restarts from the branch point, so left on '1.1.0' it would re-issue
+#    versions it has already used - and, once 1.1.0 is released, ones sorting *below* it. The
+#    resolver refuses both, rather than letting either reach a package.
 #
 #    Note: What that next target should be is a decision about the next *release*, not about
 #          any one commit. A release that adds API (a new function or class) should be a new

--- a/doc-cpp/design/architecture/README.md
+++ b/doc-cpp/design/architecture/README.md
@@ -119,8 +119,7 @@ Enforcement, in CTest (run `ctest --test-dir <build-pygplates> -C Release`):
   classification path.
 - Physically move the `app-logic` layers machinery into its own directory, and the ~17
   embedded-interpreter files out of `src/api/` (they serve `gui/PythonManager`, not the API).
-  Directory moves multiply merge risk across the two develop branches, the `vulkan` branch
-  and the downstream fork, so this waits for a dedicated both-develop-branches commit at a
-  quiet merge point.
+  Directory moves multiply merge risk across the `vulkan` branch and the downstream fork, so
+  this waits for a dedicated commit at a quiet merge point.
 - Dissolve `src/feature-visitors/` and delete the dead `deprecated/` subtrees (separate PR,
   already planned).

--- a/doc-cpp/design/testing/README.md
+++ b/doc-cpp/design/testing/README.md
@@ -13,12 +13,12 @@ What exists (as of the GoogleTest migration, 2026):
   registered individually with CTest via `gtest_discover_tests()`, so `ctest` runs them in
   parallel, `ctest -R <pattern>` targets them, and `ctest --rerun-failed` works at test-case
   granularity. CI runs them on Linux/macOS/Windows via
-  `.github/workflows/build-test-gplates.yml` (the `gplates` branch).
+  `.github/workflows/build-test-gplates.yml`.
 - **pyGPlates tests** — Python `unittest` suite in `pygplates/test/`, registered with CTest as
   `pygplates-test` (plus `pygplates-stub-test` for the `.pyi` stub) in pyGPlates build configs
-  (`GPLATES_BUILD_GPLATES=FALSE`). CI runs them via `.github/workflows/build-test-pygplates.yml`
-  (the `pygplates` branch). These cover the pyGPlates API surface (app-logic, maths, model) and
-  are documented separately.
+  (`GPLATES_BUILD_GPLATES=FALSE`). CI runs them via `.github/workflows/build-test-pygplates.yml`.
+  These cover the pyGPlates API surface (app-logic, maths, model) and are documented
+  separately.
 
 The two suites are complementary, not redundant: the pyGPlates suite exercises the
 reconstruction/model machinery through the public Python API; the C++ suite exercises what the
@@ -117,9 +117,11 @@ take everything.
 
 ## CI notes
 
-- The two workflows are branch-scoped: `build-test-gplates.yml` on `gplates`,
-  `build-test-pygplates.yml` on `pygplates`. The branches are normally at the same HEAD, so the
-  per-branch split covers both products without doubling CI cost.
+- Both workflows run on every push to `gplates` and on every pull request based on it, so each
+  push builds and tests both products. Until the two develop branches were unified (2026-09)
+  each workflow ran only on its own branch and built only its own product, and a change to the
+  shared sources could break the other product undetected until the next sync merge — see
+  `doc-cpp/design/versioning/README.md`.
 - sccache cache keys are namespaced per product (`sccache-gplates-*` and `sccache-pygplates-*`):
   `gplates` is the repository's *default* branch, so its caches are visible to every ref, and the
   two build configurations share no cache entries (every common translation unit differs in

--- a/doc-cpp/design/versioning/README.md
+++ b/doc-cpp/design/versioning/README.md
@@ -286,10 +286,29 @@ Four checks abort the configure rather than let a bad version reach a package:
    | reference | allowed targets | rejected |
    |---|---|---|
    | `1.0.0` (a release) | `1.0.1`, `1.1.0`, `2.0.0`, and candidates of those (`1.0.1rc1`, …) | `1.0.2`, `1.2.0`, `3.0.0`, `1.0.0rc2` |
-   | `1.0.0rc1` (a candidate) | `1.0.0rc2`, `1.0.0` | `1.0.1`, `1.1.0` |
+   | `1.0.0rc1` (a candidate on this line) | `1.0.0rc2`, `1.0.0` | `1.0.1`, `1.1.0` |
+   | `1.0.0rc1` (a candidate on another branch) | `1.0.1`, `1.1.0`, `2.0.0`, and candidates of those | `1.0.0`, `1.0.0rc2`, `1.0.2`, `1.2.0` |
 
-   The reference's own head is permitted only so that a candidate can be followed by another
-   candidate or by the release; after a final release, same-head targets are rejected by check 3.
+   A candidate binds only the line it is on. Whether the reference tag is on HEAD's first-parent
+   line is decided by walking back `HEAD~n`, with `n` the reference's distance: `~` follows first
+   parents, so that commit is the tag's own if the tag is on the line, and otherwise the commit
+   the series branch was cut from. On the line — the series branch, or a patch branch off it —
+   only the candidate's own head may follow, as another candidate or as the release. Off the
+   line — the development branch once the series branch cut from it has its first candidate, or
+   a feature branch cut before then — the candidate's head counts as released, and *staying* on
+   it is refused: the `1.1.0` line has moved to the series branch, which is minting
+   `1.1.0rc1.devN`, and the development branch's count has restarted from the branch point
+   (section 8.2), so left on `1.1.0` it would re-issue `1.1.0.dev1`, `dev2`, … for new commits.
+   After a final release, same-head targets are rejected by check 3 wherever the tag is.
+
+   The first cut of this rule made no on-line/off-line distinction, and a review before the
+   branch merged found what that meant: the first candidate on *any* series branch became the
+   development branch's reference (every series tag ties at the branch point, and the highest
+   base wins), so every configure there aborted until the release was final — and, because both
+   versions are always resolved, a GPlates candidate stopped every pyGPlates build too. The only
+   accepted target in that window was the candidate's own head, which is the one that re-issues
+   numbers. Hence the distinction, and the extra rows in the scenario table below.
+
    **This one is policy, not correctness**, and the error message says so, because it can be
    loosened without breaking anything. The evidence supports it: the GPlates release line has no
    skips (the apparent `0.9.5` → `0.9.7.1` gap is a released 0.9.6 whose tag went missing, and the
@@ -313,13 +332,19 @@ tag supplies the count, and is computed separately:
 
 **The honest limit of checks 3 and 4:** they catch a target set backwards or skipping, not a typo
 that lands one step forwards. `1.10` normalises to `1.10.0` and, from a `1.9.0` reference, is a
-legitimate next minor.
+legitimate next minor. And they judge a commit by the tags that exist *now*: a development
+commit made after a series branch was cut but before the target was bumped configured fine when
+it was made, and fails ("already released", or "being released on another branch") when
+`git bisect` revisits it after the tags exist. Bumping the target in the same sitting as the cut
+keeps that window empty; a bisect that lands in it anyway can pass the version as a `-D` define.
 
 The pure parts of the resolver — splitting, joining, ordering and the target checks — are tested
 by `cmake/modules/VersionFromGitTest.cmake`, registered with CTest as `version-resolver-test` in
-both build trees, and runnable directly with `cmake -P`. The tests include the repository's
-actual targets against its actual nearest releases, so a mistake in `VersionRelease.cmake` fails
-one test rather than every configure.
+both build trees, and runnable directly with `cmake -P`. It ends by running the whole resolver
+once against the repository it is in, so the git path gets exercised and a mistake in
+`VersionRelease.cmake` fails a test as well as the configure. (An earlier version wrote the
+expected nearest releases down as literals, `2.5.0` and `1.0.0`, which would have gone red at the
+first release after it was written; the resolver finds them itself.)
 
 ### 7.3 Worked scenarios
 
@@ -330,6 +355,9 @@ pyGPlates unless stated; `T` is the target in `VersionRelease.cmake`.
 | development branch, 46 first-parent commits past the last release | `1.1.0` | `PyGPlates-1.0.0`, dev 0, distance 46 | `1.1.0.dev46` |
 | series branch cut, preparing the first candidate | `1.1.0rc1` | `PyGPlates-1.0.0`, distance 48 | `1.1.0rc1.dev48` |
 | standing on the tag `PyGPlates-1.1.0rc1` | `1.1.0rc1` | at HEAD, dev 0, base = T | `1.1.0rc1` |
+| development branch, 2 commits after the series branch was cut, target not moved | `1.1.0` | `PyGPlates-1.1.0rc1`, distance 2, off the line | **fatal** — `1.1.0` is being released on another branch; set T to `1.2.0` |
+| same, target moved on | `1.2.0` | `PyGPlates-1.1.0rc1`, distance 2 | `1.2.0.dev2` |
+| a feature branch cut before the series branch, not yet merged with the development branch | `1.1.0` | `PyGPlates-1.1.0rc1`, off the line | **fatal** — merge the development branch in |
 | two commits later, a second candidate decided | `1.1.0rc2` | `PyGPlates-1.1.0rc1`, distance 2 | `1.1.0rc2.dev2` |
 | standing on the release tag `PyGPlates-1.1.0` | `1.1.0` | at HEAD, dev 0, base = T | `1.1.0` |
 | … but the target was never moved off `1.0.0` | `1.0.0` | at HEAD, base ≠ T | **fatal** — set T to `1.1.0` |
@@ -376,13 +404,18 @@ branch and cannot contribute. The tie is harmless — both carry development num
 emitted version is identical — and the guards choose their reference release separately from the
 count (section 7.2).
 
-### 8.2 When a release is tagged, N on the development branch drops
+### 8.2 When a series branch gets its first tag, N on the development branch drops
 
-Because of 8.1, the moment `PyGPlates-1.1.0` is tagged the development branch starts counting from
-a much later branch point, and N falls from, say, 120 to 3. That is safe only because the release
-target must be bumped at the same moment — and guard 2 makes it compulsory, since leaving the
-target on the version just released is exactly what it refuses. So the base rises as the counter
-falls, and the emitted version still moves forward: `2.6.0-120` → `2.7.0-3`.
+Because of 8.1, the moment the first tag lands on a series branch — `PyGPlates-1.1.0rc1`, or
+`PyGPlates-1.1.0` if there was no candidate — the development branch starts counting from a much
+later branch point, and N falls from, say, 120 to 3. That is safe only because the release target
+must be bumped at the same moment, and the guards make it compulsory in both cases: after a
+release, leaving the target on the version just released is exactly what guard 2 refuses; after
+a candidate, the off-the-line rule in guard 4 refuses the candidate's head for the same reason.
+So the base rises as the counter falls, and the emitted version still moves forward:
+`2.6.0-120` → `2.7.0-3`. (Before that rule was line-aware, the candidate case was the opposite:
+the bump was *forbidden*, and the development branch re-issued `1.1.0.dev1`, `dev2`, … for new
+commits until the release was final — section 7.2.)
 
 ### 8.3 The number is monotonic along one first-parent line, not across lines
 

--- a/doc-cpp/design/versioning/README.md
+++ b/doc-cpp/design/versioning/README.md
@@ -34,8 +34,16 @@ The rules that follow from it:
   candidates, the release, and each later patch release are successive commits on the one
   branch, so its tip is always the newest X.Y.z.
 - **There is no permanent 'production' branch and no `hotfix/` concept.** A patch is a commit on
-  the series branch, tagged there; a patch that also applies to the development branch is merged
-  there too.
+  the series branch, tagged there.
+- **Fixes move between the lines by cherry-pick, never by merging a series branch into the
+  development branch.** A fix wanted on both lines normally lands on the development branch
+  first and is cherry-picked (`git cherry-pick -x`) to the series, which is what GDAL's and
+  QGIS's backport bots do; one made on the series first is cherry-picked forward the same way.
+  Only the target-bump commits touch `VersionRelease.cmake`, and those are never cherry-picked,
+  so nothing conflicts. A *merge* would: both sides have changed that file since the branch
+  point (the series to `1.1.0rc1`, `1.1.0`, `1.1.1`; the development branch to `1.2.0`), so it
+  conflicts every time — and the one time it would not, because the development branch's copy
+  had not changed yet, is the fast-forward that hands it the series' target (section 8.1).
 - **A series branch is cut when the first release in the series is prepared**, not before. A
   branch cut ahead of need is an empty branch. As of 2026-09-12 none has been cut yet; the first
   will be `release/pygplates-1.1`.
@@ -473,6 +481,27 @@ default branch `gplates`, 2026-09-11) is to do that rather than to change the re
 editing `GPLATES_RELEASE_VERSION` to `2.7.0` while upstream is on `2.6` produces two different
 projects both publishing something called GPlates 2.7.0, and the no-skip guard now refuses the
 larger jumps anyway.
+
+**A fork has no tags to begin with.** GitHub copies none into a fork — checked on 2026-09-12: the
+three active forks hold one tag between them, and it is the fork's own — and a fetch of one
+branch brings only the tags on it, while release tags live on the series branches. With no
+`GPlates-*` or `PyGPlates-*` tags the resolver has nothing to count from, and it stops there,
+saying so and naming the remedy, rather than falling through to the fallbacks for a tree with
+no repository and blaming the wrong thing:
+
+```
+git fetch --tags <upstream>
+git fetch <upstream> 'refs/tags/GPlates-*:refs/tags/GPlates-*' 'refs/tags/PyGPlates-*:refs/tags/PyGPlates-*'   # or just the release tags
+git push <fork> --tags
+```
+
+The push is what gives the fork's own clones and its CI the tags. It wants repeating after each
+upstream series cut: otherwise, once upstream's target moves past a release the fork has never
+seen, the no-skip guard fires — and its message says to fetch tags first. A plain `git clone`
+is unaffected, since it fetches every tag whichever branch it asks for (verified: a clone of the
+development branch alone carried all 258 tags and resolved both versions). Everything on the
+public remote is a `GPlates-*` or `PyGPlates-*` tag, and the resolver ignores any other prefix,
+so fetching all tags is safe.
 
 ## 10. Recipes
 

--- a/doc-cpp/design/versioning/README.md
+++ b/doc-cpp/design/versioning/README.md
@@ -335,8 +335,11 @@ that lands one step forwards. `1.10` normalises to `1.10.0` and, from a `1.9.0` 
 legitimate next minor. And they judge a commit by the tags that exist *now*: a development
 commit made after a series branch was cut but before the target was bumped configured fine when
 it was made, and fails ("already released", or "being released on another branch") when
-`git bisect` revisits it after the tags exist. Bumping the target in the same sitting as the cut
-keeps that window empty; a bisect that lands in it anyway can pass the version as a `-D` define.
+`git bisect` revisits it after the tags exist. Making the bump the *first* commit after the cut
+keeps that window empty — the cut commit itself is an ancestor of the series tag, so the tag is
+skipped there and that commit still counts from the older release — and it is only non-empty if
+something else lands on the development branch in between. A bisect that lands in it anyway can
+pass the version as a `-D` define.
 
 The pure parts of the resolver — splitting, joining, ordering and the target checks — are tested
 by `cmake/modules/VersionFromGitTest.cmake`, registered with CTest as `version-resolver-test` in

--- a/doc-cpp/design/versioning/README.md
+++ b/doc-cpp/design/versioning/README.md
@@ -377,8 +377,12 @@ Each is surprising the first time a developer meets it.
 ### 8.1 On the development branch, the count runs from the branch point, not from the tag
 
 A release tag sits on a series branch, so it is never on the development branch's first-parent
-line — whether or not the series branch is merged back, since such a merge takes the series branch
-as its *second* parent. That sounds like a problem and is not: the count from such a tag equals
+line. (Series branches are not merged back — a fix wanted on both lines lands on the development
+branch and is cherry-picked to the series, which is what GDAL's and QGIS's backport bots do — and
+a merge would carry the series branch's release target with it. Were one ever merged, it would
+have to be with `--no-ff`: a fast-forward puts the tags on the line and hands the development
+branch the series' target, with no guard firing.) That sounds like a problem and is not: the
+count from such a tag equals
 the count from the commit the series branch was **cut from**. Everything reachable from the tag,
 including the branch point and all history before it, is excluded, and the series branch's own
 commits were never on the development line to begin with.
@@ -451,9 +455,11 @@ reference release.
 **Upstream depends on one right now.** The `gplates` branch's first-parent line runs back through
 the 2013 `python-api` branch, and no ancestor of any GPlates release tag newer than that sits on
 it, so without `GPlates-2.6.0-47` the count runs from 2013 and gives `2.6.0-1206`. Deleting the
-tag would silently restore the larger number. It stops being load-bearing when
-`release/gplates-2.6` is cut and `GPlates-2.6.0` tagged there, because that tag is then the
-nearest.
+tag would silently restore the larger number. Once `release/gplates-2.6` is cut and
+`GPlates-2.6.0` tagged there, the tip counts from that tag instead — but every commit between the
+anchor and the branch point still counts from the anchor (a tag HEAD is an ancestor of scores 0
+and is skipped, so the anchor is the nearest tag again), and those are exactly the commits
+`git bisect` walks. So the anchor stays load-bearing for its stretch of history: never delete it.
 
 **A fork keeps its own numbers with one.** Commits on a fork advance its own first-parent line,
 so by default a fork mints the same development version strings as upstream for different code.
@@ -536,7 +542,7 @@ second parent**, and pushed to `gplates` as a fast-forward:
 
 ```
 git checkout pygplates && git merge --no-ff gplates
-git push public HEAD:gplates
+git push <remote> HEAD:gplates
 ```
 
 Three details mattered:

--- a/doc-cpp/design/versioning/README.md
+++ b/doc-cpp/design/versioning/README.md
@@ -1,0 +1,546 @@
+# Branches and versions
+
+How this repository is branched, how a version is chosen, and why. It is a decision record — what
+was chosen, what was rejected, and the evidence — rather than a tutorial: `README.md` at the
+repository root is the "how do I use this repository" document, and links here.
+
+The two development branches were unified on 2026-09-12. Everything below was measured in the
+days around that, and is dated wherever it will go stale.
+
+## 1. The decision
+
+Before (four permanent branches, gitflow):
+
+```
+gplates    (default) ──┐                 release-gplates    ← GPlates release tags
+pygplates  ────────────┘  near-identical  release-pygplates  ← pyGPlates release tags
+                                          release/<product>-<version>   temporary
+                                          hotfix/<product>-<version>    temporary
+```
+
+After (one permanent branch, plus one per release series):
+
+```
+gplates                    permanent, the default: both products are developed here
+release/gplates-2.6        permanent, carries 2.6.0, 2.6.1, …
+release/pygplates-1.1      permanent, carries 1.1.0rc1, 1.1.0, 1.1.1, …
+feature/<name>, fix/<name>     temporary, off the development branch
+<patch branches>               temporary, off a release series branch
+```
+
+The rules that follow from it:
+
+- **Release tags live only on release series branches**, never on the development branch. The
+  candidates, the release, and each later patch release are successive commits on the one
+  branch, so its tip is always the newest X.Y.z.
+- **There is no permanent 'production' branch and no `hotfix/` concept.** A patch is a commit on
+  the series branch, tagged there; a patch that also applies to the development branch is merged
+  there too.
+- **A series branch is cut when the first release in the series is prepared**, not before. A
+  branch cut ahead of need is an empty branch. As of 2026-09-12 none has been cut yet; the first
+  will be `release/pygplates-1.1`.
+- **Series branches are never deleted.** GDAL keeps 29 and QGIS 71 (section 4); a branch ref
+  costs nothing, and deleting one loses the "check out the latest 2.6.x" contract for that series.
+- The development branch keeps the name `gplates` for now and will be renamed `main` in a
+  separate change (section 12).
+
+This is the trunk-plus-release-series model that QGIS, GDAL, CGAL, LLVM and CPython use. It is no
+longer gitflow, and section 3 says why.
+
+## 2. Why one development branch
+
+Until 2026-09-12 there were two, `gplates` and `pygplates`, one per product, kept close by sync
+merges in both directions. Both products could be built from either, so the split bought nothing
+on its own; what it cost was measured while deciding to end it.
+
+**Every change had to be synced, and the sync merge is where problems surfaced.** A defect
+written on one branch became visible on the other only when merged across, weeks later, where it
+looked like the merge's fault. The clearest case arrived while this change was being planned.
+`GeoscimlReaderTest` was written on `pygplates`, where the GPlates unit tests never run. The sync
+merge `86cebd62f` (2026-09-11) was the first time it had ever executed on any platform's GPlates
+CI, and two of its cases failed on macOS. Nothing about the merge was wrong: the test had been
+reading freed memory since the day it was written (`only_geometry()` returns a
+`non_null_ptr_to_const_type` by value and the test kept only the raw pointer, which happened to
+stay valid for every geometry type but `gml:Point`), and only macOS's allocator dirties freed
+memory. The same merge also left `pygplates-source-closure-test` failing on `gplates` for a
+regenerated-doc drift that only a pyGPlates build could see. Both were fixed as PR #70, a month
+after they were introduced.
+
+**CI covered only one product per branch.** Each workflow ran on its own branch and built its own
+product, so a change to the shared sources or the CMake source lists could break the other product
+undetected. `AGENTS.md` had recorded this as a known gap and deferred it as a maintainer decision.
+One branch cannot have a per-product push filter, so unifying the branches forced the decision:
+**both products are now built on every push**. The added cost is less than it looks. The two
+sccache namespaces are disjoint (every shared translation unit differs in `-fPIC` and
+`GPLATES_PYTHON_EMBEDDING`), so the second build cannot evict the first's entries, and a change
+that touches only one product hits the cache almost entirely for the other.
+
+**The split also kept the compiler cache cold.** Measured across four `gplates` CI runs
+(2026-09-11):
+
+| run | sccache hit rate | why |
+|---|---|---|
+| 18 Aug, two pushes hours apart | 99.50% on all three platforms | ordinary incremental pushes |
+| 6 Sept sync merge | 0% | no `gplates` run for 19 days, and GitHub evicts a cache untouched for 7 |
+| 10 Sept sync merge | 0% | a cache was restored, but the merge brought 285 lines of `src/CMakeLists.txt` plus three other CMake files, and sccache keys on the command line as well as the source |
+| 10 Sept, same push, `pygplates` | 98.90% | small incremental push |
+
+So `gplates` scored 99.5% on the days it had nothing to compile and 0% on the days it did: its
+real work arrived as occasional large merges, far enough apart to expire the cache and large
+enough to invalidate what survived. With one branch every push is small and frequent, which is the
+regime that already measured 98–99%.
+
+**The two version counters drifted.** The development number is a first-parent count (section 7),
+and each branch counts its own line. A merge adds exactly one commit to the receiving line however
+many it carries, so routine syncing never converged them:
+
+| measured | `gplates` | `pygplates` |
+|---|---|---|
+| 2026-09-10 | `1.1.0.dev40` / `2.6.0-47` | `1.1.0.dev46` / `2.6.0-54` |
+| 2026-09-11, after PR #69 was synced | `1.1.0.dev41` / `2.6.0-48` | `1.1.0.dev47` / `2.6.0-55` |
+| 2026-09-12, after PR #70 | `1.1.0.dev42` / `2.6.0-49` | `1.1.0.dev47` / `2.6.0-55` |
+
+Two branches minting different numbers for the same product is tolerable only while nothing
+publishes from the lower one. It also decided how the unification had to be done (section 11).
+
+## 3. Why development happens on the default branch
+
+gitflow's defining feature is that `master` holds the production-ready state and development
+happens elsewhere. The default branches of GPlates' peers, queried live on 2026-09-11:
+
+| repository | default branch | shape |
+|---|---|---|
+| qgis/QGIS | `master` | development; `release-3_44`, `release-4_0`, … per series |
+| OSGeo/gdal | `master` | development; `release/1.4` … `release/3.13` per series |
+| OSGeo/PROJ | `master` | development |
+| Kitware/VTK | `master` | development, plus a rolling `release` branch |
+| CGAL/cgal | `main` | development; `6.1.x-branch`, `6.2.x-branch` |
+| llvm/llvm-project | `main` | development; `release/N.x` |
+| python/cpython | `main` | development; `3.12`, `3.13`, … |
+| numpy/numpy, scikit-learn/scikit-learn | `main` | development |
+| qt/qtbase | `dev` | development |
+| opencv/opencv | `5.x` | the next major's development branch |
+| nvie/gitflow | `develop` | gitflow, by its author |
+| boostorg/boost | `master` | gitflow proper: `master` (stable) + `develop`, default `master` |
+
+Among the projects that resemble GPlates — C++, versioned, desktop, geospatial or scientific — the
+pattern is near-unanimous: **the default branch is where development happens**, and "production"
+is expressed as per-series release branches and tags. Boost is the one real counter-example and
+the closest thing to a control. (Boost's branch list also carries `feature/gha` and
+`fix/boost-1.91.0-gh-release`, independent corroboration of the `fix/<name>` convention here.)
+
+gitflow's author reached a similar view. Vincent Driessen added a reflection to *A successful Git
+branching model* on 5 March 2020: the model still suits teams "building explicitly versioned
+software or maintaining multiple versions in production" — GPlates qualifies — but it came to be
+applied dogmatically, and "panaceas don't exist. Consider your own context." The part that has
+aged is specifically `master = production-ready`. It rests on a 2010 assumption that cloning is
+how users obtain software. For GPlates it is not: GPlates users take binaries from gplates.org,
+pyGPlates users take wheels from PyPI and packages from conda-forge. The people who clone are
+developers and packagers, and GitHub's Releases page and the tags serve "give me the production
+state" better than a branch does.
+
+## 4. Why permanent per-series branches
+
+Release branches are kept forever by the peers that have them, and the reason is patching, not
+archival. Counted with full pagination (2026-09-11):
+
+- GDAL: 29 `release/X.Y` branches, `release/1.4` through `release/3.13`. None deleted.
+- QGIS: 71 `release-X_Y` branches, `release-0_0_11` through `release-4_2`. None deleted.
+
+GDAL's `release/3.8` branch carries 18 tags:
+
+```
+v3.8.0beta1 v3.8.0RC1 v3.8.0RC2 v3.8.0
+v3.8.1RC1 v3.8.1RC2 v3.8.1RC3 v3.8.1
+v3.8.2RC1 v3.8.2  v3.8.3RC1 v3.8.3RC2 v3.8.3RC3 v3.8.3
+v3.8.4RC1 v3.8.4  v3.8.5RC1 v3.8.5
+```
+
+One branch, six public releases, one preparation period; and its in-flight list showed
+`backport-15205-to-release/3.13`, the short-lived patch branch pattern.
+
+**This is why the permanent branch is named per series, not per version.** A branch is worth
+keeping alive only if commits will be added to it later. A tag already names a commit, keeps it
+reachable and is checkout-able, and does it better, being immutable; a branch that will never
+receive another commit is only a second, mutable name for a commit the tag already names.
+`release/gplates-2.6.0` is frozen the moment `GPlates-2.6.0` is tagged on it, since a released
+version's content cannot change, so a 2.6.1 fix forces either a false name or a new branch per
+patch, and in both cases "kept alive" is doing no work. `release/gplates-2.6` describes an ongoing
+line: the tip is always the newest 2.6.x, and it is the unambiguous backport target.
+
+## 5. What was rejected
+
+- **Keeping gitflow.** Sections 2 and 3. Its permanent production branch answered a question
+  ("what is released?") that tags and the Releases page answer better, and its two-develop-branch
+  form here had measurable costs.
+- **One interleaved release branch for both products.** The two `release-*` branches were
+  justified only by there being two products, so merging them into one was considered. With one
+  branch the tip means "the state at the most recent release of *either* product", so checking it
+  out to build GPlates right after a pyGPlates release gives an untested GPlates, which breaks the
+  "check out this branch to compile the release" contract. Per-series branches solve the same
+  problem better, being scoped to one product *and* one release line.
+- **A release branch per version.** Section 4.
+- **Cutting series branches in advance.** An empty branch, and a name that implies a release is
+  being prepared when it is not.
+- **Renaming the development branch to `main` in the same change.** Deferred (section 12) because
+  it is the only step that disturbs the downstream forks, and doing everything else first meant
+  everything else could land immediately.
+
+## 6. What deleting `release-gplates` and `release-pygplates` lost: nothing
+
+Verified with `git merge-base --is-ancestor` before deletion:
+
+- `release-gplates`'s tip `f31ac9455` is tagged `GPlates-2.5`.
+- `release-pygplates`'s tip `27d48c91f` is tagged `PyGPlates-1.0.0`.
+- Each tag's ancestry covers that branch's entire first-parent chain, back through 2.3 / 0.36.
+
+Tags are refs, so every commit stays reachable, and GitHub lists tags and releases independently
+of branches, so the old releases work exactly as before. The one recipe lost is
+`git log --first-parent release-gplates release-pygplates`; section 10 has the replacement.
+
+Deleting the old branches did not need the new series branches to exist first, because what the
+old branches carried is tags. The first series branch is cut whenever the first release is.
+
+`gplates-3.0-dev` was deleted at the same time. It was a leftover from the pre-Vulkan 3.0 work,
+frozen since 2023-07-28, and its tip `0e51c7615` is an ancestor of `feature/vulkan`
+(`git rev-list --count gplates-3.0-dev --not feature/vulkan` is 0), so every commit on it is
+carried by a live branch.
+
+## 7. How a version is chosen
+
+`cmake/modules/VersionFromGit.cmake` computes it; its header comment is the reference, and this
+section is the reasoning. There are two inputs: a hand-edited **release target** in
+`cmake/modules/VersionRelease.cmake`, and the repository's tags.
+
+### 7.1 The algorithm
+
+1. List the tags matching the product's prefix (`GPlates-*` or `PyGPlates-*`).
+2. Split each into a **base** and a **development number**, discarding any that do not parse. That
+   is what excludes `GPlates-1.5+hellinger-testing`, `GPlates-0.9.10.1` and the couple of hundred
+   `svn-migration/*` tags. Two-component tags are normalised (`GPlates-2.5` → `2.5.0`), so the
+   historical tags count without retagging.
+3. For each, `distance = git rev-list --count --first-parent <tag>..HEAD`.
+4. Skip any tag at distance 0 that is not *at* HEAD. Those are tags HEAD is an ancestor of — they
+   name a later commit — and without this a `git bisect` step or a `HEAD~10` build scored 0, won
+   the minimum, and aborted the configure.
+5. The nearest tag wins; among equally near tags the largest development number wins, so the
+   count cannot go backwards.
+6. **N = that tag's development number + its distance**, and the version is `join(target, N)`.
+
+The base always comes from the *target*, never from the tag. A tag contributes a number and a
+position in history; tags' bases are read only by the guards. That is most visible with anchor
+tags (section 9): tagging `GPlates-2.5.0-2000` while the target is `2.6.0` yields `2.6.0-2000`.
+
+`join` is spelt per product, so that each stays orderable under its own rules (and GPlates under
+Debian's too):
+
+| | N = 0 | N > 0 |
+|---|---|---|
+| GPlates, plain base | `2.6.0` | `2.6.0-8` |
+| GPlates, pre-release base | `2.6.0-rc.1` | `2.6.0-rc.1.8` |
+| pyGPlates, plain base | `1.1.0` | `1.1.0.dev10` |
+| pyGPlates, pre-release base | `1.1.0rc1` | `1.1.0rc1.dev5` |
+
+**Why `--first-parent`:** it counts the number of times the branch tip has advanced — one per
+merged pull request or direct push — rather than every commit on every branch merged in. **Why
+`rev-list --count` and not `git describe`:** `git describe --first-parent` requires the tag to sit
+*on* the first-parent line and fails outright here ("No tags can describe"). Under this model no
+release tag is ever on the development branch's first-parent line (section 8.1), and
+`rev-list --count --first-parent <tag>..HEAD` needs no such ancestry.
+
+**Why derive it at all:** a hand-incremented development number has to anticipate the order in
+which branches will *merge*, which is not known while editing the file. Two pull requests opened
+from the same base both take the next number, and whichever merges second is wrong. That happened
+here — `7c6c6243f` jumped dev7 to dev9 because `c967acd21` had taken dev8 on another line the same
+day — and the two products' counters had drifted apart. Git already knows the merge order.
+
+Everything else is a fallback for builds with no repository, in this order: an existing CMake
+variable (`-D…`), an environment variable of the same name, git, `PKG-INFO` (the pyGPlates
+sdist), `cmake/modules/VersionRecorded.cmake` (written into the sdist by `cmake/version.py`),
+then a fatal error. A shallow clone is refused outright rather than allowed to produce a smaller,
+plausible number.
+
+### 7.2 The guards
+
+Four checks abort the configure rather than let a bad version reach a package:
+
+1. **Standing on a release tag whose base is not the target.** Tagging `PyGPlates-1.1.0` while the
+   target still says `1.0.0` is a fatal error naming what to set the target to. This is what makes
+   a tagged release and its target agree by construction, and it is why `build-wheels.yml` can
+   check the tag against the resolved version in its first minute.
+2. **The target has already been released.** The nearest release is a plain release of the target
+   and HEAD is past it: the next commit after tagging `1.1.0` would otherwise emit `1.1.0.dev1`,
+   which sorts *below* the `1.1.0` just published. The fix is to set the next target, which
+   `VersionRelease.cmake` says to do immediately after tagging.
+3. **The target sorts below the nearest release.** Added on 2026-09-12 after verifying the hole:
+   with `PyGPlates-1.0.0` long released, a target of `0.9.0` resolved to `0.9.0.dev49` and exited
+   0. Check 2 fired only on *equality*; nothing required the target to be *greater*. The
+   comparison is product-aware, because CMake's own `VERSION_LESS` reads `1.1.0rc1` and `1.1.0` as
+   equal: numeric head first, then the suffix rank (pyGPlates `.postN` > final > `rcN` > `bN` >
+   `aN`; GPlates final > `-rc.N` > `-beta.N` > `-alpha.N`). Check 2 is now one of this check's
+   messages.
+4. **The target skips a version.** Check 3 passes `1.2.0` after a released `1.0.0`, which is the
+   accidentally-skipped `1.1` case. So the target's numeric head must be the reference's, or its
+   next patch, next minor or next major:
+
+   | reference | allowed targets | rejected |
+   |---|---|---|
+   | `1.0.0` (a release) | `1.0.1`, `1.1.0`, `2.0.0`, and candidates of those (`1.0.1rc1`, …) | `1.0.2`, `1.2.0`, `3.0.0`, `1.0.0rc2` |
+   | `1.0.0rc1` (a candidate) | `1.0.0rc2`, `1.0.0` | `1.0.1`, `1.1.0` |
+
+   The reference's own head is permitted only so that a candidate can be followed by another
+   candidate or by the release; after a final release, same-head targets are rejected by check 3.
+   **This one is policy, not correctness**, and the error message says so, because it can be
+   loosened without breaking anything. The evidence supports it: the GPlates release line has no
+   skips (the apparent `0.9.5` → `0.9.7.1` gap is a released 0.9.6 whose tag went missing, and the
+   big early pyGPlates jumps used the SVN revision as the minor version). A side benefit: a fork
+   cannot quietly jump to `2.8.0` while upstream is on `2.6` (section 9).
+
+**Which release is "the nearest release"** for checks 3 and 4 is a separate question from which
+tag supplies the count, and is computed separately:
+
+- **Plain releases only.** An anchor tag (development number ≠ 0) says nothing about what has
+  been released, and a fork standing on `GPlates-2.6.0-2000` with target `2.6.0` is the normal
+  configuration. So the nearest tag of any kind supplies N, while the guard looks at the nearest
+  *release* tag, which may be much further back.
+- **Among releases tied at that distance, the highest base.** From the development branch,
+  `GPlates-2.6.0` and `GPlates-2.6.1` will tie (both on the series branch, both off the
+  first-parent line — section 8.1). Comparing against `2.6.0` would make a legitimate `2.6.2` look
+  like a skip; `2.6.1` gets it right.
+- **Never the greatest tag anywhere.** A maintenance series branch legitimately targets `2.6.1`
+  while `GPlates-2.7.0` exists on another series branch. "Nearest" is what scopes the check to
+  the line being descended from.
+
+**The honest limit of checks 3 and 4:** they catch a target set backwards or skipping, not a typo
+that lands one step forwards. `1.10` normalises to `1.10.0` and, from a `1.9.0` reference, is a
+legitimate next minor.
+
+The pure parts of the resolver — splitting, joining, ordering and the target checks — are tested
+by `cmake/modules/VersionFromGitTest.cmake`, registered with CTest as `version-resolver-test` in
+both build trees, and runnable directly with `cmake -P`. The tests include the repository's
+actual targets against its actual nearest releases, so a mistake in `VersionRelease.cmake` fails
+one test rather than every configure.
+
+### 7.3 Worked scenarios
+
+pyGPlates unless stated; `T` is the target in `VersionRelease.cmake`.
+
+| situation | T | nearest tag | result |
+|---|---|---|---|
+| development branch, 46 first-parent commits past the last release | `1.1.0` | `PyGPlates-1.0.0`, dev 0, distance 46 | `1.1.0.dev46` |
+| series branch cut, preparing the first candidate | `1.1.0rc1` | `PyGPlates-1.0.0`, distance 48 | `1.1.0rc1.dev48` |
+| standing on the tag `PyGPlates-1.1.0rc1` | `1.1.0rc1` | at HEAD, dev 0, base = T | `1.1.0rc1` |
+| two commits later, a second candidate decided | `1.1.0rc2` | `PyGPlates-1.1.0rc1`, distance 2 | `1.1.0rc2.dev2` |
+| standing on the release tag `PyGPlates-1.1.0` | `1.1.0` | at HEAD, dev 0, base = T | `1.1.0` |
+| … but the target was never moved off `1.0.0` | `1.0.0` | at HEAD, base ≠ T | **fatal** — set T to `1.1.0` |
+| series branch, 3 commits after the release, target not bumped | `1.1.0` | `PyGPlates-1.1.0`, distance 3, base = T | **fatal** — already released |
+| same, after bumping the target for the patch line | `1.1.1` | `PyGPlates-1.1.0`, distance 3 | `1.1.1.dev3` |
+| development branch after the release, target bumped | `1.2.0` | `PyGPlates-1.1.0`, distance 5 | `1.2.0.dev5` |
+| development branch, target left at `0.9.0` | `0.9.0` | `PyGPlates-1.0.0` | **fatal** — sorts below the release |
+| development branch, target set to `1.3.0` | `1.3.0` | `PyGPlates-1.0.0` | **fatal** — skips 1.1 and 1.2 |
+| fork standing on its own anchor `GPlates-2.6.0-2000` | `2.6.0` | at HEAD, dev 2000 | `2.6.0-2000` |
+| fork, 5 commits past that anchor | `2.6.0` | the anchor, dev 2000, distance 5 | `2.6.0-2005` |
+| `git bisect` at a commit below every tag | `1.1.0` | tags HEAD is an ancestor of are skipped | counts from the nearest tag *behind* |
+
+## 8. Three things that look like bugs and are not
+
+Each is surprising the first time a developer meets it.
+
+### 8.1 On the development branch, the count runs from the branch point, not from the tag
+
+A release tag sits on a series branch, so it is never on the development branch's first-parent
+line — whether or not the series branch is merged back, since such a merge takes the series branch
+as its *second* parent. That sounds like a problem and is not: the count from such a tag equals
+the count from the commit the series branch was **cut from**. Everything reachable from the tag,
+including the branch point and all history before it, is excluded, and the series branch's own
+commits were never on the development line to begin with.
+
+Verified on a synthetic topology (`A0 A1 A2` on main; a series branch cut, with `R1 R2` and the
+tag on it; then `M1 M2 M3`, the merge back, and `M4`):
+
+```
+main first-parent:  M4  Merge  M3  M2  M1  A2  A1  A0      # the tag's commit is absent
+count from the tag           : 5
+count from the branch point  : 5
+```
+
+and the same equality with the series branch never merged back. So **N is the number of times
+the development tip has advanced since that release diverged**, which is a more meaningful
+quantity than distance to a tagged commit would have been.
+
+The shape already existed in-tree before the model changed: `PyGPlates-1.0.0rc1` is on
+`f4de85708`, a commit of the old `release/pygplates-1.0.0` branch. From the old `pygplates`
+branch, `PyGPlates-1.0.0rc1` and `PyGPlates-1.0.0` were both at first-parent distance 46, while
+the unrestricted counts were 394 and 350: the commits between the two tags live on the release
+branch and cannot contribute. The tie is harmless — both carry development number 0, so the
+emitted version is identical — and the guards choose their reference release separately from the
+count (section 7.2).
+
+### 8.2 When a release is tagged, N on the development branch drops
+
+Because of 8.1, the moment `PyGPlates-1.1.0` is tagged the development branch starts counting from
+a much later branch point, and N falls from, say, 120 to 3. That is safe only because the release
+target must be bumped at the same moment — and guard 2 makes it compulsory, since leaving the
+target on the version just released is exactly what it refuses. So the base rises as the counter
+falls, and the emitted version still moves forward: `2.6.0-120` → `2.7.0-3`.
+
+### 8.3 The number is monotonic along one first-parent line, not across lines
+
+Measured on 2026-09-11:
+
+| | commit | resolved |
+|---|---|---|
+| `pygplates` tip | `818761237` | `1.1.0.dev46` |
+| `feature/version-from-git`, 3 commits on top | `9de01b089` | `1.1.0.dev49` |
+| after that branch merged as one PR merge commit | — | `1.1.0.dev47` |
+
+A feature branch counts its own commits (46 + 3), and the number **drops** when the branch merges,
+because the development line gains only the single merge commit (46 + 1). Two feature branches
+cut from the same base mint the *same* numbers as each other. A developer *will* notice a pull
+request build numbered higher than the merge that follows it.
+
+This is inherent, not a defect, and it does not reintroduce the bug the scheme was built to fix.
+That bug was collisions among numbers that became **permanent** on the development line. Here the
+development line's numbers remain distinct and increasing; only unmerged, unpublished work can
+collide, and nothing publishes from it (`build-wheels.yml` refuses a `.dev` version on a tag).
+
+The same property is why the two old development branches could not simply be merged either way
+round (section 11), and why a version string is not a globally unique name for a commit
+(section 10).
+
+## 9. Anchor tags and forks
+
+Because the nearest tag wins, a tag placed on a branch takes over the numbering from that point.
+A tag with a **non-zero** development number is an *anchor*: it supplies its number and its
+position, and nothing else. It is not a release, and the guards ignore it when choosing a
+reference release.
+
+**Upstream depends on one right now.** The `gplates` branch's first-parent line runs back through
+the 2013 `python-api` branch, and no ancestor of any GPlates release tag newer than that sits on
+it, so without `GPlates-2.6.0-47` the count runs from 2013 and gives `2.6.0-1206`. Deleting the
+tag would silently restore the larger number. It stops being load-bearing when
+`release/gplates-2.6` is cut and `GPlates-2.6.0` tagged there, because that tag is then the
+nearest.
+
+**A fork keeps its own numbers with one.** Commits on a fork advance its own first-parent line,
+so by default a fork mints the same development version strings as upstream for different code.
+Tagging the fork's branch `GPlates-2.6.0-2000` makes that the nearest tag, and the fork counts on
+from 2000. Because the base comes from the target, the anchor's own version is just a label and
+can name whichever release the fork started from. The advice given to the 17 forks (all with
+default branch `gplates`, 2026-09-11) is to do that rather than to change the release version:
+editing `GPLATES_RELEASE_VERSION` to `2.7.0` while upstream is on `2.6` produces two different
+projects both publishing something called GPlates 2.7.0, and the no-skip guard now refuses the
+larger jumps anyway.
+
+## 10. Recipes
+
+**What a checkout resolves to**, without configuring a build:
+
+```
+cmake -P cmake/modules/VersionFromGit.cmake gplates
+cmake -P cmake/modules/VersionFromGit.cmake pygplates
+```
+
+**Which tags are releases.** The [Releases page](https://github.com/GPlates/GPlates/releases) is
+the canonical list. On the command line:
+
+```
+git -c versionsort.suffix=a -c versionsort.suffix=b -c versionsort.suffix=rc tag --list 'GPlates-*' --sort=version:refname
+```
+
+(`PyGPlates-*` for pyGPlates.) The `versionsort.suffix` settings are what sort `PyGPlates-1.0.0rc1`
+*before* `PyGPlates-1.0.0` rather than after it. Not every tag listed is a release: **a tag
+carrying a development number is an anchor, never a release** — `GPlates-2.6.0-47` sorts last in
+that list, precisely where the newest release would be expected — and a few very old tags, such
+as `GPlates-1.5+hellinger-testing`, are neither. A release tag is `GPlates-<version>` or
+`PyGPlates-<version>` with no development number.
+
+**From a version string back to the commit.** The development number counts first-parent commits
+on from the nearest tag, so subtract that tag's own development number and count that far along
+the branch:
+
+```
+# pyGPlates 1.1.0.dev48, counting from PyGPlates-1.0.0 (development number 0)
+git rev-list --first-parent --reverse PyGPlates-1.0.0..gplates | sed -n '48p'
+
+# GPlates 2.6.0-56, counting from the anchor GPlates-2.6.0-47 (development number 47): 56 - 47 = 9
+git rev-list --first-parent --reverse GPlates-2.6.0-47..gplates | sed -n '9p'
+```
+
+Both return `1b699ffe8`, the unification merge. Count along the branch the build came from — the
+development branch, or a release series branch — because of section 8.3: the same string can name
+different commits on different lines. Concretely, `1.1.0.dev42` was the `gplates` tip at
+`79fa87d8d` on 2026-09-11, and counting 42 along today's `gplates` lands on `255dceb25`, because
+the unification made the old `pygplates` line the one `gplates` follows. A version minted before
+the unification cannot be found by counting at all.
+
+**So tag any development build that is handed to someone**, and the commit is findable by name.
+It costs nothing, verified on a synthetic six-commit repository: before tagging, A5 resolved to
+`1.1.0.dev5` and A3 to `1.1.0.dev3`; after tagging A3 as `PyGPlates-1.1.0.dev3`, A3, A4 and A5
+still resolved to dev3, dev4 and dev5. A tag whose development number equals the count already in
+force is a numerical no-op, deleting it again restores the same numbers, and `build-wheels.yml`
+excludes `PyGPlates-*.dev*` from its publish trigger, so such a tag cannot start a release run.
+The distinction worth keeping is between a tag that merely *records* a build, which is freely
+deletable, and an anchor that *re-bases* the count, which is not while it is load-bearing.
+
+## 11. How the two development branches were unified
+
+Recorded because the merge commit `1b699ffe8` looks odd in the history — a merge that changed no
+file, made on the branch that was about to be deleted — and a future reader will wonder why.
+
+The two branches resolved to different development numbers for the same product (section 2), and
+**whichever branch's first-parent line survived the merge would determine the numbers
+afterwards.** Had `gplates`'s line won, pyGPlates would have gone `.dev47 → .dev43` and GPlates
+`-55 → -50`: both counters running backwards, so two different trees could mint the same version
+string, the exact failure the derived scheme exists to eliminate. The resolver could not catch it:
+`1.1.0.dev43` sorts perfectly well above the last *release*, `1.0.0`; what it sorts below is a
+development version already minted on the other branch, and nothing anywhere records that a
+development number was ever issued. The scheme derives numbers from history and has no memory of
+what it has emitted.
+
+So it was got right by construction. The merge was made **on `pygplates`, with `gplates` as the
+second parent**, and pushed to `gplates` as a fast-forward:
+
+```
+git checkout pygplates && git merge --no-ff gplates
+git push public HEAD:gplates
+```
+
+Three details mattered:
+
+- **`--no-ff` was load-bearing.** The sync merge `86cebd62f` had made `pygplates` an ancestor of
+  `gplates`, so a plain `git merge gplates` would have fast-forwarded `pygplates` to `79fa87d8d`,
+  created no commit, reported "Everything up-to-date" on push, and left the counters continuing
+  from `.dev42` / `-49` — the failure above, arrived at by a command that looked like it succeeded.
+- **The merge could not go through a pull request.** A PR merge commit takes the base branch as
+  its *first* parent, which would have put `gplates`'s line back in front. The fast-forward push
+  was the mechanism; the documentation and CI changes went in a pull request on top.
+- **The parent order made no difference to the forks.** Either order is a fast-forward for
+  `gplates` (its tip is one of the merge's parents either way) and produces the same tree
+  (`git merge-tree --write-tree` gave `99f91b38d`, identical to `gplates`'s own tree). The branch
+  the forks track was never rewound. The order mattered only to the derived numbers.
+
+The counters were computed from the first-parent distances before the merge rather than guessed
+(`PyGPlates-1.0.0..pygplates` was 47 and `GPlates-2.6.0-47..pygplates` was 8, so the merge sits
+at 48 and 9) and verified afterwards: `1.1.0.dev48` and `2.6.0-56`. No anchor tags were needed.
+The fallback, had the ordering proved awkward, was to keep `gplates`'s line and re-anchor both
+counters forward with two anchor tags on the merge commit; it was the fallback rather than the
+plan because choosing the numbers by hand is the class of error the scheme removed.
+
+Then the one open pull request based on `pygplates` was retargeted to `gplates` (deleting the
+base branch of an open PR closes it), and `pygplates` was deleted from both remotes.
+
+## 12. Follow-up: rename the development branch to `main`
+
+`main` is the right name once there is a single development branch — `develop` was the
+alternative, but with `release-gplates` / `release-pygplates` gone there is no "main release
+branch" for `main` to collide with, which was the only argument against it.
+
+It is a separate change so the forks get notice first. GitHub redirects web URLs, moves branch
+protection rules, retargets open PRs and shows contributors a banner; it does **not** redirect raw
+file URLs, does **not** make Actions workflows follow the rename (the five workflow files that
+name `gplates` must be edited again), and does **not** redirect `git pull` of the old name. Forks
+keep their own branch called `gplates`, and GitHub's "Sync fork" matches branches *by name*, so
+afterwards it has nothing to sync against until the fork renames too. The redirect also survives
+only while the old name is unoccupied, so a stale clone pushing `gplates` would silently reoccupy
+it; a ruleset blocking creation of that name is worth considering.

--- a/doc-python-api/pygplates_getting_started.rst
+++ b/doc-python-api/pygplates_getting_started.rst
@@ -189,21 +189,27 @@ On **Windows**:
 Install from source code
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The first step is to obtain the source code for the current pyGPlates release by checking out the
-``release-pygplates`` branch of the `GPlates GitHub repository <https://github.com/GPlates/GPlates>`_.
-Or you can check out the pyGPlates *development* branch ``pygplates`` (if you want the latest *unofficial* updates).
+The first step is to obtain the source code for the current pyGPlates release by checking out its
+release tag in the `GPlates GitHub repository <https://github.com/GPlates/GPlates>`_.
+Or you can check out the development branch ``gplates`` (if you want the latest *unofficial* updates).
 
 .. note:: You'll first need to `install git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
   (if you don't already have it).
 
-In a terminal or command window, type the following to download the GPlates repository and switch to the ``release-pygplates`` branch
-(replacing ``<parent-of-source-code-dir>`` with the directory you want to download the repository into):
+In a terminal or command window, type the following to download the GPlates repository and switch to the
+latest pyGPlates release (replacing ``<parent-of-source-code-dir>`` with the directory you want to download
+the repository into):
 ::
 
   cd <parent-of-source-code-dir>
   git clone https://github.com/GPlates/GPlates.git
   cd GPlates
-  git switch release-pygplates
+  git tag --list 'PyGPlates-*' --sort=version:refname
+  git switch --detach <the last tag listed>
+
+.. note:: Each release series also has a branch of its own, such as ``release/pygplates-1.1``, whose tip is
+  always the most recent release in that series. So ``git switch release/pygplates-1.1`` gets you the latest
+  1.1.x, rather than a specific version.
 
 Then follow the instructions in ``BUILD-Linux.md`` (on Linux), ``BUILD-macOS.md`` (on macOS) or ``BUILD-Windows.md`` (on Windows) to install
 the dependency libraries required by pyGPlates (and to install the compilation tools).

--- a/doc-python-api/pygplates_getting_started.rst
+++ b/doc-python-api/pygplates_getting_started.rst
@@ -204,8 +204,10 @@ the repository into):
   cd <parent-of-source-code-dir>
   git clone https://github.com/GPlates/GPlates.git
   cd GPlates
-  git tag --list 'PyGPlates-*' --sort=version:refname
-  git switch --detach <the last tag listed>
+  git switch --detach <release-tag>
+
+where ``<release-tag>`` is the tag of the latest release, such as ``PyGPlates-1.0.0`` - the
+`releases page <https://github.com/GPlates/GPlates/releases>`_ lists them.
 
 .. note:: Each release series also has a branch of its own, such as ``release/pygplates-1.1``, whose tip is
   always the most recent release in that series. So ``git switch release/pygplates-1.1`` gets you the latest

--- a/pygplates/MERGE-PLAN.md
+++ b/pygplates/MERGE-PLAN.md
@@ -6,6 +6,10 @@
 > - `MERGE-FINDINGS-3-build-layout.md` — build system, tree layout, packaging, src/api
 > - `MERGE-EXECUTION-DETAILS.md` — empirical `git merge-tree` conflict list, hunk-level resolutions, risk register
 
+> **2026-09-12:** the branches *were* unified in the end, though not by this plan and not for this
+> plan's reasons - see `doc-cpp/design/versioning/README.md`. The 2026-07-07 note below is kept as
+> the record of what was decided at the time; it no longer describes the repository.
+
 > **2026-07-07 landing-strategy update (supersedes the "land on `gplates`" plan below):**
 > `gplates` and `pygplates` stay **separate** long-lived develop branches — they are not being
 > unified into one. The goal of this work is instead to reconcile the model/build divergence so

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -387,10 +387,9 @@ The flow, end to end:
    `rc1` tag as `1.1.0rc2.devN`.
 2. Tag that commit `PyGPlates-<version>` (exactly the version string - the run fails in its
    first minute if the two disagree, or if the version is a `.dev` one) and push the tag. A
-   release is tagged on `release-pygplates`, on the merge commit that brings
-   `release/pygplates-<version>` into it; release tags belong on the main release branches and
-   nowhere else. A release *candidate* is tagged on the `release/pygplates-<version>` branch
-   itself, not being a release. The root `README.md` has the branching model.
+   release is tagged on the release series branch `release/pygplates-<major>.<minor>`, and so is
+   every release candidate before it and every patch release after it - release tags belong on
+   the series branches and nowhere else. The root `README.md` has the branching model.
 3. The run builds the sdist and every wheel (about 2.5 hours warm, 4.5 cold), then uploads the
    sdist plus one platform's wheels to [TestPyPI](https://test.pypi.org/p/pygplates) - a
    rehearsal that catches anything the index itself would reject (metadata, most of all)

--- a/pygplates/wheel/README.md
+++ b/pygplates/wheel/README.md
@@ -94,7 +94,7 @@ problem).
 
 The images only need rebuilding when a dependency changes (ie, when the dockerfile or the
 version pins in `versions.sh` change). In CI that happens automatically: the workflow triggers
-on any push to the `pygplates` branch that touches either file (and can also be dispatched
+on any push to the `gplates` branch that touches either file (and can also be dispatched
 manually).
 
 To build the image locally instead (eg, to test a dockerfile change before pushing):


### PR DESCRIPTION
## Summary

The two development branches, `gplates` and `pygplates`, were unified on 2026-09-12: the merge `1b699ffe8` is already on `gplates` (pushed as a fast-forward so that both version counters kept moving forward), and `pygplates` is deleted. This PR carries everything that follows from having one development branch.

- **CI builds both products on every push to `gplates`.** Each workflow used to run only on its own branch and build only its own product, so a change to the shared sources could break the other product undetected until the next sync merge. Both defects PR #70 fixed had been hiding in that gap.
- **The branching model is no longer gitflow.** Releases are prepared on permanent per-series branches, `release/gplates-<X.Y>` and `release/pygplates-<X.Y>`, cut from `gplates` when the first release in the series is prepared, and release tags live only there. There is no `hotfix/` concept and no permanent production branch; a patch release is a further commit on the series branch. The old `release-gplates`, `release-pygplates` and `gplates-3.0-dev` branches are deleted. Nothing is lost: the two release tips are the commits tagged `GPlates-2.5` and `PyGPlates-1.0.0`, and the third is contained in `feature/vulkan`.
- **The version resolver now checks the hand-edited release target against the nearest release**, and aborts the configure rather than mint a bad version: a target already released, one sorting below the nearest release (`0.9.0` after `PyGPlates-1.0.0` used to resolve to `0.9.0.dev49` and exit 0), or one skipping a version. A release candidate binds only the line it is on: on the series branch only the same head may follow it, while from `gplates` its head counts as released and the target has to move on. These rules are tested by `cmake/modules/VersionFromGitTest.cmake`, registered with CTest as `version-resolver-test` in both build trees.
- **Anchor tags are pinned down.** An anchor (a tag carrying a development number) is exactly a development tag whose number has been raised: its base must be the release target at its commit, which the resolver checks and refuses otherwise, and it counts only on the first-parent line it was placed on. So a fork's anchor cannot take over an upstream checkout's count when the fork is fetched or its pull request merged, and a development tag on a merged feature branch cannot either; at equal distance a release beats an anchor, so a development tag left beside a release tag does not carry the old count past the release. The line rule found the existing anchor `GPlates-2.6.0-47` off the line `gplates` now follows (the unification merge was made on the old `pygplates` line), so the merge commit carries a second anchor, `GPlates-2.6.0-56`, its own number rather than a chosen one; every version is unchanged. Neither anchor may be deleted. The resolver treats a development tag and an anchor as one mechanism - every tag carrying a development number supplies its number, has its base checked and counts only on its own line, and nothing constrains the number - and its comments and the design document now say so, along with what an upstream target bump does to a fork's anchored count (the base changes, the count does not, and a fork that wants a fresh count re-anchors the merge commit that brought the bump in).
- **Wheels for a development version** come from a manual dispatch of `build-wheels.yml`, from a `PyGPlates-*.dev*` tag by preference so that the build stays findable by its version. The sdist job's tag check applies only to a pushed tag, and a dispatch can never publish. The workflow's concurrency group now includes the event, so a dispatch from a release tag cannot cancel that tag's release run waiting at the approval gate, and a `two-python-versions` input limits a dispatch that only tests the machinery.
- **A fork with no tags is told what to do.** GitHub copies no tags into a fork, so a fork's first build after syncing this would have stopped with a message blaming a missing repository. The resolver now says the repository has no release tags to count from and gives the fetch and push commands — unless the tree carries the sdist's `PKG-INFO` or a recorded version, as an sdist imported into a packaging repository does, in which case those supply the version as before.
- **Documentation.** The root `README.md` is cut back to an overview for people compiling from source. `doc-cpp/design/versioning/README.md` is the decision record: what was chosen, what was rejected, the evidence, how a version is chosen, the guards, the things that look like bugs and are not, anchor tags and forks, and how the unification merge was made. `AGENTS.md`, the release skill, the wheel README and the pyGPlates getting-started page are brought into line.

## What changes for releasing

- The series branch is cut once the candidate is prepared on `gplates`, its first commit is the one tagged, and `gplates` bumps its target straight after: the development branch cannot move on until that tag exists, and anything landing on it in between fails to configure once the tag appears.
- When a series branch gets its **first** tag (the first candidate, or the release if there is none), set the target on `gplates` to the next minor. The development branch's count restarts from the branch point at that moment, and left on the old target it would re-issue versions it has already used; the resolver refuses that.
- On the series branch, after the release, set the target to the next patch. After a candidate, nothing: the next commit there prepares the next candidate or the release.
- Fixes move between `gplates` and a series branch by `git cherry-pick -x`, never by merging the series branch into `gplates`. Such a merge conflicts on `VersionRelease.cmake` every time, and when it does not it silently hands `gplates` the series branch's target.
- A pyGPlates release ends by creating the GitHub Release for the tag: the getting-started page sends people to the releases page, and nothing created the entry.

## Review

The branch was reviewed before opening. The review found that the candidate rule as first written would have stopped every configure on `gplates` from the first release candidate until the release was final, and, since both versions are always resolved, a GPlates candidate would have stopped every pyGPlates build. That and the rest of the findings are addressed in the four commits ending at fbcb15b34, and the resolver was exercised on a synthetic repository with a 1.0 release, a 1.1 series with a candidate and a release, a feature branch cut before the series, and a GPlates candidate alongside.

A second review, of the commits after that, found the concurrency collision, the off-line anchor hazard and the no-tags abort hiding the sdist fallbacks. Those are the two commits after it, exercised on synthetic repositories (a fetched fork tag, a merged development tag, a development tag beside a release tag, an sdist under git) and on the real repository at the tip, the old `gplates` tip and the unification merge, where every version came out as before. The last commit is wording only, in the resolver's comments and the design document, and its claims about a fork's count across an upstream bump were measured on a synthetic repository too.

## Follow-ups

- Rename the development branch to `main`, as a separate change so that no fork is disturbed by this one.
- Post a note for the downstream forks after this merges: the branch changes, the anchor-tag mechanism, and the need to fetch our tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sKgAB1RJv3FuiH3TdRqxb
